### PR TITLE
fix(text-prompt): use native \u003cinput\u003e for paste support

### DIFF
--- a/src/dialogs/text-prompt.tsx
+++ b/src/dialogs/text-prompt.tsx
@@ -1,6 +1,6 @@
 // Single-line text prompt dialog. Enter submits, Esc cancels.
 
-import { useState } from "react"
+import { useState, useCallback } from "react"
 import { useKeyboard } from "@opentui/react"
 import { useTheme } from "../theme"
 import type { DialogContext } from "../ui/dialog"
@@ -17,17 +17,13 @@ const TextPrompt = (props: Props) => {
   const theme = useTheme().theme
   const [value, setValue] = useState(props.initial ?? "")
 
+  const submit = useCallback(() => {
+    const v = value.trim()
+    if (v) props.onSubmit(v)
+  }, [value, props.onSubmit])
+
   useKeyboard((key) => {
     if (key.name === "escape") return props.onCancel()
-    if (key.name === "return") {
-      const v = value.trim()
-      if (v) props.onSubmit(v)
-      return
-    }
-    if (key.name === "backspace") return setValue(v => v.slice(0, -1))
-    if (key.ctrl && key.name === "u") return setValue("")
-    if (!key.ctrl && !key.meta && key.raw && key.raw.length === 1 && key.raw >= " ")
-      return setValue(v => v + key.raw)
   })
 
   return (
@@ -38,15 +34,20 @@ const TextPrompt = (props: Props) => {
       <box height={1} flexDirection="row" overflow="hidden">
         <box flexShrink={0}><text fg={theme.accent}>{"┃ "}</text></box>
         <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
-          <text>
-            <span fg={theme.text}>{value}</span>
-            <span fg={theme.accent}>█</span>
-          </text>
+          <input
+            value={value}
+            onInput={setValue}
+            onSubmit={submit as unknown as (e: { value: string }) => void}
+            focused={true}
+            textColor={theme.text}
+            backgroundColor={theme.backgroundElement}
+            focusedBackgroundColor={theme.backgroundElement}
+          />
         </box>
       </box>
       <box height={1} />
       <box height={1}><text fg={theme.textMuted}>
-        {value.trim() ? "Enter confirm  ·  Esc cancel  ·  Ctrl+U clear" : "Esc cancel"}
+        {value.trim() ? "Enter confirm  ·  Esc cancel" : "Esc cancel"}
       </text></box>
     </box>
   )

--- a/src/dialogs/text-prompt.tsx
+++ b/src/dialogs/text-prompt.tsx
@@ -1,6 +1,6 @@
 // Single-line text prompt dialog. Enter submits, Esc cancels.
 
-import { useState, useCallback } from "react"
+import { useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import { useTheme } from "../theme"
 import type { DialogContext } from "../ui/dialog"
@@ -17,11 +17,9 @@ const TextPrompt = (props: Props) => {
   const theme = useTheme().theme
   const [value, setValue] = useState(props.initial ?? "")
 
-  const submit = useCallback(() => {
-    const v = value.trim()
-    if (v) props.onSubmit(v)
-  }, [value, props.onSubmit])
-
+  // Native <input> owns text/paste/cursor; global bus only handles Esc
+  // (DialogProvider also clears on Esc, but it doesn't resolve the
+  // promise — onCancel does).
   useKeyboard((key) => {
     if (key.name === "escape") return props.onCancel()
   })
@@ -37,8 +35,8 @@ const TextPrompt = (props: Props) => {
           <input
             value={value}
             onInput={setValue}
-            onSubmit={submit as unknown as (e: { value: string }) => void}
-            focused={true}
+            onSubmit={() => { const v = value.trim(); if (v) props.onSubmit(v) }}
+            focused
             textColor={theme.text}
             backgroundColor={theme.backgroundElement}
             focusedBackgroundColor={theme.backgroundElement}
@@ -47,7 +45,7 @@ const TextPrompt = (props: Props) => {
       </box>
       <box height={1} />
       <box height={1}><text fg={theme.textMuted}>
-        {value.trim() ? "Enter confirm  ·  Esc cancel" : "Esc cancel"}
+        {value.trim() ? "Enter confirm  ·  Esc cancel  ·  Ctrl+U clear" : "Esc cancel"}
       </text></box>
     </box>
   )

--- a/test/text-prompt.test.tsx
+++ b/test/text-prompt.test.tsx
@@ -5,10 +5,14 @@ import { useDialog } from "../src/ui/dialog"
 import { openTextPrompt } from "../src/dialogs/text-prompt"
 import { useEffect } from "react"
 
+let resolved: string | null | undefined
+
 const Opener = () => {
   const dialog = useDialog()
   useEffect(() => {
+    resolved = undefined
     void openTextPrompt(dialog, { title: "Rename Thing", label: "Title", initial: "hello" })
+      .then(v => { resolved = v })
   }, [])
   return null
 }
@@ -44,6 +48,31 @@ describe("TextPrompt", () => {
     // Hint row still intact directly after.
     const valY = lines.findIndex(l => l.includes("┃"))
     expect(lines[valY + 2]).toContain("Enter confirm")
+    t.destroy()
+  })
+
+  test("bracketed-paste lands in the buffer", async () => {
+    const t = await mountNode(<Opener />)
+    await until(t, () => t.frame().includes("┃ hello"))
+    await act(async () => { await t.keys.pasteBracketedText("-sk-abc123") })
+    await until(t, () => t.frame().includes("hello-sk-abc123"))
+    const lines = t.frame().split("\n")
+    const valY = lines.findIndex(l => l.includes("┃"))
+    expect(lines[valY]).toContain("hello-sk-abc123")
+    t.destroy()
+  })
+
+  test("← moves cursor: char inserts before end; Enter resolves", async () => {
+    const t = await mountNode(<Opener />)
+    await until(t, () => t.frame().includes("┃ hello"))
+    // "hello" cursor at end → ←← → type X → "helXlo"
+    await act(async () => { t.keys.pressArrow("left") })
+    await act(async () => { t.keys.pressArrow("left") })
+    await act(async () => { await t.keys.typeText("X") })
+    await until(t, () => t.frame().includes("helXlo"))
+    await act(async () => { t.keys.pressEnter() })
+    await until(t, () => resolved !== undefined)
+    expect(resolved).toBe("helXlo")
     t.destroy()
   })
 })


### PR DESCRIPTION
## Problem

Pasting (Cmd+V / Ctrl+V) into the single-line text prompt (used in Env/API Keys editor) does nothing.

## Root Cause

The previous  implementation accumulated text manually via :



Terminal bracketed-paste sends the pasted content as a multi-character chunk wrapped in . Because , every character in the paste is silently discarded, forcing users to manually type long API keys.

## Why this matters

Other parts of herm handle paste correctly:
-  uses 
-  uses OpenTUI native 

Only  re-implements keyboard accumulation by hand and breaks paste.

## Fix

Replace the hand-rolled  text accumulation with OpenTUI's native  component (same mechanism already used in  and ).

-  natively consumes the terminal input stream, including bracketed-paste sequences.
-  is preserved only for Escape cancellation.

## Verification

- Built successfully with bun install v1.3.11 (af24e281)

Checked 369 installs across 469 packages (no changes) [121.00ms]
┌───────────────────────────────────────────┬─────────┐
│                                           │ Values  │
├───────────────────────────────────────────┼─────────┤
│                                  index.js │ 7435 KB │
│                              db.worker.js │ 17 KB   │
│                          parser.worker.js │ 116 KB  │
│                   highlights-ghv9g403.scm │ 3 KB    │
│      tree-sitter-javascript-nd0q4pe9.wasm │ 402 KB  │
│                   highlights-eq9cgrbb.scm │ 10 KB   │
│      tree-sitter-typescript-zxjzwt75.wasm │ 1381 KB │
│                   highlights-r812a2qc.scm │ 3 KB    │
│        tree-sitter-markdown-411r6y9b.wasm │ 412 KB  │
│                   injections-73j83es3.scm │ 1 KB    │
│                   highlights-x6tmsnaa.scm │ 2 KB    │
│ tree-sitter-markdown_inline-j5349f42.wasm │ 416 KB  │
│                   highlights-hk7bwhj4.scm │ 3 KB    │
│             tree-sitter-zig-e78zbjpm.wasm │ 676 KB  │
│                 tree-sitter-3jzf13jk.wasm │ 201 KB  │
└───────────────────────────────────────────┴─────────┘

build: dist/ ready (15 files)
- herm — OpenTUI client for hermes-agent

Usage:
  herm                    start a fresh session
  herm -c, --continue     resume the last real TUI session
  herm --resume [id]      resume last (or the given) session
  herm --no-splash        skip the launch splash
  herm -v, --version      print version
  herm -h, --help         show this help produces correct output
- Paste now works in the text prompt dialog

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update