### PR TITLE
fix(goal): route /goal through command.dispatch

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -442,7 +442,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           return
         }
         case "goal": {
-          goalHook.cmd(arg)
+          goalHook.cmd(arg, sid)
             .then(r => {
               dispatch({ kind: "system", text: r.line })
               // CLI's _handle_goal_command kicks the loop off via

--- a/src/app/goalHook.ts
+++ b/src/app/goalHook.ts
@@ -4,11 +4,11 @@
 // tui_gateway/server.py (the post-turn Ralph loop); this module is the
 // reactor, not the driver.
 //
-// Setting/controlling the goal goes through the slash-worker
-// (slash.exec → HermesCLI._handle_goal_command → GoalManager), NOT via
-// shell.exec + `python3 -c` — that pattern is on tools/approval.py's
-// DANGEROUS_PATTERNS list and tui_gateway's shell.exec handler hard-
-// rejects it with a 4005 before it ever runs.
+// Setting/controlling the goal goes through command.dispatch, NOT the
+// slash-worker. HermesCLI._handle_goal_command queues the kickoff prompt
+// onto an in-process _pending_input queue that a slash-worker subprocess
+// cannot read, so tui_gateway handles /goal directly and returns a typed
+// {type: "send", notice, message} payload.
 
 import type { DialogContext } from "../ui/dialog"
 import type { Gateway } from "./gateway"
@@ -18,22 +18,19 @@ import { io } from "../io"
 
 type Toast = { show: (o: { variant: "success"; title?: string; message: string; duration?: number }) => void }
 type ShellResult = { stdout: string; stderr: string; code: number }
-type SlashResult = { output?: string; warning?: string }
+type DispatchResult = { type?: string; output?: string; notice?: string; message?: string }
 
 export type GoalHook = {
   /** Called from onTurnComplete. Reads goal state, fires if done. */
   check: (sid: string) => void
-  /** Route /goal through the slash-worker. Returns cleaned output for
-   *  the transcript plus whether this was a fresh set (caller kicks
-   *  off the loop by sending the goal text as a prompt — parity with
-   *  the CLI's _pending_input.put(goal)). */
-  cmd: (arg: string) => Promise<{ line: string; kick: string | null }>
+  /** Route /goal through command.dispatch. Returns cleaned output for
+   *  the transcript plus an optional kickoff prompt from the gateway
+   *  ({type: "send", message}) when setting a fresh goal. */
+  cmd: (arg: string, sid?: string) => Promise<{ line: string; kick: string | null }>
 }
 
 const SECONDS = 10
 const SUSPEND = process.platform === "darwin" ? "pmset sleepnow" : "systemctl suspend"
-const VERBS = new Set(["status", "pause", "resume", "clear", "stop", "done"])
-
 // _handle_goal_command prints via _cprint with _DIM/_RST interpolated
 // into the string before the worker's lambda swap, so the ANSI bytes
 // are in the captured buffer. Strip them for the transcript.
@@ -74,17 +71,12 @@ export function makeGoalHook(gw: Gateway, dialog: DialogContext, toast: Toast): 
         act(s.goal)
       }).catch(() => {})
     },
-    cmd: async (arg: string) => {
+    cmd: async (arg: string, sid?: string) => {
       const trimmed = arg.trim()
-      const first = trimmed.split(/\s+/, 1)[0]?.toLowerCase() ?? ""
-      // Non-verb (and non-empty) first token ⇒ this is a fresh goal
-      // set; the caller should kick the loop off by submitting the
-      // goal text as the first prompt. Verbs + bare `/goal` just
-      // report/mutate state.
-      const kick = trimmed && !VERBS.has(first) ? trimmed : null
-      const r = await gw.request<SlashResult>("slash.exec",
-        { command: `/goal${trimmed ? " " + trimmed : ""}` })
-      const line = (r.output ?? "").replace(ANSI, "").trim() || "ok"
+      const r = await gw.request<DispatchResult>("command.dispatch",
+        { name: "goal", arg: trimmed, ...(sid ? { session_id: sid } : {}) })
+      const line = (r.notice ?? r.output ?? "").replace(ANSI, "").trim() || "ok"
+      const kick = r.type === "send" && r.message ? r.message : null
       return { line, kick }
     },
   }

--- a/test/goal.test.tsx
+++ b/test/goal.test.tsx
@@ -77,13 +77,21 @@ describe("countdown dialog", () => {
   })
 })
 
-// ─── goalHook.cmd → slash.exec dispatch ──────────────────────────────
+// ─── goalHook.cmd → command.dispatch ─────────────────────────────────
 
 describe("goalHook.cmd", () => {
   const mk = () => {
-    const calls: string[] = []
+    const calls: Record<string, unknown>[] = []
     const gw = new MockGateway({
-      "slash.exec": (p) => { calls.push(String(p.command)); return { output: "  ⊙ Goal set (20-turn budget): x\n  \x1b[2mAfter each turn…\x1b[22m" } },
+      "command.dispatch": (p) => {
+        calls.push(p)
+        if (String(p.arg).startsWith("ship")) return {
+          type: "send",
+          notice: "  ⊙ Goal set (20-turn budget): x\n  \x1b[2mAfter each turn…\x1b[22m",
+          message: String(p.arg),
+        }
+        return { type: "exec", output: String(p.arg) ? `ok ${String(p.arg)}` : "No active goal" }
+      },
     })
     const dialog = { replace: () => {}, clear: () => {}, stack: [] as const, open: () => false }
     const toast = { show: () => {} }
@@ -91,28 +99,29 @@ describe("goalHook.cmd", () => {
     return { hook, calls }
   }
 
-  test("verbs pass through to /goal <verb>; no kick", async () => {
+  test("verbs pass through to command.dispatch; no kick", async () => {
     const { hook, calls } = mk()
     for (const v of ["status", "pause", "resume", "clear", "done"]) {
       const r = await hook.cmd(v)
       expect(r.kick).toBeNull()
     }
-    expect(calls).toEqual([
-      "/goal status", "/goal pause", "/goal resume", "/goal clear", "/goal done",
+    expect(calls.map(c => c.arg)).toEqual([
+      "status", "pause", "resume", "clear", "done",
     ])
+    expect(calls.every(c => c.name === "goal")).toBe(true)
   })
 
   test("bare /goal → status; no kick", async () => {
     const { hook, calls } = mk()
     const r = await hook.cmd("")
-    expect(calls[0]).toBe("/goal")
+    expect(calls[0]).toMatchObject({ name: "goal", arg: "" })
     expect(r.kick).toBeNull()
   })
 
   test("free text → set; kick = goal text; ANSI stripped from output", async () => {
     const { hook, calls } = mk()
     const r = await hook.cmd("ship the $(thing)")
-    expect(calls[0]).toBe("/goal ship the $(thing)")
+    expect(calls[0]).toMatchObject({ name: "goal", arg: "ship the $(thing)" })
     expect(r.kick).toBe("ship the $(thing)")
     // _DIM/_RST stripped; lines trimmed.
     expect(r.line).toContain("⊙ Goal set")
@@ -126,7 +135,7 @@ describe("goalHook.cmd", () => {
   test("never dispatches shell.exec", async () => {
     let touched = false
     const gw = new MockGateway({
-      "slash.exec": () => ({ output: "ok" }),
+      "command.dispatch": () => ({ type: "exec", output: "ok" }),
       "shell.exec": () => { touched = true; return { stdout: "", stderr: "", code: 0 } },
     })
     const hook = makeGoalHook(gw,


### PR DESCRIPTION
## Summary
- route Herm's local `/goal` handler through `command.dispatch` instead of `slash.exec`
- use the gateway's typed `/goal` payload (`notice` + kickoff `message`) to start the goal loop
- update goal hook tests to guard the `command.dispatch` route

## Why
`/goal` is a pending-input command: the slash-worker subprocess cannot read the live CLI's in-process `_pending_input` queue. Routing through `slash.exec` can set goal state but drop the kickoff prompt, so the goal does not actually start. The gateway already exposes the correct `command.dispatch` path.

Note: the default `dev` branch appears to have a broader version of this fix already (`f2bda4d`), but `main`/`v1.2.1` still has the broken route.

## Test Plan
- [x] `bun test test/goal.test.tsx`
- [x] `bun run build`
- [x] `git diff --check`
- [ ] `bun test` (1 unrelated existing failure on macOS path canonicalization in `test/git.test.ts`: `/var/...` vs `/private/var/...`)
- [ ] `bunx tsc --noEmit` (unrelated existing `test/context.test.tsx` fixture type error: missing `streaming` on a `TextPart`)
