### PR TITLE
fix(steer+queue): immediate dispatch during streaming + response parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ profiles/
 issues.jsonl
 *.bak
 *.code-workspace
+AGENTS.local.md

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -115,6 +115,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [status, setStatus] = useState("")
   const [eikon, setEikon] = useState<ParsedEikon | undefined>(undefined)
   const [queue, setQueue] = useState<string[]>([])
+  type BusyInputMode = "queue" | "steer" | "interrupt"
+  const [busyInputMode, setBusyInputMode] = useState<BusyInputMode>("queue")
   // ── Splash ────────────────────────────────────────────────────────
   // Welcome-state chrome over an empty transcript. Composer stays live
   // underneath; first send dismisses. `/splash` re-summons mid-session
@@ -206,7 +208,46 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     setForce(next)
   }, [cloud])
   const closeCloud = useCallback(() => { setForce(false); setPick(undefined) }, [])
-  const onEnqueue = useCallback((t: string) => setQueue(q => [...q, t]), [])
+  // Ref for the interrupt function — populated after doInterrupt is defined
+  const doInterruptRef = useRef<() => void>(() => {})
+  // Stable ref to send() — lets us dispatch slash commands immediately during streaming
+  const sendRef = useRef<(raw: string) => void>(() => {})
+  // Mode-aware handler for input while streaming. Slash commands (e.g. /steer, /queue)
+  // are dispatched immediately via send(); plain text respects display.busy_input_mode:
+  //   "queue"     — append to queue, drain on idle (default for TUI)
+  //   "steer"     — inject into current turn via session.steer; falls back to queue
+  //   "interrupt" — interrupt current turn, then send as new prompt
+  const onEnqueue = useCallback((t: string) => {
+    // Slash commands execute immediately even while streaming (parity with Ink TUI)
+    if (/^\/\S/.test(t)) {
+      sendRef.current(t)
+      return
+    }
+    const mode = busyInputMode
+    if (mode === "steer") {
+      gw.request<{ status?: string; text?: string }>("session.steer", { text: t })
+        .then(r => {
+          if (r.status === "queued") {
+            toast.show({ variant: "success", message: "Steered — lands on next tool result" })
+          } else {
+            setQueue(q => [...q, t])
+            toast.show({ variant: "info", message: "Steer rejected — queued for next turn" })
+          }
+        })
+        .catch(() => {
+          setQueue(q => [...q, t])
+          toast.show({ variant: "info", message: "Steer failed — queued for next turn" })
+        })
+      return
+    }
+    if (mode === "interrupt") {
+      doInterruptRef.current()
+      setQueue(q => [...q, t])
+      return
+    }
+    // Default: "queue" — just enqueue for next turn
+    setQueue(q => [...q, t])
+  }, [busyInputMode, gw, toast])
   const onAttach = useCallback((r: ImageAttachResponse) => setAttachments(a => [...a, r]), [])
 
   // ── Session reset / lifecycle ─────────────────────────────────────
@@ -392,8 +433,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // `slash` and `send` reference each other (skill/alias dispatch needs
   // to submit a turn; typed `/cmd` in send() resolves via slash). The
   // cycle is broken with a forward ref — same shape as upstream Ink's
-  // slashRef/submitRef pair.
-  const sendRef = useRef<(raw: string) => void>(() => {})
+  // slashRef/submitRef pair. (sendRef declared earlier for onEnqueue access)
   const slash = useCallback((c: SlashCommand, arg = "") => {
     if (c.target === "local") {
       switch (c.name) {
@@ -526,8 +566,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           return
         case "steer": {
           const fire = (text: string) =>
-            gw.request<{ accepted: boolean }>("session.steer", { text })
-              .then(r => toast.show(r.accepted
+            gw.request<{ status?: string; text?: string }>("session.steer", { text })
+              .then(r => toast.show(r.status === "queued"
                 ? { variant: "success", message: "Queued — lands on next tool result" }
                 : { variant: "info", message: "No turn running; send as a normal message" }))
               .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
@@ -775,6 +815,14 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           setTitle(r.title ?? "")
           if (r.session_key) preferences.set("lastSessionId", r.session_key)
         }).catch(() => {})
+        // Fetch display.busy_input_mode from config — TUI defaults to "queue"
+        gw.request<{ config?: Record<string, any> }>("config.get", { key: "full" }).then(r => {
+          const d = r.config?.display ?? {}
+          const raw = String(d.busy_input_mode ?? "").trim().toLowerCase()
+          if (raw === "steer" || raw === "interrupt" || raw === "queue") {
+            setBusyInputMode(raw)
+          }
+        }).catch(() => {})
       },
       onUsage: (u) => setUsage(u),
       onTurnComplete: () => {
@@ -866,6 +914,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     d.text = ""; d.think = ""
     session.interrupt()
   }, [session])
+  doInterruptRef.current = doInterrupt
 
   // ── Keyboard ──────────────────────────────────────────────────────
   useAppKeys({

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -115,8 +115,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [status, setStatus] = useState("")
   const [eikon, setEikon] = useState<ParsedEikon | undefined>(undefined)
   const [queue, setQueue] = useState<string[]>([])
-  type BusyInputMode = "queue" | "steer" | "interrupt"
-  const [busyInputMode, setBusyInputMode] = useState<BusyInputMode>("queue")
+  const [busy, setBusy] = useState<"queue" | "steer" | "interrupt">("queue")
   // ── Splash ────────────────────────────────────────────────────────
   // Welcome-state chrome over an empty transcript. Composer stays live
   // underneath; first send dismisses. `/splash` re-summons mid-session
@@ -208,46 +207,25 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     setForce(next)
   }, [cloud])
   const closeCloud = useCallback(() => { setForce(false); setPick(undefined) }, [])
-  // Ref for the interrupt function — populated after doInterrupt is defined
-  const doInterruptRef = useRef<() => void>(() => {})
-  // Stable ref to send() — lets us dispatch slash commands immediately during streaming
-  const sendRef = useRef<(raw: string) => void>(() => {})
-  // Mode-aware handler for input while streaming. Slash commands (e.g. /steer, /queue)
-  // are dispatched immediately via send(); plain text respects display.busy_input_mode:
-  //   "queue"     — append to queue, drain on idle (default for TUI)
-  //   "steer"     — inject into current turn via session.steer; falls back to queue
-  //   "interrupt" — interrupt current turn, then send as new prompt
+  const intr = useRef<() => void>(() => {})
+  // Plain text submitted while streaming (Composer routes slash-shaped
+  // input to onSend instead). `interrupt` prepends so the drain effect
+  // fires this text first once turn.streaming flips.
   const onEnqueue = useCallback((t: string) => {
-    // Slash commands execute immediately even while streaming (parity with Ink TUI)
-    if (/^\/\S/.test(t)) {
-      sendRef.current(t)
-      return
-    }
-    const mode = busyInputMode
-    if (mode === "steer") {
-      gw.request<{ status?: string; text?: string }>("session.steer", { text: t })
+    if (busy === "steer") {
+      gw.request<{ status: string }>("session.steer", { text: t })
         .then(r => {
-          if (r.status === "queued") {
-            toast.show({ variant: "success", message: "Steered — lands on next tool result" })
-          } else {
-            setQueue(q => [...q, t])
-            toast.show({ variant: "info", message: "Steer rejected — queued for next turn" })
-          }
-        })
-        .catch(() => {
+          if (r.status === "queued")
+            return toast.show({ variant: "success", message: "steered — lands on next tool result" })
           setQueue(q => [...q, t])
-          toast.show({ variant: "info", message: "Steer failed — queued for next turn" })
+          toast.show({ variant: "info", message: "steer rejected — queued for next turn" })
         })
+        .catch(() => setQueue(q => [...q, t]))
       return
     }
-    if (mode === "interrupt") {
-      doInterruptRef.current()
-      setQueue(q => [...q, t])
-      return
-    }
-    // Default: "queue" — just enqueue for next turn
+    if (busy === "interrupt") { intr.current(); return setQueue(q => [t, ...q]) }
     setQueue(q => [...q, t])
-  }, [busyInputMode, gw, toast])
+  }, [busy, gw, toast])
   const onAttach = useCallback((r: ImageAttachResponse) => setAttachments(a => [...a, r]), [])
 
   // ── Session reset / lifecycle ─────────────────────────────────────
@@ -433,7 +411,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // `slash` and `send` reference each other (skill/alias dispatch needs
   // to submit a turn; typed `/cmd` in send() resolves via slash). The
   // cycle is broken with a forward ref — same shape as upstream Ink's
-  // slashRef/submitRef pair. (sendRef declared earlier for onEnqueue access)
+  // slashRef/submitRef pair.
+  const sendRef = useRef<(raw: string) => void>(() => {})
   const slash = useCallback((c: SlashCommand, arg = "") => {
     if (c.target === "local") {
       switch (c.name) {
@@ -815,13 +794,9 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           setTitle(r.title ?? "")
           if (r.session_key) preferences.set("lastSessionId", r.session_key)
         }).catch(() => {})
-        // Fetch display.busy_input_mode from config — TUI defaults to "queue"
-        gw.request<{ config?: Record<string, any> }>("config.get", { key: "full" }).then(r => {
-          const d = r.config?.display ?? {}
-          const raw = String(d.busy_input_mode ?? "").trim().toLowerCase()
-          if (raw === "steer" || raw === "interrupt" || raw === "queue") {
-            setBusyInputMode(raw)
-          }
+        gw.request<{ value?: string }>("config.get", { key: "busy" }).then(r => {
+          const m = r.value
+          if (m === "queue" || m === "steer" || m === "interrupt") setBusy(m)
         }).catch(() => {})
       },
       onUsage: (u) => setUsage(u),
@@ -914,7 +889,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     d.text = ""; d.think = ""
     session.interrupt()
   }, [session])
-  doInterruptRef.current = doInterrupt
+  intr.current = doInterrupt
 
   // ── Keyboard ──────────────────────────────────────────────────────
   useAppKeys({

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -186,6 +186,11 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (!text || !live.current.props.ready) return
       hist.push(text)
       write("")
+      // Slash-shaped input routes through onSend so send() → slash()
+      // can apply per-command streaming policy (local cases fire now,
+      // gateway-target cases self-queue). Only plain text hits the
+      // app-side busy-mode branch.
+      if (text.startsWith("/")) return void live.current.props.onSend(text)
       live.current.props.onEnqueue?.(text)
       return
     }


### PR DESCRIPTION
## Summary

Fixes three issues with `/steer` and `/queue` behavior when the TUI is streaming:

### 1. `/steer` response type mismatch

The `session.steer` RPC returns `{status: 'queued'|'rejected', text}` but herm expected `{accepted: boolean}`. The condition always evaluated to falsy, making /steer appear silently broken.

### 2. Slash commands delayed until turn ends

When streaming, the Composer's `onEnqueue` blindly queued ALL text — including `/steer hello` and `/queue text`. These only resolved on drain (after the turn ended), which defeated `/steer`'s purpose entirely (mid-turn injection needs to fire immediately).

**Fix:** Text starting with `/` is now routed through `sendRef.current()` for immediate slash resolution, matching the Ink TUI's behavior (`useSubmission.ts` line 290-297 dispatches slash commands immediately regardless of busy state).

### 3. `display.busy_input_mode` not respected for plain text

Plain text typed during streaming always queued regardless of the `display.busy_input_mode` config value. Now reads the config via `config.get` RPC on session start and routes accordingly:
- `'queue'` (TUI default): append to queue, drain on idle
- `'steer'`: call `session.steer` RPC; falls back to queue if rejected
- `'interrupt'`: fire `doInterrupt()`, then queue for drain

### Reference

Hermes Agent `ui-tui/src/app/useSubmission.ts` — `handleBusyInput()` + `dispatchSubmission()`

### Changes

- `src/app.tsx` — 54 insertions, 5 deletions
- `.gitignore` — add `AGENTS.local.md`