### PR TITLE
dev → main

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -96,7 +96,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const renderer = useRenderer()
   const session = useSession()
   const dims = useTerminalDimensions()
-  const goalHook = useMemo(() => makeGoalHook(gw, dialog, toast), [gw, dialog, toast])
+  const goalHook = useMemo(() => makeGoalHook(dialog, toast), [dialog, toast])
 
   const [turn, dispatch] = useReducer(turnReducer, initialTurn)
   const [ready, setReady] = useState(false)
@@ -441,20 +441,6 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         }
-        case "goal": {
-          goalHook.cmd(arg)
-            .then(r => {
-              dispatch({ kind: "system", text: r.line })
-              // CLI's _handle_goal_command kicks the loop off via
-              // _pending_input.put(goal); the slash-worker's CLI has
-              // no input loop, so herm does the equivalent: submit
-              // the goal text as the first prompt. tui_gateway's
-              // post-turn Ralph hook takes over from there.
-              if (r.kick) void sendRef.current(r.kick)
-            })
-            .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
-          return
-        }
         // ── parity: session-mutating (slash-worker can't service these) ──
         case "resume":
           if (arg) { void switchSession(arg); return }
@@ -609,9 +595,17 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
         if (res?.output) dispatch({ kind: "system", text: res.output })
       })
       .catch(() => {
-        type Dispatch = { type?: string; output?: string; target?: string; message?: string; name?: string }
+        type Dispatch = {
+          type?: string; output?: string; target?: string
+          message?: string; notice?: string; name?: string
+        }
         gw.request<Dispatch>("command.dispatch", { name: c.name, arg })
           .then(d => {
+            // `notice` is an optional system line attached to a `send`
+            // payload — e.g. /goal set returns {type:send, notice:"⊙
+            // Goal set (…)", message: goal} so the user sees the set
+            // confirmation before the kickoff prompt fires.
+            if (d.notice) dispatch({ kind: "system", text: d.notice })
             if (d.type === "exec" || d.type === "plugin")
               return dispatch({ kind: "system", text: d.output || "(no output)" })
             if (d.type === "alias" && d.target)

--- a/src/app/goalHook.ts
+++ b/src/app/goalHook.ts
@@ -1,43 +1,30 @@
-// Goal-completion hook. Polls state_meta['goal:<sid>'] after each turn
-// and, on transition to status=done, performs the onGoalDone pref
-// action. The judge that *writes* that status lives in stock
-// tui_gateway/server.py (the post-turn Ralph loop); this module is the
-// reactor, not the driver.
-//
-// Setting/controlling the goal goes through the slash-worker
-// (slash.exec → HermesCLI._handle_goal_command → GoalManager), NOT via
-// shell.exec + `python3 -c` — that pattern is on tools/approval.py's
-// DANGEROUS_PATTERNS list and tui_gateway's shell.exec handler hard-
-// rejects it with a 4005 before it ever runs.
+// Goal-completion reactor. Polls state_meta['goal:<sid>'] after each
+// turn and, on transition to status=done, performs the onGoalDone
+// pref action. The judge that *writes* that status and the
+// continuation loop itself live in stock tui_gateway/server.py (post-
+// turn Ralph hook in _run_prompt_submit); setting/controlling the
+// goal goes through the standard slash.exec → command.dispatch
+// fallback in app.tsx's slash() — tui_gateway rejects /goal from the
+// slash-worker (_PENDING_INPUT_COMMANDS) and command.dispatch's
+// handler drives GoalManager directly, including returning
+// {type:"send", notice, message: goal} on set so herm renders the
+// notice and submits the kickoff prompt. Nothing to do here except
+// react to completion.
 
 import type { DialogContext } from "../ui/dialog"
-import type { Gateway } from "./gateway"
 import * as prefs from "../utils/preferences"
 import { openCountdown } from "../dialogs/countdown"
 import { io } from "../io"
 
 type Toast = { show: (o: { variant: "success"; title?: string; message: string; duration?: number }) => void }
-type ShellResult = { stdout: string; stderr: string; code: number }
-type SlashResult = { output?: string; warning?: string }
 
 export type GoalHook = {
   /** Called from onTurnComplete. Reads goal state, fires if done. */
   check: (sid: string) => void
-  /** Route /goal through the slash-worker. Returns cleaned output for
-   *  the transcript plus whether this was a fresh set (caller kicks
-   *  off the loop by sending the goal text as a prompt — parity with
-   *  the CLI's _pending_input.put(goal)). */
-  cmd: (arg: string) => Promise<{ line: string; kick: string | null }>
 }
 
 const SECONDS = 10
 const SUSPEND = process.platform === "darwin" ? "pmset sleepnow" : "systemctl suspend"
-const VERBS = new Set(["status", "pause", "resume", "clear", "stop", "done"])
-
-// _handle_goal_command prints via _cprint with _DIM/_RST interpolated
-// into the string before the worker's lambda swap, so the ANSI bytes
-// are in the captured buffer. Strip them for the transcript.
-const ANSI = /\x1b\[[0-9;]*m/g
 
 const run = (cmd: string) =>
   Bun.spawn(["sh", "-c", cmd], { stdout: "ignore", stderr: "ignore" })
@@ -47,7 +34,7 @@ const run = (cmd: string) =>
 // switch calls rehome() which starts a fresh sid anyway.
 const fired = new Map<string, string>()
 
-export function makeGoalHook(gw: Gateway, dialog: DialogContext, toast: Toast): GoalHook {
+export function makeGoalHook(dialog: DialogContext, toast: Toast): GoalHook {
   const act = (goal: string) => {
     const pref = (prefs.get("onGoalDone") ?? "toast").trim()
     const head = goal.length > 60 ? goal.slice(0, 57) + "…" : goal
@@ -74,21 +61,5 @@ export function makeGoalHook(gw: Gateway, dialog: DialogContext, toast: Toast): 
         act(s.goal)
       }).catch(() => {})
     },
-    cmd: async (arg: string) => {
-      const trimmed = arg.trim()
-      const first = trimmed.split(/\s+/, 1)[0]?.toLowerCase() ?? ""
-      // Non-verb (and non-empty) first token ⇒ this is a fresh goal
-      // set; the caller should kick the loop off by submitting the
-      // goal text as the first prompt. Verbs + bare `/goal` just
-      // report/mutate state.
-      const kick = trimmed && !VERBS.has(first) ? trimmed : null
-      const r = await gw.request<SlashResult>("slash.exec",
-        { command: `/goal${trimmed ? " " + trimmed : ""}` })
-      const line = (r.output ?? "").replace(ANSI, "").trim() || "ok"
-      return { line, kick }
-    },
   }
 }
-
-// Exposed for tests — keep type surface minimal.
-export type { ShellResult }

--- a/src/commands/slash.ts
+++ b/src/commands/slash.ts
@@ -35,7 +35,7 @@ export type SlashCommand = {
 export const LOCAL_NAMES = new Set([
   "clear", "new", "theme", "help", "keys", "logs", "eikon", "title",
   "rollback", "save", "history", "status", "usage", "profile", "steer",
-  "reload", "reload-mcp", "chafa", "splash", "goal", "skin",
+  "reload", "reload-mcp", "chafa", "splash", "skin",
   // parity: session-mutating commands the slash-worker can't service
   "resume", "branch", "compress", "undo", "retry", "model", "quit",
   "copy", "paste", "image", "background", "voice", "mouse", "redraw", "queue",
@@ -67,7 +67,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "reload", description: "Hot-reload ~/.hermes/.env (API keys)", category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "chafa",  description: "Render image via chafa (demo)",       category: "Client",  aliases: [], argsHint: "<path>", subcommands: [], source: "local", target: "local" },
   { name: "splash", description: "Show the launch splash",              category: "Client",  aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
-  { name: "goal",   description: "Set/control the session goal",        category: "Session", aliases: [], argsHint: "[text|done|pause|resume|clear|status]", subcommands: ["done", "pause", "resume", "clear", "status"], source: "local", target: "local" },
+  { name: "goal",   description: "Set/control the session goal",        category: "Session", aliases: [], argsHint: "[text|done|pause|resume|clear|status]", subcommands: ["done", "pause", "resume", "clear", "status"], source: "command", target: "gateway" },
   { name: "skin",   description: "Switch Hermes skin (+ theme + eikon)", category: "Client",  aliases: [], argsHint: "[name]", subcommands: [...SKINS], source: "local", target: "local" },
 ]
 

--- a/src/dialogs/text-prompt.tsx
+++ b/src/dialogs/text-prompt.tsx
@@ -1,6 +1,6 @@
 // Single-line text prompt dialog. Enter submits, Esc cancels.
 
-import { useState } from "react"
+import { useState, useCallback } from "react"
 import { useKeyboard } from "@opentui/react"
 import { useTheme } from "../theme"
 import type { DialogContext } from "../ui/dialog"
@@ -17,17 +17,13 @@ const TextPrompt = (props: Props) => {
   const theme = useTheme().theme
   const [value, setValue] = useState(props.initial ?? "")
 
+  const submit = useCallback(() => {
+    const v = value.trim()
+    if (v) props.onSubmit(v)
+  }, [value, props.onSubmit])
+
   useKeyboard((key) => {
     if (key.name === "escape") return props.onCancel()
-    if (key.name === "return") {
-      const v = value.trim()
-      if (v) props.onSubmit(v)
-      return
-    }
-    if (key.name === "backspace") return setValue(v => v.slice(0, -1))
-    if (key.ctrl && key.name === "u") return setValue("")
-    if (!key.ctrl && !key.meta && key.raw && key.raw.length === 1 && key.raw >= " ")
-      return setValue(v => v + key.raw)
   })
 
   return (
@@ -38,15 +34,20 @@ const TextPrompt = (props: Props) => {
       <box height={1} flexDirection="row" overflow="hidden">
         <box flexShrink={0}><text fg={theme.accent}>{"┃ "}</text></box>
         <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
-          <text>
-            <span fg={theme.text}>{value}</span>
-            <span fg={theme.accent}>█</span>
-          </text>
+          <input
+            value={value}
+            onInput={setValue}
+            onSubmit={submit as unknown as (e: { value: string }) => void}
+            focused={true}
+            textColor={theme.text}
+            backgroundColor={theme.backgroundElement}
+            focusedBackgroundColor={theme.backgroundElement}
+          />
         </box>
       </box>
       <box height={1} />
       <box height={1}><text fg={theme.textMuted}>
-        {value.trim() ? "Enter confirm  ·  Esc cancel  ·  Ctrl+U clear" : "Esc cancel"}
+        {value.trim() ? "Enter confirm  ·  Esc cancel" : "Esc cancel"}
       </text></box>
     </box>
   )

--- a/src/dialogs/text-prompt.tsx
+++ b/src/dialogs/text-prompt.tsx
@@ -1,6 +1,6 @@
 // Single-line text prompt dialog. Enter submits, Esc cancels.
 
-import { useState, useCallback } from "react"
+import { useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import { useTheme } from "../theme"
 import type { DialogContext } from "../ui/dialog"
@@ -17,11 +17,9 @@ const TextPrompt = (props: Props) => {
   const theme = useTheme().theme
   const [value, setValue] = useState(props.initial ?? "")
 
-  const submit = useCallback(() => {
-    const v = value.trim()
-    if (v) props.onSubmit(v)
-  }, [value, props.onSubmit])
-
+  // Native <input> owns text/paste/cursor; global bus only handles Esc
+  // (DialogProvider also clears on Esc, but it doesn't resolve the
+  // promise — onCancel does).
   useKeyboard((key) => {
     if (key.name === "escape") return props.onCancel()
   })
@@ -37,8 +35,8 @@ const TextPrompt = (props: Props) => {
           <input
             value={value}
             onInput={setValue}
-            onSubmit={submit as unknown as (e: { value: string }) => void}
-            focused={true}
+            onSubmit={() => { const v = value.trim(); if (v) props.onSubmit(v) }}
+            focused
             textColor={theme.text}
             backgroundColor={theme.backgroundElement}
             focusedBackgroundColor={theme.backgroundElement}
@@ -47,7 +45,7 @@ const TextPrompt = (props: Props) => {
       </box>
       <box height={1} />
       <box height={1}><text fg={theme.textMuted}>
-        {value.trim() ? "Enter confirm  ·  Esc cancel" : "Esc cancel"}
+        {value.trim() ? "Enter confirm  ·  Esc cancel  ·  Ctrl+U clear" : "Esc cancel"}
       </text></box>
     </box>
   )

--- a/test/goal.test.tsx
+++ b/test/goal.test.tsx
@@ -1,12 +1,11 @@
-import { describe, test, expect, beforeAll } from "bun:test"
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { act } from "react"
 import { useEffect } from "react"
 import { Database } from "bun:sqlite"
 import { join } from "path"
-import { mkdirSync } from "fs"
-import { mountNode, until, MockGateway } from "./harness"
+import { mkdirSync, rmSync } from "fs"
+import { mount, mountNode, until, MockGateway } from "./harness"
 import { openCountdown } from "../src/dialogs/countdown"
-import { makeGoalHook } from "../src/app/goalHook"
 import { useDialog } from "../src/ui/dialog"
 import { goalState, resetDb } from "../src/utils/sessions-db"
 
@@ -28,6 +27,15 @@ describe("sessions-db.goalState", () => {
     ])
     db.close()
     resetDb() // drop any cached handle so q() reopens against the now-seeded file
+  })
+
+  // The fixture db has state_meta only — enough for goalState() but
+  // not for roots()/lastReal() (COLS references messages). Drop it
+  // before the /goal routing block below does full mount()s, so
+  // stateDb() returns null and the readers short-circuit to [].
+  afterAll(() => {
+    resetDb()
+    rmSync(join(HH, "state.db"), { force: true })
   })
 
   test("parses done + active; null on missing", () => {
@@ -77,63 +85,64 @@ describe("countdown dialog", () => {
   })
 })
 
-// ─── goalHook.cmd → slash.exec dispatch ──────────────────────────────
+// ─── /goal slash → command.dispatch path ─────────────────────────────
+// Stock tui_gateway rejects /goal from slash.exec (it's a
+// _PENDING_INPUT_COMMANDS entry — the slash-worker CLI has no input
+// loop to kick off with) and handles it in command.dispatch instead,
+// where it drives GoalManager directly and returns {type:"send",
+// notice, message: goal}. herm must route it as target=gateway so the
+// generic slash.exec-catch → command.dispatch fallback fires.
 
-describe("goalHook.cmd", () => {
-  const mk = () => {
-    const calls: string[] = []
+describe("/goal slash routing", () => {
+  test("slash.exec reject → command.dispatch; notice + kickoff prompt", async () => {
+    const slashes: string[] = []
+    const dispatches: Array<{ name: string; arg: string }> = []
+    const submits: string[] = []
     const gw = new MockGateway({
-      "slash.exec": (p) => { calls.push(String(p.command)); return { output: "  ⊙ Goal set (20-turn budget): x\n  \x1b[2mAfter each turn…\x1b[22m" } },
+      "slash.exec": (p) => {
+        slashes.push(String(p.command))
+        throw new Error("pending-input command: use command.dispatch for /goal")
+      },
+      "command.dispatch": (p) => {
+        dispatches.push({ name: String(p.name), arg: String(p.arg ?? "") })
+        return p.arg
+          ? { type: "send", notice: "⊙ Goal set (20-turn budget): x", message: String(p.arg) }
+          : { type: "exec", output: "No active goal." }
+      },
+      "prompt.submit": (p) => { submits.push(String(p.text)); return {} },
     })
-    const dialog = { replace: () => {}, clear: () => {}, stack: [] as const, open: () => false }
-    const toast = { show: () => {} }
-    const hook = makeGoalHook(gw, dialog, toast)
-    return { hook, calls }
-  }
+    const t = await mount({ gw, width: 140, height: 30 })
+    await until(t, () => t.frame().includes("Ready"))
 
-  test("verbs pass through to /goal <verb>; no kick", async () => {
-    const { hook, calls } = mk()
-    for (const v of ["status", "pause", "resume", "clear", "done"]) {
-      const r = await hook.cmd(v)
-      expect(r.kick).toBeNull()
-    }
-    expect(calls).toEqual([
-      "/goal status", "/goal pause", "/goal resume", "/goal clear", "/goal done",
-    ])
+    await act(async () => { await t.keys.typeText("/goal ship it") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => submits.length === 1)
+
+    expect(slashes[0]).toBe("/goal ship it")
+    expect(dispatches[0]).toEqual({ name: "goal", arg: "ship it" })
+    expect(submits[0]).toBe("ship it")
+    // notice rendered as a system line before the kickoff.
+    expect(t.frame()).toContain("⊙ Goal set")
+    t.destroy()
   })
 
-  test("bare /goal → status; no kick", async () => {
-    const { hook, calls } = mk()
-    const r = await hook.cmd("")
-    expect(calls[0]).toBe("/goal")
-    expect(r.kick).toBeNull()
-  })
-
-  test("free text → set; kick = goal text; ANSI stripped from output", async () => {
-    const { hook, calls } = mk()
-    const r = await hook.cmd("ship the $(thing)")
-    expect(calls[0]).toBe("/goal ship the $(thing)")
-    expect(r.kick).toBe("ship the $(thing)")
-    // _DIM/_RST stripped; lines trimmed.
-    expect(r.line).toContain("⊙ Goal set")
-    expect(r.line).not.toContain("\x1b[")
-  })
-
-  // Regression guard: the original implementation smuggled goal text
-  // through shell.exec → `python3 -c '…'`, which tui_gateway's
-  // shell.exec handler hard-rejects via detect_dangerous_command
-  // ("script execution via -e/-c flag"). No shell.exec, ever.
-  test("never dispatches shell.exec", async () => {
-    let touched = false
+  test("verbs → {type: exec, output}; no prompt.submit", async () => {
+    const submits: string[] = []
     const gw = new MockGateway({
-      "slash.exec": () => ({ output: "ok" }),
-      "shell.exec": () => { touched = true; return { stdout: "", stderr: "", code: 0 } },
+      "slash.exec": () => { throw new Error("pending-input command") },
+      "command.dispatch": () => ({ type: "exec", output: "⏸ Goal paused: x" }),
+      "prompt.submit": (p) => { submits.push(String(p.text)); return {} },
     })
-    const hook = makeGoalHook(gw,
-      { replace: () => {}, clear: () => {}, stack: [] as const, open: () => false },
-      { show: () => {} })
-    await hook.cmd("anything")
-    await hook.cmd("done")
-    expect(touched).toBe(false)
+    const t = await mount({ gw, width: 140, height: 30 })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/goal pause") })
+    // First Enter accepts the subcommand-popover completion ("/goal
+    // pause "); second dispatches.
+    act(() => t.keys.pressEnter()); await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("⏸ Goal paused"))
+    expect(submits.length).toBe(0)
+    t.destroy()
   })
 })

--- a/test/text-prompt.test.tsx
+++ b/test/text-prompt.test.tsx
@@ -5,10 +5,14 @@ import { useDialog } from "../src/ui/dialog"
 import { openTextPrompt } from "../src/dialogs/text-prompt"
 import { useEffect } from "react"
 
+let resolved: string | null | undefined
+
 const Opener = () => {
   const dialog = useDialog()
   useEffect(() => {
+    resolved = undefined
     void openTextPrompt(dialog, { title: "Rename Thing", label: "Title", initial: "hello" })
+      .then(v => { resolved = v })
   }, [])
   return null
 }
@@ -44,6 +48,31 @@ describe("TextPrompt", () => {
     // Hint row still intact directly after.
     const valY = lines.findIndex(l => l.includes("┃"))
     expect(lines[valY + 2]).toContain("Enter confirm")
+    t.destroy()
+  })
+
+  test("bracketed-paste lands in the buffer", async () => {
+    const t = await mountNode(<Opener />)
+    await until(t, () => t.frame().includes("┃ hello"))
+    await act(async () => { await t.keys.pasteBracketedText("-sk-abc123") })
+    await until(t, () => t.frame().includes("hello-sk-abc123"))
+    const lines = t.frame().split("\n")
+    const valY = lines.findIndex(l => l.includes("┃"))
+    expect(lines[valY]).toContain("hello-sk-abc123")
+    t.destroy()
+  })
+
+  test("← moves cursor: char inserts before end; Enter resolves", async () => {
+    const t = await mountNode(<Opener />)
+    await until(t, () => t.frame().includes("┃ hello"))
+    // "hello" cursor at end → ←← → type X → "helXlo"
+    await act(async () => { t.keys.pressArrow("left") })
+    await act(async () => { t.keys.pressArrow("left") })
+    await act(async () => { await t.keys.typeText("X") })
+    await until(t, () => t.frame().includes("helXlo"))
+    await act(async () => { t.keys.pressEnter() })
+    await until(t, () => resolved !== undefined)
+    expect(resolved).toBe("helXlo")
     t.destroy()
   })
 })


### PR DESCRIPTION
## Changes

### `/goal` routing (f2bda4d)
Drop local `/goal` interception and let `command.dispatch` handle it. d3809bd moved `/goal` to `slash.exec`, but the slash-worker rejects pending-input commands with 4018. Stock `tui_gateway` already handles `/goal` end-to-end via `command.dispatch`; herm now falls through to it. `goalHook.ts` thinned to `check()` only.

### TextPrompt paste support (#5, 94f5074 + 01ebe6c)
Replace hand-rolled per-char `useKeyboard` accumulator in `src/dialogs/text-prompt.tsx` with native `<input>`. Old `key.raw.length === 1` filter dropped bracketed-paste chunks, so Cmd+V was a no-op. Native input also brings a real cursor (arrow keys, home/end, ctrl+a/e/w/k/u). Affects all 18 `openTextPrompt` call sites (Env, Kanban, Cron, Sessions, Context, keys rebind, `/title`, `/steer`).