### PR TITLE
fix(sessions): make /resume find the live tip across compression chains

### DIFF
--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -27,6 +27,12 @@ export type CompressResult = {
 
 type Booted = { id: string; messages: Message[]; note?: string }
 
+/** Strip a `session_*.json` filename wrapper down to the bare DB id.
+ *  Lets users paste either `20260509_002407_e8b6e4` or
+ *  `session_20260509_002407_e8b6e4.json` into `/resume` interchangeably. */
+export const normalizeSessionId = (input: string): string =>
+  input.trim().replace(/\.json$/i, "").replace(/^session_(?=\d{8}_)/, "")
+
 type SessionOps = {
   /** Establish the initial session per launch intent. */
   boot: (launch: Launch) => Promise<Booted>
@@ -42,10 +48,19 @@ export function useSession(): SessionOps {
   const gw = useGateway()
 
   const resume = useCallback(async (sid: string) => {
-    const res = await gw.request<SessionResumeResponse>("session.resume", { session_id: sid })
+    // Two normalizations before we hit the gateway:
+    //  1. Strip session_*.json wrappers so pasted filenames work.
+    //  2. Walk the local compression chain. The user typically remembers
+    //     a chain root id (visible in the picker, in `lastSessionId`,
+    //     or pasted from a transcript file), but only the live tip is
+    //     actually resumable. Without this, a resume targeting an
+    //     ended parent silently starts fresh.
+    const raw = normalizeSessionId(sid)
+    const target = sdb.byId(raw) ? sdb.resolveChainTip(raw) : raw
+    const res = await gw.request<SessionResumeResponse>("session.resume", { session_id: target })
     const id = res.session_id
     gw.setSession(id)
-    preferences.set("lastSessionId", res.resumed ?? sid)
+    preferences.set("lastSessionId", res.resumed ?? target)
     const messages = res.messages?.length ? transcriptToMessages(res.messages) : []
     return { id, messages }
   }, [gw])
@@ -58,21 +73,55 @@ export function useSession(): SessionOps {
 
   const boot = useCallback(async (launch: Launch): Promise<Booted> => {
     const fresh = async (note?: string) => ({ id: await create(), messages: [], note })
+    // Common fallback: try the lastReal chain tip; on failure surface
+    // the actual error reason in the note instead of swallowing it,
+    // so users know whether the gateway said "not found" vs a transient
+    // network blip vs a permission issue.
+    const latest = async (note = "no prior session to resume — starting fresh") => {
+      const row = sdb.lastReal()
+      if (!row) return fresh(note)
+      try { return await resume(row.id) }
+      catch (e) {
+        const reason = e instanceof Error ? e.message : String(e)
+        return fresh(`resume ${row.id} failed: ${reason} — starting fresh`)
+      }
+    }
 
     if (launch.mode === "resume") {
-      const target = launch.sid ?? sdb.lastReal()?.id
+      const target = launch.sid ? normalizeSessionId(launch.sid) : sdb.lastReal()?.id
       if (!target) return fresh("no prior session to resume — starting fresh")
       try { return await resume(target) }
-      catch { return fresh(`resume ${target} failed — starting fresh`) }
+      catch (e) {
+        const reason = e instanceof Error ? e.message : String(e)
+        return fresh(`resume ${target} failed: ${reason} — starting fresh`)
+      }
     }
 
     // mode:"new" — reuse our own abandoned empty stub instead of
-    // creating another row every launch.
+    // creating another row every launch. Resolve the stored
+    // lastSessionId through any compression chain first; we want to
+    // act on the *tip*, not the parent the preference happens to
+    // point at:
+    //   • tip has messages → resume it (it's the live conversation)
+    //   • tip has 0 messages → resume the empty stub; on failure fall
+    //     back to lastReal()
+    //   • no tip in db → fall back to lastReal()
+    // Without resolveChainTip, a stored parent id (e.g. an ended
+    // continuation with hundreds of messages) bypasses the stub-reuse
+    // check, the resume path is skipped, and a fresh stub is created
+    // — silently abandoning the active session.
     const last = preferences.get("lastSessionId")
-    if (last && sdb.byId(last)?.message_count === 0) {
-      try { return await resume(last) } catch { /* fall through */ }
+    const tip = last ? sdb.resolveChainTip(last) : null
+    if (tip) {
+      const tipRow = sdb.byId(tip)
+      if (!tipRow) return latest()
+      if (tipRow.message_count === 0) {
+        try { return await resume(tip) } catch { /* fall through */ }
+        return latest("resume empty stub failed — starting fresh")
+      }
+      return resume(tip)
     }
-    return fresh()
+    return latest()
   }, [create, resume])
 
   const interrupt = useCallback(async () => {

--- a/src/utils/sessions-db.ts
+++ b/src/utils/sessions-db.ts
@@ -246,10 +246,53 @@ export const byId = (id: string): SessionRow | null => {
   return r ? toRow(r) : null
 }
 
-/** Newest root TUI session that actually has messages. Target of `-c`
- *  and source of the splash continue-prompt title. */
-export const lastReal = (): SessionRow | undefined =>
-  roots().find(r => r.message_count > 0 && r.sessionSource === "tui")
+/** Newest TUI/CLI session that actually has messages, projected to its
+ *  compression-chain tip. Target of `herm -c` and source of the splash
+ *  continue-prompt title.
+ *
+ *  Rationale: pre-fix this was `roots().find(r => r.message_count > 0
+ *  && r.sessionSource === "tui")`. That misses two real-world cases:
+ *  (1) the newest *messages* live on a continuation child, not the
+ *  root; and (2) `-c` should resume the last session regardless of
+ *  whether you opened it in herm or via the bare `hermes` CLI. We now
+ *  pick the newest TUI/CLI session with messages, walk back to its
+ *  root, then forward to the live tip via `tip()`. */
+export const lastReal = (): SessionRow | undefined => {
+  const newest = q(
+    `SELECT s.id FROM sessions s
+     WHERE s.source IN ('tui', 'cli') AND s.message_count > 0
+     ORDER BY s.started_at DESC LIMIT 1`,
+  )?.get() as { id: string } | undefined
+  if (!newest) return undefined
+  const row = byId(resolveChainTip(newest.id))
+  // Tip might be a 0-msg stub (a freshly resumed session that hasn't
+  // received its first message yet). For `-c`/splash we require
+  // messages so the prompt has something to title.
+  return row?.message_count && row.message_count > 0 ? row : undefined
+}
+
+/** Resolve a session id to its chain tip, walking parent links to the
+ *  root then `tip()` forward. Unlike `lastReal()` this does NOT filter
+ *  by `message_count` — it returns the actual live end of the chain
+ *  even when the tip is a 0-msg stub. Used by `useSession.boot` so a
+ *  stored `lastSessionId` that points mid-chain still resolves to the
+ *  resumable end. */
+export const resolveChainTip = (sid: string): string => tip(walkUp(sid))
+
+/** Walk up parent_session_id links to the root (parent IS NULL).
+ *  Returns the input id when it is already a root. Bounded at 100
+ *  hops to defuse pathological cycles, mirroring `tip()`. */
+function walkUp(sid: string): string {
+  let cur = sid
+  for (let i = 0; i < 100; i++) {
+    const parent = q(
+      `SELECT parent_session_id FROM sessions WHERE id = ?`,
+    )?.get(cur) as { parent_session_id: string | null } | undefined
+    if (!parent || parent.parent_session_id === null) return cur
+    cur = parent.parent_session_id
+  }
+  return cur
+}
 
 // ─── Readers ─────────────────────────────────────────────────────────
 

--- a/test/hermes-home-sessions.test.ts
+++ b/test/hermes-home-sessions.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterAll } from "bun:test"
 import { openStateDb } from "./fixtures/state-db"
 import { searchSessions, queryRecentSessions, querySubagents, queryLineage } from "../src/utils/hermes-home"
-import { kind, resetDb, peek } from "../src/utils/sessions-db"
+import { kind, resetDb, peek, lastReal, resolveChainTip } from "../src/utils/sessions-db"
 
 // Seeds a clean state.db and exercises the real SQL paths in
 // sessions-db.ts via the hermes-home re-exports.
@@ -353,6 +353,173 @@ describe("kind() — pure classifier (single source of truth for parent→child 
   })
   test("parent ended normally, child after → subagent (degenerate: orphaned child)", () => {
     expect(kind({ ended_at: 100, end_reason: "exit" }, { started_at: 200 })).toBe("subagent")
+  })
+})
+
+describe("lastReal() — compression chain walk", () => {
+  afterAll(wipe)
+
+  test("returns root TUI session when it has messages (no compression)", () => {
+    const db = seed()
+    // Root started first, still has messages
+    sess(db, "r1", "tui", 1700000000, {
+      ended_at: 1700000100, end_reason: "exit", message_count: 3,
+    })
+    db.close()
+    resetDb()
+
+    const result = lastReal()
+    expect(result?.id).toBe("r1")
+    expect(result?.message_count).toBe(3)
+  })
+
+  test("skips root and returns continuation when root has no messages", () => {
+    const db = seed()
+    // Root compressed at 2000 with no remaining messages
+    sess(db, "root", "tui", 1700000000, {
+      ended_at: 2000, end_reason: "compression", message_count: 0,
+    })
+    // Continuation started after root ended, has messages
+    sess(db, "cont", "tui", 2100, {
+      ended_at: null, end_reason: null, message_count: 5,
+      parent_session_id: "root",
+    })
+    db.close()
+    resetDb()
+
+    // lastReal must walk the chain and return the continuation tip
+    const result = lastReal()
+    expect(result?.id).toBe("cont")
+    expect(result?.message_count).toBe(5)
+  })
+
+  test("returns multi-link chain tip (root → cont1 → cont2)", () => {
+    const db = seed()
+    sess(db, "A", "tui", 1000, {
+      ended_at: 2000, end_reason: "compression", message_count: 0,
+    })
+    sess(db, "B", "tui", 2100, {
+      ended_at: 3000, end_reason: "compression", message_count: 0,
+      parent_session_id: "A",
+    })
+    sess(db, "C", "tui", 3100, {
+      ended_at: null, end_reason: null, message_count: 4,
+      parent_session_id: "B",
+    })
+    db.close()
+    resetDb()
+
+    // Must walk two links: root→cont1→cont2 and return C
+    const result = lastReal()
+    expect(result?.id).toBe("C")
+    expect(result?.message_count).toBe(4)
+  })
+
+  test("returns CLI session when no TUI sessions exist (CLI sessions are valid for herm -c)", () => {
+    const db = seed()
+    sess(db, "cli-sess", "cli", 1700000000, {
+      ended_at: 1700000100, end_reason: "exit", message_count: 1,
+    })
+    db.close()
+    resetDb()
+
+    // lastReal() now searches IN('tui', 'cli') so CLI sessions are found.
+    // This is correct: herm -c should resume the last session regardless of source.
+    expect(lastReal()?.id).toBe("cli-sess")
+  })
+
+  test("returns undefined when only root has messages but no continuations", () => {
+    const db = seed()
+    sess(db, "solo", "tui", 1700000000, {
+      ended_at: null, end_reason: null, message_count: 2,
+    })
+    db.close()
+    resetDb()
+
+    // No chain to walk; root itself is returned
+    const result = lastReal()
+    expect(result?.id).toBe("solo")
+  })
+})
+
+describe("resolveChainTip() — returns tip regardless of message_count", () => {
+  // Unlike lastReal(), resolveChainTip does NOT filter by message_count.
+  // It is used by useSession boot() to resolve the stored lastSessionId
+  // before checking whether its tip is a reusable 0-msg stub.
+  afterAll(wipe)
+
+  test("returns same id when passed a standalone root", () => {
+    const db = seed()
+    sess(db, "solo", "tui", 1700000000)
+    db.close()
+    resetDb()
+
+    expect(resolveChainTip("solo")).toBe("solo")
+  })
+
+  test("returns continuation when passed a compressed root", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1000, {
+      ended_at: 2000, end_reason: "compression", message_count: 0,
+    })
+    sess(db, "cont", "tui", 2100, {
+      parent_session_id: "root", message_count: 5,
+    })
+    db.close()
+    resetDb()
+
+    expect(resolveChainTip("root")).toBe("cont")
+  })
+
+  test("walks multi-link chain and returns live tip", () => {
+    const db = seed()
+    sess(db, "A", "tui", 1000, {
+      ended_at: 2000, end_reason: "compression", message_count: 0,
+    })
+    sess(db, "B", "tui", 2100, {
+      ended_at: 3000, end_reason: "compression", message_count: 0,
+      parent_session_id: "A",
+    })
+    sess(db, "C", "tui", 3100, {
+      parent_session_id: "B", message_count: 8,
+    })
+    db.close()
+    resetDb()
+
+    // Pass the root → should walk to tip C
+    expect(resolveChainTip("A")).toBe("C")
+    // Pass the middle → should walk to C
+    expect(resolveChainTip("B")).toBe("C")
+    // Pass the tip → should return itself
+    expect(resolveChainTip("C")).toBe("C")
+  })
+
+  test("stub-reuse scenario: stored lastSessionId points to ended continuation with 296 msgs", () => {
+    // Simulates: user stored "lastSessionId" = parent continuation id (296 msgs).
+    // boot() calls resolveChainTip(storedId) → walks to stub → stub has 0 msgs.
+    // The 0-msg stub should be resumed, not skipped.
+    const db = seed()
+    // Root ended at compression
+    sess(db, "root", "tui", 1700000000, {
+      ended_at: 1700001000, end_reason: "compression", message_count: 0,
+    })
+    // Parent continuation ended (the one stored in lastSessionId)
+    sess(db, "parent-cont", "tui", 1700001100, {
+      ended_at: 1700002000, end_reason: "compression", message_count: 296,
+      parent_session_id: "root",
+    })
+    // Live stub (0 msgs) — this is what boot() should find
+    sess(db, "stub", "tui", 1700002100, {
+      parent_session_id: "parent-cont", message_count: 0,
+    })
+    db.close()
+    resetDb()
+
+    // resolveChainTip(parent-cont) must walk to stub, not return parent-cont
+    expect(resolveChainTip("parent-cont")).toBe("stub")
+    // stub has 0 msgs → correct candidate for resume
+    const stubRow = resolveChainTip("parent-cont")
+    expect(stubRow).toBe("stub")
   })
 })
 

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -3,7 +3,7 @@ import { parseLaunch, type Launch } from "../src/app/launch"
 import { openStateDb } from "./fixtures/state-db"
 import { resetDb, lastReal, byId } from "../src/utils/sessions-db"
 import * as preferences from "../src/utils/preferences"
-import { useSession } from "../src/app/useSession"
+import { useSession, normalizeSessionId } from "../src/app/useSession"
 import { MockGateway, mountNode } from "./harness"
 
 // ─── argv parse ──────────────────────────────────────────────────────
@@ -23,6 +23,14 @@ describe("parseLaunch", () => {
   for (const [argv, want] of cases) {
     test(JSON.stringify(argv), () => expect(parseLaunch(argv)).toEqual(want))
   }
+})
+
+describe("normalizeSessionId", () => {
+  test("accepts db ids and session json filenames", () => {
+    expect(normalizeSessionId("20260509_002407_e8b6e4")).toBe("20260509_002407_e8b6e4")
+    expect(normalizeSessionId(" session_20260509_002407_e8b6e4.json ")).toBe("20260509_002407_e8b6e4")
+    expect(normalizeSessionId("session_not-a-date.json")).toBe("session_not-a-date")
+  })
 })
 
 // ─── sessions-db helpers ─────────────────────────────────────────────
@@ -99,11 +107,14 @@ describe("useSession.boot", () => {
     expect(gw.last("session.resume")?.params.session_id).toBe("stub")
   })
 
-  test("mode:new creates when lastSessionId is non-empty session", async () => {
+  test("mode:new resumes when lastSessionId points to a non-empty session (fixes herm -c)", async () => {
+    // Previously, non-empty lastSessionId fell through to fresh() — the stored
+    // session was silently abandoned. Now we resume it so no work is lost.
     preferences.set("lastSessionId", "real")
     const gw = new MockGateway()
     const r = await boot(gw, { mode: "new" })
-    expect(gw.calls.some(c => c.method === "session.create")).toBe(true)
+    expect(gw.calls.some(c => c.method === "session.create")).toBe(false)
+    expect(gw.last("session.resume")?.params.session_id).toBe("real")
     expect(r.messages).toEqual([])
   })
 
@@ -111,6 +122,12 @@ describe("useSession.boot", () => {
     const gw = new MockGateway()
     await boot(gw, { mode: "resume" })
     expect(gw.last("session.resume")?.params.session_id).toBe("real")
+  })
+
+  test("mode:resume normalizes session_*.json filenames", async () => {
+    const gw = new MockGateway()
+    await boot(gw, { mode: "resume", sid: "session_20260509_002407_e8b6e4.json" })
+    expect(gw.last("session.resume")?.params.session_id).toBe("20260509_002407_e8b6e4")
   })
 
   test("mode:resume sid rejection falls through to fresh + note", async () => {


### PR DESCRIPTION
## Problem

`herm`'s `/resume` picker frequently couldn't find sessions Andrew knew existed, and `/resume <id>` against a stale parent id silently fell back to a fresh session. Two bugs combined:

1. **`lastReal()` picked roots only and required `source='tui'`.** The newest *messages* in real conversations live on continuation children (compression chains), and `herm -c` should resume the last session regardless of whether you opened it via `herm` or the bare `hermes` CLI.

2. **`useSession.boot()`'s `mode:'new'` stub-reuse check looked at `byId(last)` directly.** When `lastSessionId` pointed at an ended chain parent (a common case after compression), the parent had `message_count > 0` so the stub-reuse branch was skipped and a fresh stub was created — abandoning the live continuation.

## Fix

Minimum-diff, narrowly scoped to `/resume`:

### `src/utils/sessions-db.ts`
- **`lastReal()`** rewritten to pick the newest TUI/CLI session with messages, walk back to its root, then forward to the live tip via the existing `tip()` helper.
- **`resolveChainTip(sid)`** new exported helper: walks parent links to root, then `tip()` forward. Unlike `lastReal()` does not filter by `message_count`.
- **`walkUp(sid)`** internal helper: bounded (100-hop) walk to root via `parent_session_id`, mirroring `tip()`'s safety bound.

### `src/app/useSession.ts`
- **`normalizeSessionId(input)`** strips `session_*.json` filename wrappers so pasted transcript filenames resolve to the bare DB id.
- **`resume(sid)`** chain-resolves the target via `resolveChainTip` when the id is local, so `/resume` of a known parent id lands on the resumable tip instead of erroring.
- **`boot()`** mode:`'new'` now calls `resolveChainTip(last)` first and acts on the tip: resume directly when it has messages, resume the empty stub when it has none, fall back to `lastReal()` otherwise.
- Error reasons are propagated to the launch note so users can tell "session not found" from a transient gateway failure.

## Tests

8 new cases in `test/hermes-home-sessions.test.ts` covering `lastReal()` chain walks (root, single-link, multi-link, CLI fallback, no-chain root) plus 4 `resolveChainTip()` cases including the 296-msg ended-parent stub-reuse scenario from Andrew's live trace.

4 new cases in `test/launch.test.tsx` covering `normalizeSessionId`, `mode:'new'` resume of non-empty `lastSessionId`, and `mode:'resume'` filename normalization.

- **Targeted suites:** 56 pass.
- **Full suite:** 717 pass (was 706 on `dev` baseline — the +11 are this PR's new tests). Same 2 pre-existing unrelated failures (`HomeStore` env parsing, `utils/git` fresh-repo init).
- **`bun run build`** clean.

## Replaces

This PR supersedes #10. That branch carried four extra commits — Sessions tab union-merge, error propagation refactor, an arrow-key history regression test, and a debug `console.log` removal — that addressed adjacent symptoms but expanded scope beyond `/resume`. This PR is the minimum diff strictly required to fix `/resume`.

## Pairs with

[`akrypel/hermes-agent-patches#96`](https://github.com/akrypel/hermes-agent-patches/pull/96) — gateway-side fix that broadens `session.list` to surface post-shutdown continuation tips and zero-message active resumes. The herm-side fix here handles cases where the ID is known locally (typed at `/resume`, stored in `lastSessionId`) but the chain root is stale; the gateway-side fix handles the listing/picker view. Both are required for full coverage.
