### PR TITLE
 1.3.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ profiles/
 issues.jsonl
 *.bak
 *.code-workspace
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ function foo() {
 - Avoid mocks as much as possible
 - Test actual implementation, do not duplicate logic into tests
 - Run tests with `bun test`
+- **Never run a standalone script that calls `hermesPath()` / `rmSync` / writes SQLite without first setting `HERMES_HOME` to a tmpdir.** `test/preload.ts` does this for `bun test`; `bun <file>.tsx` does NOT. A one-off repro script that imports from `src/` resolves `~/.hermes` and will clobber real user data. Pattern: `process.env.HERMES_HOME = mkdtempSync(join(tmpdir(), "herm-scratch-"))` as the first line, before any `src/` import.
 
 ## Type Checking
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -115,6 +115,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [status, setStatus] = useState("")
   const [eikon, setEikon] = useState<ParsedEikon | undefined>(undefined)
   const [queue, setQueue] = useState<string[]>([])
+  type BusyInputMode = "queue" | "steer" | "interrupt"
+  const [busyInputMode, setBusyInputMode] = useState<BusyInputMode>("queue")
   // ── Splash ────────────────────────────────────────────────────────
   // Welcome-state chrome over an empty transcript. Composer stays live
   // underneath; first send dismisses. `/splash` re-summons mid-session
@@ -206,7 +208,46 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     setForce(next)
   }, [cloud])
   const closeCloud = useCallback(() => { setForce(false); setPick(undefined) }, [])
-  const onEnqueue = useCallback((t: string) => setQueue(q => [...q, t]), [])
+  // Ref for the interrupt function — populated after doInterrupt is defined
+  const doInterruptRef = useRef<() => void>(() => {})
+  // Stable ref to send() — lets us dispatch slash commands immediately during streaming
+  const sendRef = useRef<(raw: string) => void>(() => {})
+  // Mode-aware handler for input while streaming. Slash commands (e.g. /steer, /queue)
+  // are dispatched immediately via send(); plain text respects display.busy_input_mode:
+  //   "queue"     — append to queue, drain on idle (default for TUI)
+  //   "steer"     — inject into current turn via session.steer; falls back to queue
+  //   "interrupt" — interrupt current turn, then send as new prompt
+  const onEnqueue = useCallback((t: string) => {
+    // Slash commands execute immediately even while streaming (parity with Ink TUI)
+    if (/^\/\S/.test(t)) {
+      sendRef.current(t)
+      return
+    }
+    const mode = busyInputMode
+    if (mode === "steer") {
+      gw.request<{ status?: string; text?: string }>("session.steer", { text: t })
+        .then(r => {
+          if (r.status === "queued") {
+            toast.show({ variant: "success", message: "Steered — lands on next tool result" })
+          } else {
+            setQueue(q => [...q, t])
+            toast.show({ variant: "info", message: "Steer rejected — queued for next turn" })
+          }
+        })
+        .catch(() => {
+          setQueue(q => [...q, t])
+          toast.show({ variant: "info", message: "Steer failed — queued for next turn" })
+        })
+      return
+    }
+    if (mode === "interrupt") {
+      doInterruptRef.current()
+      setQueue(q => [...q, t])
+      return
+    }
+    // Default: "queue" — just enqueue for next turn
+    setQueue(q => [...q, t])
+  }, [busyInputMode, gw, toast])
   const onAttach = useCallback((r: ImageAttachResponse) => setAttachments(a => [...a, r]), [])
 
   // ── Session reset / lifecycle ─────────────────────────────────────
@@ -392,8 +433,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // `slash` and `send` reference each other (skill/alias dispatch needs
   // to submit a turn; typed `/cmd` in send() resolves via slash). The
   // cycle is broken with a forward ref — same shape as upstream Ink's
-  // slashRef/submitRef pair.
-  const sendRef = useRef<(raw: string) => void>(() => {})
+  // slashRef/submitRef pair. (sendRef declared earlier for onEnqueue access)
   const slash = useCallback((c: SlashCommand, arg = "") => {
     if (c.target === "local") {
       switch (c.name) {
@@ -526,8 +566,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           return
         case "steer": {
           const fire = (text: string) =>
-            gw.request<{ accepted: boolean }>("session.steer", { text })
-              .then(r => toast.show(r.accepted
+            gw.request<{ status?: string; text?: string }>("session.steer", { text })
+              .then(r => toast.show(r.status === "queued"
                 ? { variant: "success", message: "Queued — lands on next tool result" }
                 : { variant: "info", message: "No turn running; send as a normal message" }))
               .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
@@ -775,6 +815,14 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           setTitle(r.title ?? "")
           if (r.session_key) preferences.set("lastSessionId", r.session_key)
         }).catch(() => {})
+        // Fetch display.busy_input_mode from config — TUI defaults to "queue"
+        gw.request<{ config?: Record<string, any> }>("config.get", { key: "full" }).then(r => {
+          const d = r.config?.display ?? {}
+          const raw = String(d.busy_input_mode ?? "").trim().toLowerCase()
+          if (raw === "steer" || raw === "interrupt" || raw === "queue") {
+            setBusyInputMode(raw)
+          }
+        }).catch(() => {})
       },
       onUsage: (u) => setUsage(u),
       onTurnComplete: () => {
@@ -866,6 +914,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     d.text = ""; d.think = ""
     session.interrupt()
   }, [session])
+  doInterruptRef.current = doInterrupt
 
   // ── Keyboard ──────────────────────────────────────────────────────
   useAppKeys({

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -588,6 +588,16 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
             })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
+        case "reload-skills":
+          gw.request<{ output: string; result: { added?: unknown[]; removed?: unknown[]; total?: number } }>(
+            "skills.reload", {})
+            .then(r => {
+              dispatch({ kind: "system", text: r.output })
+              const n = Number(r.result?.total ?? 0)
+              toast.show({ variant: "success", message: `Skills reloaded (${n} available)` })
+            })
+            .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
+          return
         case "save":
           gw.request<{ file: string }>("session.save")
             .then(r => toast.show({ variant: "success", message: `Saved → ${r.file}` }))

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -115,8 +115,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [status, setStatus] = useState("")
   const [eikon, setEikon] = useState<ParsedEikon | undefined>(undefined)
   const [queue, setQueue] = useState<string[]>([])
-  type BusyInputMode = "queue" | "steer" | "interrupt"
-  const [busyInputMode, setBusyInputMode] = useState<BusyInputMode>("queue")
+  const [busy, setBusy] = useState<"queue" | "steer" | "interrupt">("queue")
   // ── Splash ────────────────────────────────────────────────────────
   // Welcome-state chrome over an empty transcript. Composer stays live
   // underneath; first send dismisses. `/splash` re-summons mid-session
@@ -208,46 +207,25 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     setForce(next)
   }, [cloud])
   const closeCloud = useCallback(() => { setForce(false); setPick(undefined) }, [])
-  // Ref for the interrupt function — populated after doInterrupt is defined
-  const doInterruptRef = useRef<() => void>(() => {})
-  // Stable ref to send() — lets us dispatch slash commands immediately during streaming
-  const sendRef = useRef<(raw: string) => void>(() => {})
-  // Mode-aware handler for input while streaming. Slash commands (e.g. /steer, /queue)
-  // are dispatched immediately via send(); plain text respects display.busy_input_mode:
-  //   "queue"     — append to queue, drain on idle (default for TUI)
-  //   "steer"     — inject into current turn via session.steer; falls back to queue
-  //   "interrupt" — interrupt current turn, then send as new prompt
+  const intr = useRef<() => void>(() => {})
+  // Plain text submitted while streaming (Composer routes slash-shaped
+  // input to onSend instead). `interrupt` prepends so the drain effect
+  // fires this text first once turn.streaming flips.
   const onEnqueue = useCallback((t: string) => {
-    // Slash commands execute immediately even while streaming (parity with Ink TUI)
-    if (/^\/\S/.test(t)) {
-      sendRef.current(t)
-      return
-    }
-    const mode = busyInputMode
-    if (mode === "steer") {
-      gw.request<{ status?: string; text?: string }>("session.steer", { text: t })
+    if (busy === "steer") {
+      gw.request<{ status: string }>("session.steer", { text: t })
         .then(r => {
-          if (r.status === "queued") {
-            toast.show({ variant: "success", message: "Steered — lands on next tool result" })
-          } else {
-            setQueue(q => [...q, t])
-            toast.show({ variant: "info", message: "Steer rejected — queued for next turn" })
-          }
-        })
-        .catch(() => {
+          if (r.status === "queued")
+            return toast.show({ variant: "success", message: "steered — lands on next tool result" })
           setQueue(q => [...q, t])
-          toast.show({ variant: "info", message: "Steer failed — queued for next turn" })
+          toast.show({ variant: "info", message: "steer rejected — queued for next turn" })
         })
+        .catch(() => setQueue(q => [...q, t]))
       return
     }
-    if (mode === "interrupt") {
-      doInterruptRef.current()
-      setQueue(q => [...q, t])
-      return
-    }
-    // Default: "queue" — just enqueue for next turn
+    if (busy === "interrupt") { intr.current(); return setQueue(q => [t, ...q]) }
     setQueue(q => [...q, t])
-  }, [busyInputMode, gw, toast])
+  }, [busy, gw, toast])
   const onAttach = useCallback((r: ImageAttachResponse) => setAttachments(a => [...a, r]), [])
 
   // ── Session reset / lifecycle ─────────────────────────────────────
@@ -433,7 +411,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // `slash` and `send` reference each other (skill/alias dispatch needs
   // to submit a turn; typed `/cmd` in send() resolves via slash). The
   // cycle is broken with a forward ref — same shape as upstream Ink's
-  // slashRef/submitRef pair. (sendRef declared earlier for onEnqueue access)
+  // slashRef/submitRef pair.
+  const sendRef = useRef<(raw: string) => void>(() => {})
   const slash = useCallback((c: SlashCommand, arg = "") => {
     if (c.target === "local") {
       switch (c.name) {
@@ -815,13 +794,9 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           setTitle(r.title ?? "")
           if (r.session_key) preferences.set("lastSessionId", r.session_key)
         }).catch(() => {})
-        // Fetch display.busy_input_mode from config — TUI defaults to "queue"
-        gw.request<{ config?: Record<string, any> }>("config.get", { key: "full" }).then(r => {
-          const d = r.config?.display ?? {}
-          const raw = String(d.busy_input_mode ?? "").trim().toLowerCase()
-          if (raw === "steer" || raw === "interrupt" || raw === "queue") {
-            setBusyInputMode(raw)
-          }
+        gw.request<{ value?: string }>("config.get", { key: "busy" }).then(r => {
+          const m = r.value
+          if (m === "queue" || m === "steer" || m === "interrupt") setBusy(m)
         }).catch(() => {})
       },
       onUsage: (u) => setUsage(u),
@@ -914,7 +889,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     d.text = ""; d.think = ""
     session.interrupt()
   }, [session])
-  doInterruptRef.current = doInterrupt
+  intr.current = doInterrupt
 
   // ── Keyboard ──────────────────────────────────────────────────────
   useAppKeys({

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -185,6 +185,20 @@ export function useAppKeys(o: Opts) {
         return
       }
     }
+    // Alt+1..0 → tab 1..10 (1-indexed), Alt+- → tab 11.
+    // Direct single-stroke, no leader needed.
+    if (key.meta && !key.ctrl && !key.shift && key.eventType !== "release") {
+      const map: Record<string, number> = {
+        "1": 0, "2": 1, "3": 2, "4": 3, "5": 4,
+        "6": 5, "7": 6, "8": 7, "9": 8, "0": 9, "-": 10,
+      }
+      const n = map[key.name]
+      if (n !== undefined && n <= o.tabMax) {
+        o.setTab(() => { o.setFocusRegion(regionFor(n)); return n })
+        key.stopPropagation()
+        return
+      }
+    }
 
     // Popover owns up/down/tab/escape while open; stopPropagation keeps the
     // textarea renderable from also moving the cursor on the same keypress.

--- a/src/commands/slash.ts
+++ b/src/commands/slash.ts
@@ -35,7 +35,7 @@ export type SlashCommand = {
 export const LOCAL_NAMES = new Set([
   "clear", "new", "theme", "help", "keys", "logs", "eikon", "title",
   "rollback", "save", "history", "status", "usage", "profile", "steer",
-  "reload", "reload-mcp", "chafa", "splash", "skin",
+  "reload", "reload-mcp", "reload-skills", "chafa", "splash", "skin",
   // parity: session-mutating commands the slash-worker can't service
   "resume", "branch", "compress", "undo", "retry", "model", "quit",
   "copy", "paste", "image", "background", "voice", "mouse", "redraw", "queue",
@@ -65,6 +65,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "steer",   description: "Inject a note mid-turn (no interrupt)", category: "Session", aliases: [], argsHint: "[text]", subcommands: [], source: "local", target: "local" },
   { name: "reload-mcp", description: "Restart MCP servers & rediscover tools", category: "Session", aliases: [], argsHint: "[now|always]", subcommands: ["now", "always"], source: "local", target: "local" },
   { name: "reload", description: "Hot-reload ~/.hermes/.env (API keys)", category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "reload-skills", description: "Re-scan ~/.hermes/skills/ for added/removed skills", category: "Session", aliases: ["reload_skills"], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "chafa",  description: "Render image via chafa (demo)",       category: "Client",  aliases: [], argsHint: "<path>", subcommands: [], source: "local", target: "local" },
   { name: "splash", description: "Show the launch splash",              category: "Client",  aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "goal",   description: "Set/control the session goal",        category: "Session", aliases: [], argsHint: "[text|done|pause|resume|clear|status]", subcommands: ["done", "pause", "resume", "clear", "status"], source: "command", target: "gateway" },

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -186,6 +186,11 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (!text || !live.current.props.ready) return
       hist.push(text)
       write("")
+      // Slash-shaped input routes through onSend so send() → slash()
+      // can apply per-command streaming policy (local cases fire now,
+      // gateway-target cases self-queue). Only plain text hits the
+      // app-side busy-mode branch.
+      if (text.startsWith("/")) return void live.current.props.onSend(text)
       live.current.props.onEnqueue?.(text)
       return
     }

--- a/src/dialogs/new-task.tsx
+++ b/src/dialogs/new-task.tsx
@@ -55,7 +55,10 @@ export function openCreateTask(
 ): Promise<Draft | null> {
   return new Promise(resolve => {
     const done = (r: Draft | null) => { dialog.clear(); resolve(r) }
-    dialog.replace(<Form pool={opts.assignees} parent={opts.parent} done={done} />)
+    // ownCancel: the Form owns Esc — first press backs out of an open
+    // sub-picker, only an Esc on the bare form cancels creation.
+    dialog.replace(<Form pool={opts.assignees} parent={opts.parent} done={done} />,
+      undefined, { ownCancel: true })
   })
 }
 
@@ -150,9 +153,12 @@ const Form = (p: {
 
   useKeyboard((key) => {
     // Picker owns the keyboard while open; DialogSelect has its own
-    // useKeyboard. We only need Esc here to close it without resolving.
+    // useKeyboard. Esc backs out one level: dirPath → workspace picker
+    // → form; any other picker → form.
     if (picker) {
-      if (key.name === "escape") setPicker(null)
+      if (key.name === "escape") {
+        setPicker(picker.kind === "dirPath" ? { kind: "workspace" } : null)
+      }
       return
     }
 

--- a/src/dialogs/new-task.tsx
+++ b/src/dialogs/new-task.tsx
@@ -170,12 +170,26 @@ const Form = (p: {
     }
     if (key.name === "tab") return moveField(key.shift ? -1 : 1)
 
-    // Arrow nav. The body textarea captures plain ↑/↓ for cursor
-    // movement and only lets them bubble at the buffer edges — so by
-    // the time we see ↑/↓ with field==="body", the cursor was already
-    // at the top/bottom line. Move focus out.
-    if (key.name === "up") return moveField(-1)
-    if (key.name === "down") return moveField(1)
+    // Arrow nav. ↑/↓ move focus between fields — EXCEPT inside the body
+    // textarea, where they move the cursor and only spill over to
+    // field-nav when the cursor is already on the first/last line.
+    // `useKeyboard` fires before the textarea processes the key, so
+    // logicalCursor.row here is the pre-move position.
+    if (key.name === "up") {
+      if (field === "body") {
+        const row = body.current?.logicalCursor.row ?? 0
+        if (row > 0) return // textarea moves the cursor up
+      }
+      return moveField(-1)
+    }
+    if (key.name === "down") {
+      if (field === "body") {
+        const row = body.current?.logicalCursor.row ?? 0
+        const last = (body.current?.lineCount ?? 1) - 1
+        if (row < last) return // textarea moves the cursor down
+      }
+      return moveField(1)
+    }
 
     if (field === "more") {
       if (key.name === "return" || key.name === "space") return setMore(m => !m)

--- a/src/dialogs/new-task.tsx
+++ b/src/dialogs/new-task.tsx
@@ -208,7 +208,7 @@ const Form = (p: {
     }))
     return (
       <DialogSelect
-        title="Priority" options={opts} placeholder="0–9…"
+        title="Priority" options={opts} filterable={false}
         current={String(priority)}
         onSelect={o => { setPriority(Number(o.value)); setPicker(null) }}
       />
@@ -225,7 +225,7 @@ const Form = (p: {
     ]
     return (
       <DialogSelect
-        title="Workspace" options={opts} placeholder="Pick a workspace kind…"
+        title="Workspace" options={opts} filterable={false}
         current={workspace.kind}
         onSelect={o => {
           if (o.value === "scratch") { setWorkspace({ kind: "scratch" }); return setPicker(null) }

--- a/src/dialogs/new-task.tsx
+++ b/src/dialogs/new-task.tsx
@@ -1,20 +1,53 @@
-// Create/edit a kanban task. Tab cycles fields; ↑↓ pick assignee or
-// bump priority depending on focused field; Enter submits when title
-// is non-empty. Body is single-line here — longer specs go in as a
-// follow-up comment (c) from the board.
+// Create a kanban task — form dialog.
+//
+// Layout: a vertical form. Fields top-to-bottom: Title (input), Body
+// (textarea), Assignee / Priority / Triage always visible; Tenant /
+// Workspace / Max runtime live under a collapsed "More" section ('m'
+// toggles). Skills is intentionally absent in v1 — tracked separately
+// (tab-completion + chips is a bigger build).
+//
+// Navigation:
+//   ↑/↓            move focus between visible fields (wraps)
+//   Tab / ⇧Tab     same, but also the ONLY way in/out of the Body
+//                  textarea (it owns ↑/↓ for cursor movement)
+//   ↑ at body top / ↓ at body bottom   escape the textarea to the
+//                  adjacent field (the textarea lets edge arrows
+//                  bubble; mid-buffer arrows move the cursor)
+//   Space          on a select-type field (Assignee/Priority/
+//                  Workspace) opens its picker; on Triage, toggles
+//   Enter          submit — except in the Body textarea, where it
+//                  inserts a newline
+//   Ctrl+Enter     submit from anywhere
+//   Esc            cancel
+//
+// The picker is rendered INSIDE this component (a `picker` state swaps
+// the field rows for a <DialogSelect>), so the form never unmounts and
+// the <input>/<textarea> buffers survive a round-trip through a picker.
 
-import { useState } from "react"
+import { useState, useRef } from "react"
 import { useKeyboard } from "@opentui/react"
+import type { TextareaRenderable } from "@opentui/core"
 import { useTheme } from "../theme"
 import type { DialogContext } from "../ui/dialog"
+import { DialogSelect } from "../ui/dialog-select"
+import type { SelectOption } from "../ui/dialog-select"
+
+export type Workspace =
+  | { kind: "scratch" }
+  | { kind: "worktree" }
+  | { kind: "dir"; path: string }
 
 export type Draft = {
-  title: string; body: string; assignee: string | null
-  priority: number; parent: string | null
+  title: string
+  body: string
+  assignee: string | null
+  priority: number
+  parent: string | null
+  triage: boolean
+  tenant: string | null
+  workspace: Workspace
+  maxRuntime: string | null
 }
-
-type Field = "title" | "body" | "assignee" | "priority"
-const ORDER: Field[] = ["title", "body", "assignee", "priority"]
 
 export function openCreateTask(
   dialog: DialogContext,
@@ -26,78 +59,322 @@ export function openCreateTask(
   })
 }
 
+// Visible-field identifiers. "More" is the collapsible header row.
+type Field =
+  | "title" | "body" | "assignee" | "priority" | "triage"
+  | "more" | "tenant" | "workspace" | "maxRuntime"
+
+const CORE: Field[] = ["title", "body", "assignee", "priority", "triage", "more"]
+const MORE: Field[] = ["tenant", "workspace", "maxRuntime"]
+
+// Fields that open a picker on Space.
+const SELECTY: ReadonlySet<Field> = new Set(["assignee", "priority", "workspace"])
+// Text-entry fields (plain arrows move form focus — single-line, no
+// vertical cursor to conflict with).
+const TEXTY: ReadonlySet<Field> = new Set(["title", "tenant", "maxRuntime"])
+
+const MAX_RUNTIME_RE = /^\d+[smhd]?$/
+
+const wsLabel = (w: Workspace): string =>
+  w.kind === "scratch" ? "scratch"
+    : w.kind === "worktree" ? "worktree"
+      : `dir @ ${w.path}`
+
+type Picker =
+  | null
+  | { kind: "assignee" }
+  | { kind: "priority" }
+  | { kind: "workspace" }
+  | { kind: "dirPath"; value: string }
+
 const Form = (p: {
-  pool: string[]; parent?: { id: string; title: string }; done: (r: Draft | null) => void
+  pool: string[]
+  parent?: { id: string; title: string }
+  done: (r: Draft | null) => void
 }) => {
   const theme = useTheme().theme
-  const pool = ["(unassigned)", ...p.pool]
-  const [field, setField] = useState<Field>("title")
-  const [title, setTitle] = useState("")
-  const [body, setBody] = useState("")
-  const [who, setWho] = useState(0)
-  const [pri, setPri] = useState(0)
-  const valid = title.trim().length > 0
+  const body = useRef<TextareaRenderable | null>(null)
+  // <textarea> has no onInput(value) — we mirror its content into state
+  // via onContentChange (reading .plainText off the ref) so the text
+  // survives a remount when a picker view is shown, and feed it back as
+  // initialValue.
+  const [bodyText, setBodyText] = useState("")
 
-  const edit = (fn: (s: string) => string) =>
-    field === "title" ? setTitle(fn) : setBody(fn)
+  const [field, setField] = useState<Field>("title")
+  const [more, setMore] = useState(false)
+  const [picker, setPicker] = useState<Picker>(null)
+
+  const [title, setTitle] = useState("")
+  const [assignee, setAssignee] = useState<string | null>(null)
+  const [priority, setPriority] = useState(0)
+  const [triage, setTriage] = useState(false)
+  const [tenant, setTenant] = useState("")
+  const [workspace, setWorkspace] = useState<Workspace>({ kind: "scratch" })
+  const [maxRuntime, setMaxRuntime] = useState("")
+
+  const order = (): Field[] => more ? [...CORE, ...MORE] : CORE
+  const titleOk = title.trim().length > 0
+  const runtimeOk = maxRuntime.trim() === "" || MAX_RUNTIME_RE.test(maxRuntime.trim())
+  const valid = titleOk && runtimeOk
+
+  const submit = () => {
+    if (!valid) return
+    p.done({
+      title: title.trim(),
+      body: (body.current?.plainText ?? bodyText).trim(),
+      assignee,
+      priority,
+      parent: p.parent?.id ?? null,
+      triage,
+      tenant: tenant.trim() || null,
+      workspace,
+      maxRuntime: maxRuntime.trim() || null,
+    })
+  }
+
+  const moveField = (dir: 1 | -1) => {
+    const o = order()
+    const i = o.indexOf(field)
+    const next = o[(i + dir + o.length) % o.length]
+    setField(next)
+    // Declarative focus (focused={field === "body"}) handles the
+    // textarea; nothing else needs an imperative focus call.
+  }
+
+  // Open the picker for the currently-focused select field.
+  const openPicker = () => {
+    if (field === "assignee") return setPicker({ kind: "assignee" })
+    if (field === "priority") return setPicker({ kind: "priority" })
+    if (field === "workspace") return setPicker({ kind: "workspace" })
+  }
 
   useKeyboard((key) => {
+    // Picker owns the keyboard while open; DialogSelect has its own
+    // useKeyboard. We only need Esc here to close it without resolving.
+    if (picker) {
+      if (key.name === "escape") setPicker(null)
+      return
+    }
+
     if (key.name === "escape") return p.done(null)
     if (key.name === "return") {
-      if (!valid) return
-      return p.done({
-        title: title.trim(), body: body.trim(),
-        assignee: who === 0 ? null : pool[who],
-        priority: pri, parent: p.parent?.id ?? null,
-      })
+      if (key.ctrl) return submit()
+      if (field !== "body") return submit()
+      return // body textarea owns plain Enter (newline)
     }
-    if (key.name === "tab") {
-      const i = ORDER.indexOf(field)
-      return setField(ORDER[(i + (key.shift ? ORDER.length - 1 : 1)) % ORDER.length])
+    if (key.name === "tab") return moveField(key.shift ? -1 : 1)
+
+    // Arrow nav. The body textarea captures plain ↑/↓ for cursor
+    // movement and only lets them bubble at the buffer edges — so by
+    // the time we see ↑/↓ with field==="body", the cursor was already
+    // at the top/bottom line. Move focus out.
+    if (key.name === "up") return moveField(-1)
+    if (key.name === "down") return moveField(1)
+
+    if (field === "more") {
+      if (key.name === "return" || key.name === "space") return setMore(m => !m)
+      return
     }
-    if (key.name === "up" || key.name === "down") {
-      const d = key.name === "up" ? -1 : 1
-      if (field === "priority") return setPri(n => Math.max(0, Math.min(9, n + d)))
-      return setWho(i => (i + d + pool.length) % pool.length)
-    }
-    if (field === "title" || field === "body") {
-      if (key.name === "backspace") return edit(s => s.slice(0, -1))
-      if (key.ctrl && key.name === "u") return edit(() => "")
-      if (!key.ctrl && !key.meta && key.raw && key.raw.length === 1 && key.raw >= " ")
-        return edit(s => s + key.raw)
-    }
+    if (field === "triage" && key.name === "space") return setTriage(t => !t)
+    if (SELECTY.has(field) && key.name === "space") return openPicker()
   })
 
-  const row = (f: Field, label: string, val: string) => (
+  // ── Picker views ────────────────────────────────────────────────
+  if (picker?.kind === "assignee") {
+    const opts: SelectOption[] = [
+      { title: "(unassigned)", value: "" },
+      ...p.pool.map(n => ({ title: n, value: n })),
+    ]
+    return (
+      <DialogSelect
+        title="Assignee" options={opts} placeholder="Search profiles…"
+        current={assignee ?? ""}
+        onSelect={o => { setAssignee(o.value || null); setPicker(null) }}
+      />
+    )
+  }
+  if (picker?.kind === "priority") {
+    const opts: SelectOption[] = Array.from({ length: 10 }, (_, n) => ({
+      title: n === 0 ? "P0 (none)" : `P${n}`,
+      value: String(n),
+      description: n === 0 ? "default"
+        : n <= 2 ? "normal" : n <= 5 ? "elevated" : "high",
+    }))
+    return (
+      <DialogSelect
+        title="Priority" options={opts} placeholder="0–9…"
+        current={String(priority)}
+        onSelect={o => { setPriority(Number(o.value)); setPicker(null) }}
+      />
+    )
+  }
+  if (picker?.kind === "workspace") {
+    const opts: SelectOption[] = [
+      { title: "scratch", value: "scratch",
+        description: "isolated temp dir under the board root (default)" },
+      { title: "worktree", value: "worktree",
+        description: "git worktree at .worktrees/<task-id> — worker runs `git worktree add`" },
+      { title: "dir:…", value: "dir",
+        description: "an exact absolute path (prompts next)" },
+    ]
+    return (
+      <DialogSelect
+        title="Workspace" options={opts} placeholder="Pick a workspace kind…"
+        current={workspace.kind}
+        onSelect={o => {
+          if (o.value === "scratch") { setWorkspace({ kind: "scratch" }); return setPicker(null) }
+          if (o.value === "worktree") { setWorkspace({ kind: "worktree" }); return setPicker(null) }
+          return setPicker({ kind: "dirPath", value: workspace.kind === "dir" ? workspace.path : "" })
+        }}
+      />
+    )
+  }
+  if (picker?.kind === "dirPath") {
+    const val = picker.value
+    const ok = val.trim().length > 0 && val.trim().startsWith("/")
+    return (
+      <box flexDirection="column" width={64}>
+        <box height={1}><text fg={theme.primary}><strong>Directory path</strong></text></box>
+        <box height={1} />
+        <box height={1}><text fg={theme.textMuted}>absolute path (required)</text></box>
+        <box height={1} flexDirection="row" overflow="hidden">
+          <box flexShrink={0}><text fg={theme.accent}>{"┃ "}</text></box>
+          <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
+            <input
+              key="dirpath"
+              value={val}
+              onInput={v => setPicker({ kind: "dirPath", value: v })}
+              onSubmit={() => {
+                if (!ok) return
+                setWorkspace({ kind: "dir", path: val.trim() })
+                setPicker(null)
+              }}
+              focused
+              textColor={theme.text}
+              backgroundColor={theme.backgroundElement}
+              focusedBackgroundColor={theme.backgroundElement}
+            />
+          </box>
+        </box>
+        <box height={1} />
+        <box height={1}><text fg={theme.textMuted}>
+          {ok ? "Enter confirm  ·  Esc back" : "absolute path required  ·  Esc back"}
+        </text></box>
+      </box>
+    )
+  }
+
+  // ── Form view ───────────────────────────────────────────────────
+  const lbl = (f: Field, text: string) => (
+    <box width={13} flexShrink={0}>
+      <text fg={field === f ? theme.accent : theme.textMuted}>
+        {field === f ? "▸ " : "  "}{text}
+      </text>
+    </box>
+  )
+
+  // Single-line text field row.
+  const textRow = (f: Field, label: string, value: string,
+                   set: (v: string) => void, placeholder?: string) => (
     <box height={1} flexDirection="row">
-      <box width={11}><text fg={field === f ? theme.accent : theme.textMuted}>
-        {field === f ? "▸ " : "  "}{label}
-      </text></box>
+      {lbl(f, label)}
       <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
-        <text>
-          <span fg={theme.text}>{val}</span>
-          {field === f && (f === "title" || f === "body")
-            ? <span fg={theme.accent}>█</span> : null}
-        </text>
+        <input
+          key={`field-${f}`}
+          value={value}
+          onInput={set}
+          onSubmit={submit}
+          focused={field === f}
+          placeholder={placeholder}
+          textColor={theme.text}
+          placeholderColor={theme.textMuted}
+          backgroundColor={field === f ? theme.backgroundElement : undefined}
+          focusedBackgroundColor={theme.backgroundElement}
+        />
       </box>
     </box>
   )
 
+  // Static read-only row (select-type value + affordance, or boolean).
+  const valRow = (f: Field, label: string, value: string, hint: string) => (
+    <box height={1} flexDirection="row">
+      {lbl(f, label)}
+      <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
+        <text fg={theme.text}>{value}</text>
+      </box>
+      {field === f ? <box flexShrink={0}><text fg={theme.textMuted}>{hint}</text></box> : null}
+    </box>
+  )
+
+  const footer = !valid
+    ? (!titleOk ? "type a title" : "fix runtime (e.g. 30m, 2h, 1800)")
+    : field === "body"
+      ? "Ctrl+Enter create  ·  Tab leave  ·  ↑↓ cursor  ·  Esc cancel"
+      : field === "more"
+        ? `Space ${more ? "collapse" : "expand"}  ·  Ctrl+Enter create  ·  ↑↓/Tab  ·  Esc`
+        : SELECTY.has(field)
+          ? "Space pick  ·  Enter create  ·  ↑↓/Tab field  ·  Esc cancel"
+          : field === "triage"
+            ? "Space toggle  ·  Enter create  ·  ↑↓/Tab field  ·  Esc"
+            : "Enter create  ·  ↑↓/Tab field  ·  Esc cancel"
+
   return (
-    <box flexDirection="column" width={64}>
-      <box height={1}><text fg={theme.primary}>
-        <strong>{p.parent ? `New Task  ·  child of ${p.parent.id}` : "New Task"}</strong>
-      </text></box>
+    <box flexDirection="column" width={66}>
+      <box height={1}><text fg={theme.primary}><strong>
+        {p.parent ? `New Task  ·  child of ${p.parent.id}` : "New Task"}
+      </strong></text></box>
       {p.parent ? <box height={1}><text fg={theme.textMuted}>  {p.parent.title}</text></box> : null}
       <box height={1} />
-      {row("title", "Title", title)}
-      {row("body", "Body", body || "—")}
-      {row("assignee", "Assignee", pool[who])}
-      {row("priority", "Priority", pri ? `P${pri}` : "—")}
+
+      {textRow("title", "Title", title, setTitle, "one-line summary")}
+
+      {/* Body textarea. keyBindings left at defaults; the React wrapper
+          maps focused → .focus(). Edge ↑/↓ bubble to our handler.
+          Content is read via the ref at submit time — <textarea> has
+          no value-change callback that hands back text. */}
+      <box flexDirection="row">
+        {lbl("body", "Body")}
+        <box flexGrow={1} minWidth={0}>
+          <textarea
+            key="field-body"
+            ref={body}
+            initialValue={bodyText}
+            onContentChange={() => { if (body.current) setBodyText(body.current.plainText) }}
+            focused={field === "body"}
+            placeholder="longer spec — markdown ok (Enter for newline)"
+            textColor={theme.text}
+            placeholderColor={theme.textMuted}
+            backgroundColor={field === "body" ? theme.backgroundElement : undefined}
+            focusedBackgroundColor={theme.backgroundElement}
+            minHeight={5}
+            maxHeight={5}
+          />
+        </box>
+      </box>
+
+      {valRow("assignee", "Assignee", assignee ?? "(unassigned)", "Space pick ▾")}
+      {valRow("priority", "Priority", priority ? `P${priority}` : "P0 (none)", "Space pick ▾")}
+      {valRow("triage", "Triage", triage ? "yes — park for a specifier" : "no", "Space toggle")}
+
+      <box height={1} flexDirection="row">
+        <box width={13} flexShrink={0}>
+          <text fg={field === "more" ? theme.accent : theme.textMuted}>
+            {field === "more" ? "▸ " : "  "}{more ? "More ▾" : "More ▸"}
+          </text>
+        </box>
+        {!more ? (
+          <box flexGrow={1} height={1} overflow="hidden">
+            <text fg={theme.textMuted}>tenant · workspace · max runtime</text>
+          </box>
+        ) : null}
+      </box>
+
+      {more ? textRow("tenant", "Tenant", tenant, setTenant, "namespace (optional)") : null}
+      {more ? valRow("workspace", "Workspace", wsLabel(workspace), "Space pick ▾") : null}
+      {more ? textRow("maxRuntime", "Runtime", maxRuntime, setMaxRuntime, "e.g. 30m, 2h, 1800 (optional)") : null}
+
       <box height={1} />
-      <box height={1}><text fg={theme.textMuted}>
-        {valid ? "Enter create  ·  Tab field  ·  ↑↓ pick  ·  Esc cancel" : "type a title  ·  Tab field"}
-      </text></box>
+      <box height={1}><text fg={theme.textMuted}>{footer}</text></box>
     </box>
   )
 }

--- a/src/keys/catalog.ts
+++ b/src/keys/catalog.ts
@@ -40,8 +40,8 @@ export const DEFAULTS = {
   "app.sidebar":       def("<leader>b",            "Toggle sidebar",                     "global"),
   "palette.open":      def("ctrl+k",               "Command palette",                    "global"), // ø command_list=ctrl+p
   "help.open":         def("f1",                   "Keyboard shortcuts",                 "global"), // ☨
-  "tab.next":          def("ctrl+right",           "Next tab",                           "global"), // ☨
-  "tab.prev":          def("ctrl+left",            "Previous tab",                       "global"), // ☨
+  "tab.next":          def("alt+right",            "Next tab",                           "global"), // ☨
+  "tab.prev":          def("alt+left",             "Previous tab",                       "global"), // ☨
   "focus.cycle":       def("tab",                  "Cycle focus (double-tap → composer)","global"), // ☨
   "editor.open":       def("<leader>e,ctrl+g",     "Open $EDITOR on prompt",             "global"),
   "reply.copy":        def("<leader>y,ctrl+y",     "Copy last assistant reply",          "global"),

--- a/src/tabs/Context.tsx
+++ b/src/tabs/Context.tsx
@@ -357,7 +357,12 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
   const compressions = info?.usage?.compressions ?? 0
 
   // Parse + build
-  const sections = useMemo(() => parse(systemPrompt?.text ?? ""), [systemPrompt?.text])
+  // Prefer the live wire prompt (info.system_prompt = agent._cached_system_prompt,
+  // reflects mid-session personality/skin switches). Fall back to state.db via
+  // useHome during the pre-session.info window or on older gateways that don't
+  // send the field.
+  const promptText = info?.system_prompt ?? systemPrompt?.text ?? ""
+  const sections = useMemo(() => parse(promptText), [promptText])
   const convTok = useMemo(() => est(messages.filter(m => m.role !== "system").map(m => msgText(m)).join("")), [messages])
 
   const top = useMemo(() => build({

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -315,8 +315,10 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
     )
   }
   // Multi-line row — used for body/result where we want markdown
-  // rendering in view mode and plain text in edit. No height cap here;
-  // the outer pane is a column flex so each row takes what it needs.
+  // rendering in view mode and plain text in edit. The label row
+  // doubles as the row's focus target; content flows in a box
+  // indented to the label's 10-col gutter so long lines wrap inside
+  // the value column instead of back to the left margin.
   const mrow = (f: PaneField, label: string, content: React.ReactNode, hint?: string) => {
     const active = cur === f
     return (
@@ -326,11 +328,11 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
           <box width={10} flexShrink={0}>
             <text fg={active ? theme.accent : theme.textMuted}>{label}</text>
           </box>
-          {hint ? <box flexGrow={1}>
+          {hint ? <box flexGrow={1} overflow="hidden">
             <text fg={theme.textMuted}>{hint}</text>
           </box> : null}
         </box>
-        <box paddingLeft={10} minHeight={1}>{content}</box>
+        <box paddingLeft={10} flexShrink={0}>{content}</box>
       </box>
     )
   }
@@ -348,87 +350,86 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
           <span fg={theme.textMuted}>{`  ·  ${p.pane.slug}  ·  ${d.status}  ·  ${ago(d.updated_at)}`}</span>
         </text>
       </box>
-      <box height={1} />
-      {srow("title", "Title", d.title,
-        p.on && cur === "title" ? "Enter edit" : undefined)}
-      {mrow("body", "Body",
-        d.body
-          ? cur === "body"
-            ? <text wrapMode="word" fg={theme.text}>{d.body}</text>
-            : <markdown content={d.body} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
-          : <text fg={theme.textMuted}>—</text>,
-        p.on && cur === "body" ? "Enter edit (raw)" : undefined)}
-      <box height={1} />
-      {srow("assignee", "Assignee", d.assignee ?? "—",
-        p.on && cur === "assignee" ? "Enter pick" : undefined)}
-      {srow("priority", "Priority", d.priority ? `P${d.priority}` : "—",
-        p.on && cur === "priority" ? "↑↓ / Enter" : undefined)}
-      {srow("status", "Status", d.status,
-        p.on && cur === "status" ? "Enter change" : undefined)}
-      {srow("parents", "Parents", d.parents.length ? d.parents.join(", ") : "—",
-        p.on && cur === "parents" ? "Enter add/remove" : undefined)}
-      {d.children.length
-        ? <box height={1} flexDirection="row" paddingLeft={1}>
-            <box width={10} flexShrink={0}><text fg={theme.textMuted}>Children</text></box>
-            <box flexGrow={1} minWidth={0} overflow="hidden">
-              <text fg={theme.textMuted}>{d.children.join(", ")}</text>
-            </box>
-          </box>
-        : null}
-      {d.workspace_kind
-        ? <box height={1} flexDirection="row" paddingLeft={1}>
-            <box width={10} flexShrink={0}><text fg={theme.textMuted}>Workspace</text></box>
-            <box flexGrow={1} minWidth={0} overflow="hidden">
-              <text fg={theme.textMuted}>
-                {d.workspace_kind}{d.workspace_path ? ` @ ${d.workspace_path}` : ""}
-              </text>
-            </box>
-          </box>
-        : null}
-      {d.skills.length
-        ? <box height={1} flexDirection="row" paddingLeft={1}>
-            <box width={10} flexShrink={0}><text fg={theme.textMuted}>Skills</text></box>
-            <box flexGrow={1} minWidth={0} overflow="hidden">
-              <text fg={theme.textMuted}>{d.skills.join(", ")}</text>
-            </box>
-          </box>
-        : null}
-      {d.pid
-        ? <box height={1} flexDirection="row" paddingLeft={1}>
-            <box width={10} flexShrink={0}><text fg={theme.textMuted}>PID</text></box>
-            <box flexGrow={1} minWidth={0} overflow="hidden">
-              <text fg={theme.textMuted}>{String(d.pid)}</text>
-            </box>
-          </box>
-        : null}
-      {d.error
-        ? <box flexDirection="column" paddingLeft={1}>
-            <box height={1}><text fg={theme.error}>Error</text></box>
-            <box paddingLeft={2}>
-              <text fg={theme.error} wrapMode="word">{d.error}</text>
-            </box>
-          </box>
-        : null}
-      {d.status === "done"
-        ? mrow("result", "Result",
-            resultText
-              ? cur === "result"
-                ? <text wrapMode="word" fg={theme.text}>{resultText}</text>
-                : <markdown content={resultText} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
-              : <text fg={theme.textMuted}>—</text>,
-            p.on && cur === "result" ? "Enter edit" : undefined)
-        : null}
-      <box height={1} />
       <scrollbox scrollY flexGrow={1}>
         <box flexDirection="column" width="100%">
+          {srow("title", "Title", d.title,
+            p.on && cur === "title" ? "Enter edit" : undefined)}
+          {mrow("body", "Body",
+            d.body
+              ? cur === "body"
+                ? <text wrapMode="word" fg={theme.text}>{d.body}</text>
+                : <markdown content={d.body} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
+              : <text fg={theme.textMuted}>—</text>,
+            p.on && cur === "body" ? "Enter edit (raw)" : undefined)}
+          {srow("assignee", "Assignee", d.assignee ?? "—",
+            p.on && cur === "assignee" ? "Enter pick" : undefined)}
+          {srow("priority", "Priority", d.priority ? `P${d.priority}` : "—",
+            p.on && cur === "priority" ? "↑↓ / Enter" : undefined)}
+          {srow("status", "Status", d.status,
+            p.on && cur === "status" ? "Enter change" : undefined)}
+          {srow("parents", "Parents", d.parents.length ? d.parents.join(", ") : "—",
+            p.on && cur === "parents" ? "Enter add/remove" : undefined)}
+          {d.children.length
+            ? <box height={1} flexDirection="row" paddingLeft={1}>
+                <box width={10} flexShrink={0}><text fg={theme.textMuted}>Children</text></box>
+                <box flexGrow={1} minWidth={0} overflow="hidden">
+                  <text fg={theme.textMuted}>{d.children.join(", ")}</text>
+                </box>
+              </box>
+            : null}
+          {d.workspace_kind
+            ? <box height={1} flexDirection="row" paddingLeft={1}>
+                <box width={10} flexShrink={0}><text fg={theme.textMuted}>Workspace</text></box>
+                <box flexGrow={1} minWidth={0} overflow="hidden">
+                  <text fg={theme.textMuted}>
+                    {d.workspace_kind}{d.workspace_path ? ` @ ${d.workspace_path}` : ""}
+                  </text>
+                </box>
+              </box>
+            : null}
+          {d.skills.length
+            ? <box height={1} flexDirection="row" paddingLeft={1}>
+                <box width={10} flexShrink={0}><text fg={theme.textMuted}>Skills</text></box>
+                <box flexGrow={1} minWidth={0} overflow="hidden">
+                  <text fg={theme.textMuted}>{d.skills.join(", ")}</text>
+                </box>
+              </box>
+            : null}
+          {d.pid
+            ? <box height={1} flexDirection="row" paddingLeft={1}>
+                <box width={10} flexShrink={0}><text fg={theme.textMuted}>PID</text></box>
+                <box flexGrow={1} minWidth={0} overflow="hidden">
+                  <text fg={theme.textMuted}>{String(d.pid)}</text>
+                </box>
+              </box>
+            : null}
+          {d.error
+            ? <box flexDirection="column" paddingLeft={1}>
+                <box height={1}><text fg={theme.error}>Error</text></box>
+                <box paddingLeft={2}>
+                  <text fg={theme.error} wrapMode="word">{d.error}</text>
+                </box>
+              </box>
+            : null}
+          {d.status === "done"
+            ? mrow("result", "Result",
+                resultText
+                  ? cur === "result"
+                    ? <text wrapMode="word" fg={theme.text}>{resultText}</text>
+                    : <markdown content={resultText} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
+                  : <text fg={theme.textMuted}>—</text>,
+                p.on && cur === "result" ? "Enter edit" : undefined)
+            : null}
           {d.runs.length > 0 ? <>
-            <box height={1}><text fg={theme.textMuted}>{`Runs (${d.runs.length})`}</text></box>
+            <box height={1} marginTop={1}>
+              <text fg={theme.textMuted}>{`Runs (${d.runs.length})`}</text>
+            </box>
             {d.runs.map(r => {
               const outcome = r.outcome || r.status || (r.ended_at ? "ended" : "active")
               const elapsed = r.ended_at
                 ? `${Math.max(0, r.ended_at - r.started_at)}s` : "active"
               return (
-                <box key={r.id} flexDirection="column" marginTop={1}>
+                <box key={r.id} flexDirection="column">
                   <box height={1}><text>
                     <span fg={theme.primary}>{`#${r.id} `}</span>
                     <span fg={theme.text}>{outcome}</span>
@@ -445,8 +446,9 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
             })}
           </> : null}
           {d.events.length > 0 ? <>
-            <box height={1} />
-            <box height={1}><text fg={theme.textMuted}>{`Events (${d.events.length})`}</text></box>
+            <box height={1} marginTop={1}>
+              <text fg={theme.textMuted}>{`Events (${d.events.length})`}</text>
+            </box>
             {d.events.map(e => (
               <box key={e.id} height={1}><text>
                 <span fg={theme.textMuted}>{`${ago(e.created_at).padEnd(10)} `}</span>
@@ -458,10 +460,11 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
             ))}
           </> : null}
           {d.comments.length > 0 ? <>
-            <box height={1} />
-            <box height={1}><text fg={theme.textMuted}>{`Comments (${d.comments.length})`}</text></box>
+            <box height={1} marginTop={1}>
+              <text fg={theme.textMuted}>{`Comments (${d.comments.length})`}</text>
+            </box>
             {d.comments.map((c, i) => (
-              <box key={i} flexDirection="column" marginTop={1}>
+              <box key={i} flexDirection="column">
                 <box height={1}><text fg={theme.textMuted}>{`${c.author}  ·  ${ago(c.at)}`}</text></box>
                 <text wrapMode="word">{c.body}</text>
               </box>

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -707,14 +707,21 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       parent: parent ? { id: parent.id, title: parent.title } : undefined,
     }).then(d => {
       if (!d) return
+      const ws = d.workspace.kind === "scratch" ? ""
+        : d.workspace.kind === "worktree" ? "--workspace worktree"
+          : `--workspace ${q(`dir:${d.workspace.path}`)}`
       const flags = [
         d.assignee ? `--assignee ${q(d.assignee)}` : "",
         d.body ? `--body ${q(d.body)}` : "",
         d.priority ? `--priority ${d.priority}` : "",
         d.parent ? `--parent ${q(d.parent)}` : "",
+        d.triage ? "--triage" : "",
+        d.tenant ? `--tenant ${q(d.tenant)}` : "",
+        ws,
+        d.maxRuntime ? `--max-runtime ${q(d.maxRuntime)}` : "",
       ].filter(Boolean).join(" ")
       return sh(`create ${q(d.title)} ${flags}`.trim(),
-        `Created${d.assignee ? ` → ${d.assignee}` : ""}`)
+        `Created${d.triage ? " (triage)" : ""}${d.assignee ? ` → ${d.assignee}` : ""}`)
     }), [dialog, sh])
 
   const assign = useCallback((t: Task) => {

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -3,7 +3,7 @@ import { useKeyboard, useTerminalDimensions } from "@opentui/react"
 import type { BorderSides, ScrollBoxRenderable } from "@opentui/core"
 import {
   boardOf, detailOf, tailLogOf, assignees, q, STATUSES,
-  currentBoard, listBoards, resetKanban,
+  currentBoard, listBoards, resetKanban, patchTask,
   type Task, type Status, type Detail, type Board,
 } from "../utils/hermes-kanban"
 import { useKeys } from "../keys"
@@ -20,32 +20,39 @@ import { openCreateTask } from "../dialogs/new-task"
 import { TabShell } from "../ui/shell"
 import { KVBlock } from "../ui/kv"
 import { ago, trunc } from "../ui/fmt"
+import { load as loadPrefs, set as setPref, type KanbanPrefs } from "../utils/preferences"
 
 // Operator surface for every kanban board under ~/.hermes/.
 //
 // Boards stack vertically; each is a collapsible section (▾/▸
 // header + filter-chip bar + capped-height row of status columns).
-// Reads are sidecar SQLite per board. Every write routes through
-// `shell.exec → hermes kanban --board <slug> <verb>` so kanban_db.py
-// owns the state machine.
+// Reads are sidecar SQLite per board. Writes split by kind:
+//   - title/body/priority: direct bun:sqlite (patchTask) inside a
+//     BEGIN IMMEDIATE txn + task_events row, mirroring dashboard
+//     plugin_api PATCH /tasks/:id.
+//   - status transitions / assign / link / edit / comment / dispatch:
+//     `shell.exec → hermes kanban --board <slug> <verb>` so
+//     kanban_db.py owns the state machine (run closure,
+//     recompute_ready, notify-sub fanout).
 //
-// Focus model — one cursor, three tiers per board:
+// Focus model — one cursor, four tiers per board:
 //   head    the ▾/▸ line            Space folds the board
 //   filter  chip bar                ←→ chip, Space toggles
 //   grid    columns × rows          ←→ col, ↑↓ row
-// ↑↓ walk the whole vertical stack — head → filter → every row →
-// next board's head → … — so holding ↓ reads top-to-bottom across
-// all boards. Tab/⇧Tab is the accelerator: jump straight to the
-// next/prev board's head without stepping through rows.
+//   pane    detail pane fields      ↑↓ / Tab walks fields
 //
-//   Tab/⇧Tab board        ←→↑↓ nav            Enter detail
-//   Space    fold / chip  Esc close pane      r reload
-//   n/N      create/child a assign            c comment
-//   u        unblock      d archive           l worker log
-//   D        dispatch     b new board
+// Tab jumps boards UNLESS the detail pane is open — then Tab moves
+// focus INTO the pane (tier=pane). Esc out of pane returns to grid;
+// Esc again closes the pane.
+//
+//   Tab/⇧Tab board / pane field   ←→↑↓ nav            Enter detail/edit
+//   Space    fold / chip           Esc close pane      r reload
+//   n/N      create/child          a assign            c comment
+//   u        unblock               d archive           l worker log
+//   D        dispatch              b new board
 
 type Sh = { stdout: string; stderr: string; code: number }
-type Tier = "head" | "filter" | "grid"
+type Tier = "head" | "filter" | "grid" | "pane"
 
 // Column scrollbars hidden — the column border + ↑↓ are enough
 // signal at kanban card density; the bar steals a col per status.
@@ -95,6 +102,51 @@ function admits<V>(g: Map<V, Tri>, v: V): boolean {
 const pass = (t: Task, m: Mask) =>
   admits(m.who, t.assignee ?? null as unknown as string)
   && admits(m.pri, t.priority)
+
+// ── Persistence (t_cce26780) ───────────────────────────────────────
+// Masks + open-set round-trip through ~/.config/herm/tui.json under
+// the `kanban` key. Keyed by slug. Maps/Sets flatten to entry arrays
+// for JSON.
+
+const maskFromPrefs = (raw: KanbanPrefs["masks"]): Map<string, Mask> => {
+  const out = new Map<string, Mask>()
+  if (!raw) return out
+  for (const slug of Object.keys(raw)) {
+    const g = raw[slug]
+    out.set(slug, {
+      who: new Map(g.who ?? []),
+      pri: new Map(g.pri ?? []),
+      status: new Map(g.status ?? []) as Map<Status, Tri>,
+    })
+  }
+  return out
+}
+
+const maskToPrefs = (masks: Map<string, Mask>): KanbanPrefs["masks"] => {
+  const out: NonNullable<KanbanPrefs["masks"]> = {}
+  for (const [slug, m] of masks) {
+    // Only persist the two non-"off" states; consumer uses Map.get
+    // which returns undefined for missing keys, same as "off" default.
+    const filt = <K,>(xs: Array<[K, Tri]>) =>
+      xs.filter(([, t]) => t === "in" || t === "ex") as Array<[K, "in" | "ex"]>
+    const who = filt<string>([...m.who])
+    const pri = filt<number>([...m.pri])
+    const status = filt<string>([...m.status] as Array<[string, Tri]>)
+    // Drop empty slugs to keep the JSON small.
+    if (who.length || pri.length || status.length)
+      out[slug] = { who, pri, status }
+  }
+  return out
+}
+
+const persist = (masks: Map<string, Mask>, open: Set<string>) => {
+  const cur = loadPrefs().kanban ?? {}
+  setPref("kanban", {
+    ...cur,
+    open: [...open],
+    masks: maskToPrefs(masks),
+  })
+}
 
 // ── Card ────────────────────────────────────────────────────────────
 // Title + bottom rule. The Ticker is always mounted; `active` gates
@@ -167,16 +219,27 @@ const Column = memo((p: {
 const FilterBar = memo((p: {
   chips: Chip[]; mask: Mask; on: boolean; sel: number
   onPick: (i: number) => void
-}) => (
-  <box height={1} flexDirection="row" flexWrap="no-wrap" overflow="hidden" marginBottom={1}>
-    {p.chips.map((c, i) => (
-      <FilterChip key={chipId(c)} label={chipLabel(c)}
-        state={triOf(c, p.mask)} selected={p.on && i === p.sel}
-        gap={i > 0 && p.chips[i - 1].kind !== c.kind ? 3 : 1}
-        onMouseDown={() => p.onPick(i)} />
-    ))}
-  </box>
-))
+}) => {
+  const theme = useTheme().theme
+  return (
+    <box height={1} flexDirection="row" flexWrap="no-wrap" overflow="hidden" marginBottom={1}>
+      {p.chips.flatMap((c, i) => {
+        const chip = (
+          <FilterChip key={chipId(c)} label={chipLabel(c)}
+            state={triOf(c, p.mask)} selected={p.on && i === p.sel}
+            onMouseDown={() => p.onPick(i)} />
+        )
+        if (i === 0 || p.chips[i - 1].kind === c.kind) return [chip]
+        return [
+          <box key={`sep:${chipId(c)}`} height={1} flexShrink={0} marginLeft={1}>
+            <text fg={theme.borderSubtle}>|</text>
+          </box>,
+          chip,
+        ]
+      })}
+    </box>
+  )
+})
 
 type ColSpec = { status: Status; tasks: Task[] }
 type Section = {
@@ -184,9 +247,35 @@ type Section = {
   total: number; shown: number; running: number; cap: number
 }
 
-type Pane = { kind: "detail"; slug: string; d: Detail } | { kind: "log"; slug: string; id: string; text: string }
+// ── Detail pane ────────────────────────────────────────────────────
+// Fields are ordered top-to-bottom to match the layout. The
+// `editable` flag gates whether Tab/↑↓ can land on a row and whether
+// Enter opens an editor. Non-editable rows (runs/events/comments)
+// are read-only views that still render in the pane but get skipped
+// by the focus walker.
 
-const SidePane = memo((p: { pane: Pane }) => {
+type PaneField =
+  | "title" | "body" | "assignee" | "priority" | "status"
+  | "parents" | "result" | "comment"
+const FIELDS: PaneField[] = [
+  "title", "body", "assignee", "priority", "status",
+  "parents", "result", "comment",
+]
+
+// `result` is only editable when task is done. `body` is always
+// editable. Return the subset of FIELDS that apply to the current
+// task so Tab/↑↓ in the pane don't land on a disabled row.
+const fieldsFor = (t: Task): PaneField[] =>
+  FIELDS.filter(f => {
+    if (f === "result") return t.status === "done"
+    return true
+  })
+
+type Pane =
+  | { kind: "detail"; slug: string; d: Detail }
+  | { kind: "log"; slug: string; id: string; text: string }
+
+const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
   const { theme, syntaxStyle } = useTheme()
   if (p.pane.kind === "log") return (
     <box flexDirection="column" padding={1} border borderColor={theme.border}
@@ -202,6 +291,54 @@ const SidePane = memo((p: { pane: Pane }) => {
     </box>
   )
   const d = p.pane.d
+  const fields = fieldsFor(d)
+  const cur = p.on ? fields[Math.min(p.sel, fields.length - 1)] : null
+  // Simple string row with optional edit-hint on the right. height=1
+  // is load-bearing — without it sibling rows stack but can visually
+  // overlap when the parent is a scroll/flex container that doesn't
+  // reserve line height.
+  const srow = (f: PaneField, label: string, value: string, hint?: string) => {
+    const active = cur === f
+    return (
+      <box key={f} height={1} flexDirection="row" paddingLeft={1}
+           backgroundColor={active ? theme.backgroundElement : undefined}>
+        <box width={10} flexShrink={0}>
+          <text fg={active ? theme.accent : theme.textMuted}>{label}</text>
+        </box>
+        <box flexGrow={1} minWidth={0} overflow="hidden">
+          <text fg={active ? theme.text : theme.textMuted}>{value}</text>
+        </box>
+        {hint ? <box flexShrink={0} paddingLeft={1}>
+          <text fg={theme.textMuted}>{hint}</text>
+        </box> : null}
+      </box>
+    )
+  }
+  // Multi-line row — used for body/result where we want markdown
+  // rendering in view mode and plain text in edit. No height cap here;
+  // the outer pane is a column flex so each row takes what it needs.
+  const mrow = (f: PaneField, label: string, content: React.ReactNode, hint?: string) => {
+    const active = cur === f
+    return (
+      <box key={f} flexDirection="column" paddingLeft={1}
+           backgroundColor={active ? theme.backgroundElement : undefined}>
+        <box height={1} flexDirection="row">
+          <box width={10} flexShrink={0}>
+            <text fg={active ? theme.accent : theme.textMuted}>{label}</text>
+          </box>
+          {hint ? <box flexGrow={1}>
+            <text fg={theme.textMuted}>{hint}</text>
+          </box> : null}
+        </box>
+        <box paddingLeft={10} minHeight={1}>{content}</box>
+      </box>
+    )
+  }
+  // Latest summary proxies for result when none was set explicitly.
+  // Mirrors `hermes kanban show` — workers write task_runs.summary,
+  // not tasks.result, so a raw ``result`` read looks empty even when
+  // real work happened.
+  const resultText = d.result || d.latest_summary || ""
   return (
     <box flexDirection="column" padding={1} border borderColor={theme.border}
          backgroundColor={theme.backgroundPanel} width="50%">
@@ -211,25 +348,114 @@ const SidePane = memo((p: { pane: Pane }) => {
           <span fg={theme.textMuted}>{`  ·  ${p.pane.slug}  ·  ${d.status}  ·  ${ago(d.updated_at)}`}</span>
         </text>
       </box>
-      <box height={1}><text fg={theme.accent}><strong>{d.title}</strong></text></box>
       <box height={1} />
-      <KVBlock rows={[
-        ["Assignee", d.assignee ?? "—"],
-        ["Priority", d.priority ? `P${d.priority}` : "—"],
-        ["Tenant", d.tenant ?? undefined],
-        ["Parents", d.parents.length ? d.parents.join(", ") : undefined],
-        ["Children", d.children.length ? d.children.join(", ") : undefined],
-        ["PID", d.pid ? String(d.pid) : undefined],
-        ["Error", d.error ?? undefined, theme.error],
-      ]} />
+      {srow("title", "Title", d.title,
+        p.on && cur === "title" ? "Enter edit" : undefined)}
+      {mrow("body", "Body",
+        d.body
+          ? cur === "body"
+            ? <text wrapMode="word" fg={theme.text}>{d.body}</text>
+            : <markdown content={d.body} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
+          : <text fg={theme.textMuted}>—</text>,
+        p.on && cur === "body" ? "Enter edit (raw)" : undefined)}
+      <box height={1} />
+      {srow("assignee", "Assignee", d.assignee ?? "—",
+        p.on && cur === "assignee" ? "Enter pick" : undefined)}
+      {srow("priority", "Priority", d.priority ? `P${d.priority}` : "—",
+        p.on && cur === "priority" ? "↑↓ / Enter" : undefined)}
+      {srow("status", "Status", d.status,
+        p.on && cur === "status" ? "Enter change" : undefined)}
+      {srow("parents", "Parents", d.parents.length ? d.parents.join(", ") : "—",
+        p.on && cur === "parents" ? "Enter add/remove" : undefined)}
+      {d.children.length
+        ? <box height={1} flexDirection="row" paddingLeft={1}>
+            <box width={10} flexShrink={0}><text fg={theme.textMuted}>Children</text></box>
+            <box flexGrow={1} minWidth={0} overflow="hidden">
+              <text fg={theme.textMuted}>{d.children.join(", ")}</text>
+            </box>
+          </box>
+        : null}
+      {d.workspace_kind
+        ? <box height={1} flexDirection="row" paddingLeft={1}>
+            <box width={10} flexShrink={0}><text fg={theme.textMuted}>Workspace</text></box>
+            <box flexGrow={1} minWidth={0} overflow="hidden">
+              <text fg={theme.textMuted}>
+                {d.workspace_kind}{d.workspace_path ? ` @ ${d.workspace_path}` : ""}
+              </text>
+            </box>
+          </box>
+        : null}
+      {d.skills.length
+        ? <box height={1} flexDirection="row" paddingLeft={1}>
+            <box width={10} flexShrink={0}><text fg={theme.textMuted}>Skills</text></box>
+            <box flexGrow={1} minWidth={0} overflow="hidden">
+              <text fg={theme.textMuted}>{d.skills.join(", ")}</text>
+            </box>
+          </box>
+        : null}
+      {d.pid
+        ? <box height={1} flexDirection="row" paddingLeft={1}>
+            <box width={10} flexShrink={0}><text fg={theme.textMuted}>PID</text></box>
+            <box flexGrow={1} minWidth={0} overflow="hidden">
+              <text fg={theme.textMuted}>{String(d.pid)}</text>
+            </box>
+          </box>
+        : null}
+      {d.error
+        ? <box flexDirection="column" paddingLeft={1}>
+            <box height={1}><text fg={theme.error}>Error</text></box>
+            <box paddingLeft={2}>
+              <text fg={theme.error} wrapMode="word">{d.error}</text>
+            </box>
+          </box>
+        : null}
+      {d.status === "done"
+        ? mrow("result", "Result",
+            resultText
+              ? cur === "result"
+                ? <text wrapMode="word" fg={theme.text}>{resultText}</text>
+                : <markdown content={resultText} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
+              : <text fg={theme.textMuted}>—</text>,
+            p.on && cur === "result" ? "Enter edit" : undefined)
+        : null}
       <box height={1} />
       <scrollbox scrollY flexGrow={1}>
         <box flexDirection="column" width="100%">
-          {d.body ? <markdown content={d.body} fg={theme.markdownText} syntaxStyle={syntaxStyle} /> : null}
-          {d.result ? <>
+          {d.runs.length > 0 ? <>
+            <box height={1}><text fg={theme.textMuted}>{`Runs (${d.runs.length})`}</text></box>
+            {d.runs.map(r => {
+              const outcome = r.outcome || r.status || (r.ended_at ? "ended" : "active")
+              const elapsed = r.ended_at
+                ? `${Math.max(0, r.ended_at - r.started_at)}s` : "active"
+              return (
+                <box key={r.id} flexDirection="column" marginTop={1}>
+                  <box height={1}><text>
+                    <span fg={theme.primary}>{`#${r.id} `}</span>
+                    <span fg={theme.text}>{outcome}</span>
+                    <span fg={theme.textMuted}>{`  @${r.profile ?? "-"}  ${elapsed}  ${ago(r.started_at)}`}</span>
+                  </text></box>
+                  {r.summary
+                    ? <text wrapMode="word" fg={theme.textMuted}>{`  → ${r.summary.split("\n")[0].slice(0, 200)}`}</text>
+                    : null}
+                  {r.error
+                    ? <text wrapMode="word" fg={theme.error}>{`  ✖ ${r.error.split("\n")[0].slice(0, 200)}`}</text>
+                    : null}
+                </box>
+              )
+            })}
+          </> : null}
+          {d.events.length > 0 ? <>
             <box height={1} />
-            <box height={1}><text fg={theme.textMuted}>Result</text></box>
-            <markdown content={d.result} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
+            <box height={1}><text fg={theme.textMuted}>{`Events (${d.events.length})`}</text></box>
+            {d.events.map(e => (
+              <box key={e.id} height={1}><text>
+                <span fg={theme.textMuted}>{`${ago(e.created_at).padEnd(10)} `}</span>
+                <span fg={theme.text}>{e.kind}</span>
+                {e.payload
+                  ? <span fg={theme.textMuted}>{`  ${JSON.stringify(e.payload)}`}</span>
+                  : null}
+              </text></box>
+            ))}
           </> : null}
           {d.comments.length > 0 ? <>
             <box height={1} />
@@ -241,9 +467,20 @@ const SidePane = memo((p: { pane: Pane }) => {
               </box>
             ))}
           </> : null}
+          {p.on && cur === "comment" ? (
+            <box height={1} marginTop={1}>
+              <text fg={theme.accent}>Enter add comment</text>
+            </box>
+          ) : null}
         </box>
       </scrollbox>
-      <box height={1}><text fg={theme.textMuted}>a assign  c comment  u unblock  d archive  l log  N child</text></box>
+      <box height={1}>
+        <text fg={theme.textMuted}>
+          {p.on
+            ? "Tab/↑↓ field  Enter edit  Esc grid  a assign  c comment  l log"
+            : "Tab into pane  a assign  c comment  u unblock  d archive  l log  N child"}
+        </text>
+      </box>
     </box>
   )
 })
@@ -260,8 +497,12 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const [data, setData] = useState<Map<string, Map<Status, Task[]>>>(
     () => new Map(boards.map(b => [b.slug, boardOf(b.slug)])),
   )
-  const [masks, setMasks] = useState<Map<string, Mask>>(() => new Map())
+  const [masks, setMasks] = useState<Map<string, Mask>>(() =>
+    maskFromPrefs(loadPrefs().kanban?.masks))
   const [open, setOpen] = useState<Set<string>>(() => {
+    const saved = loadPrefs().kanban?.open
+    if (saved) return new Set(saved)
+    // First-run fallback: current board + any non-empty board.
     const init = currentBoard()
     return new Set(listBoards()
       .filter(b => b.slug === init
@@ -273,6 +514,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const [col, setCol] = useState(0)
   const [row, setRow] = useState(0)
   const [chip, setChip] = useState(0)
+  const [paneSel, setPaneSel] = useState(0)
   const [pane, setPane] = useState<Pane | null>(null)
 
   const outer = useRef<ScrollBoxRenderable | null>(null)
@@ -285,6 +527,9 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       ? (d => d ? { ...p, d } : null)(detailOf(p.slug, p.d.id)) : p)
   }, [])
   useEffect(load, [load])
+
+  // Persist masks + open set whenever either changes.
+  useEffect(() => { persist(masks, open) }, [masks, open])
 
   const maskOf = (s: string): Mask => masks.get(s) ?? EMPTY
 
@@ -327,7 +572,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const cols = sec?.cols ?? []
   const clampCol = Math.min(col, Math.max(0, cols.length - 1))
   const cur = cols[clampCol]
-  const task = tier === "grid"
+  const task = tier === "grid" || tier === "pane"
     ? cur?.tasks[Math.min(row, Math.max(0, (cur?.tasks.length ?? 1) - 1))]
     : undefined
 
@@ -336,15 +581,19 @@ export const Kanban = memo((props: { focused?: boolean }) => {
 
   // Detail pane follows the grid cursor while open. Enter still
   // toggles it; once open, ←→↑↓ rehydrate it to whatever is under
-  // the cursor so the side pane reads as a live inspector instead
-  // of a pinned snapshot. Leaving the grid tier closes it — there's
-  // nothing sensible to show for head/filter.
+  // the cursor so the side pane reads as a live inspector. Leaving
+  // the grid/pane tiers closes it — there's nothing sensible to show
+  // for head/filter.
   useEffect(() => {
     if (pane?.kind !== "detail") return
+    if (tier !== "grid" && tier !== "pane") { setPane(null); return }
     if (!task) { setPane(null); return }
     if (pane.slug === at && pane.d.id === task.id) return
     const d = detailOf(at, task.id)
     setPane(d ? { kind: "detail", slug: at, d } : null)
+    // Reset pane cursor to the first field when the pane retargets so
+    // a stale index can't land on a disabled row of the new task.
+    setPaneSel(0)
   }, [task?.id, at, tier])
 
   useEffect(() => {
@@ -365,6 +614,19 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       return r.stdout
     }).catch((e: Error) => void toast.show({ variant: "error", message: trunc(e.message, 120) })),
   [gw, toast, load, at])
+
+  // Direct bun:sqlite patch — title/body/priority only. Mirrors
+  // dashboard PATCH /tasks/:id. Refreshes on success (no shell round-trip).
+  const patchDirect = useCallback((id: string, p: Parameters<typeof patchTask>[2], ok: string) => {
+    try {
+      if (!patchTask(at, id, p))
+        return void toast.show({ variant: "error", message: `no such task: ${id}` })
+      toast.show({ variant: "success", message: ok })
+      load()
+    } catch (e) {
+      toast.show({ variant: "error", message: trunc((e as Error).message, 120) })
+    }
+  }, [at, toast, load])
 
   // ── Cross-board nav ───────────────────────────────────────────────
   // enterTop/enterBottom land on the first/last reachable tier of
@@ -476,10 +738,9 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       return void toast.show({ variant: "info", message: `${t.id} is ${t.status}, not blocked` })
     return openTextPrompt(dialog, {
       title: `Unblock ${t.id}`, label: "Answer (posted as comment, then task → ready)",
-    }).then(async v => {
-      if (v) await sh(`comment ${q(t.id)} ${q(v)} --author user`)
-      return sh(`unblock ${q(t.id)}`, `Unblocked ${t.id}`)
-    })
+    }).then(v => {
+      if (v) return sh(`comment ${q(t.id)} ${q(v)} --author user`)
+    }).then(() => sh(`unblock ${q(t.id)}`, `Unblocked ${t.id}`))
   }, [dialog, sh, toast])
 
   const archive = useCallback((t: Task) =>
@@ -509,6 +770,142 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     setPane({ kind: "log", slug: s, id: t.id, text })
   }, [toast])
 
+  // ── Pane-field editors ──────────────────────────────────────────
+  // Invoked by Enter when tier=pane. Each one targets the CURRENT
+  // task (live.current.task) via the right write path: patchTask
+  // for fields the dashboard writes directly, shell.exec for status
+  // transitions and list-shaped fields.
+
+  const editTitle = useCallback((t: Task) =>
+    openTextPrompt(dialog, { title: `Edit title`, label: t.id, initial: t.title })
+      .then(v => v !== null && v !== undefined
+        && patchDirect(t.id, { title: v }, `Updated ${t.id}`)),
+  [dialog, patchDirect])
+
+  const editBody = useCallback((t: Task) =>
+    openTextPrompt(dialog, { title: `Edit body`, label: t.id, initial: t.body ?? "" })
+      .then(v => {
+        if (v === null || v === undefined) return
+        patchDirect(t.id, { body: v }, `Updated ${t.id}`)
+      }),
+  [dialog, patchDirect])
+
+  const editPriority = useCallback((t: Task) => {
+    const opts = Array.from({ length: 10 }, (_, i) => ({
+      title: i === 0 ? "P0 (none)" : `P${i}`, value: String(i),
+    }))
+    dialog.replace(
+      <DialogSelect title={`Priority for ${t.id}`} options={opts}
+        current={String(t.priority)} placeholder="0–9…"
+        onSelect={o => {
+          dialog.clear()
+          patchDirect(t.id, { priority: Number(o.value) }, `${t.id} → P${o.value}`)
+        }} />,
+    )
+  }, [dialog, patchDirect])
+
+  const editResult = useCallback((t: Task) => {
+    if (t.status !== "done")
+      return void toast.show({ variant: "info", message: `${t.id} is not done` })
+    return openTextPrompt(dialog, {
+      title: `Edit result`, label: t.id, initial: t.result ?? "",
+    }).then(v => {
+      if (v == null) return
+      void sh(`edit ${q(t.id)} --result ${q(v)}`, `Updated ${t.id} result`)
+    })
+  }, [dialog, sh, toast])
+
+  const editStatus = useCallback((t: Task) => {
+    // Only expose transitions the CLI has verbs for; skip `ready`
+    // unless task is blocked (unblock path).
+    const opts: Array<{ title: string; value: string; description?: string }> = []
+    if (t.status !== "done") opts.push({ title: "done", value: "complete",
+      description: "mark complete (prompts for result)" })
+    if (t.status !== "blocked") opts.push({ title: "blocked", value: "block",
+      description: "mark blocked (prompts for reason)" })
+    if (t.status === "blocked") opts.push({ title: "ready", value: "unblock",
+      description: "return to ready" })
+    opts.push({ title: "archived", value: "archive", description: "archive (terminal)" })
+    dialog.replace(
+      <DialogSelect title={`Status for ${t.id}`} options={opts}
+        current={t.status} placeholder="transition…"
+        onSelect={async o => {
+          dialog.clear()
+          if (o.value === "complete") {
+            const res = await openTextPrompt(dialog, {
+              title: `Complete ${t.id}`, label: "Result (optional)",
+              initial: t.result ?? "",
+            })
+            const flag = res ? ` --result ${q(res)}` : ""
+            void sh(`complete ${q(t.id)}${flag}`, `Completed ${t.id}`)
+            return
+          }
+          if (o.value === "block") {
+            const r = await openTextPrompt(dialog, {
+              title: `Block ${t.id}`, label: "Reason (optional, posted as comment)",
+            })
+            const arg = r ? ` ${q(r)}` : ""
+            void sh(`block ${q(t.id)}${arg}`, `Blocked ${t.id}`)
+            return
+          }
+          if (o.value === "unblock")
+            return void sh(`unblock ${q(t.id)}`, `Unblocked ${t.id}`)
+          if (o.value === "archive") return void archive(t)
+        }} />,
+    )
+  }, [dialog, sh, archive])
+
+  const editParents = useCallback((t: Task) => {
+    // Parents live on Detail, not Task; look up the current pane
+    // detail for the live parent list. Falls back to empty when the
+    // pane is somehow stale.
+    const detail = pane?.kind === "detail" && pane.d.id === t.id ? pane.d : detailOf(at, t.id)
+    const cur = detail?.parents ?? []
+    // Candidate parents = every non-archived task on the same board
+    // except self. Cycle prevention is enforced upstream by
+    // link_tasks (server rejects with "would cycle"), so we don't
+    // need to second-guess here — just show everything usable and
+    // let the linker toast the error if it fires.
+    const d = data.get(at) ?? new Map<Status, Task[]>()
+    const all = STATUSES.flatMap(s => d.get(s) ?? [])
+    const opts = all
+      .filter(x => x.id !== t.id)
+      .map(x => ({
+        title: x.id, description: trunc(x.title, 50),
+        value: x.id,
+        category: cur.includes(x.id) ? "linked" : "available",
+      }))
+    dialog.replace(
+      <DialogSelect title={`Parents for ${t.id}`} options={opts}
+        placeholder="Select to toggle link…"
+        onSelect={o => {
+          dialog.clear()
+          const linked = cur.includes(o.value)
+          if (linked) void sh(`unlink ${q(o.value)} ${q(t.id)}`, `Unlinked ${o.value}`)
+          else void sh(`link ${q(o.value)} ${q(t.id)}`, `Linked ${o.value}`)
+        }} />,
+    )
+  }, [dialog, sh, data, at, pane])
+
+  const openField = useCallback((f: PaneField, t: Task) => {
+    if (f === "title") return void editTitle(t)
+    if (f === "body") return void editBody(t)
+    if (f === "assignee") return assign(t)
+    if (f === "priority") return editPriority(t)
+    if (f === "status") return editStatus(t)
+    if (f === "parents") return editParents(t)
+    if (f === "result") return void editResult(t)
+    if (f === "comment") return void comment(t)
+  }, [editTitle, editBody, assign, editPriority, editStatus, editParents, editResult, comment])
+
+  // Bump priority with ↑↓ while the priority row is focused — no
+  // modal. Mirrors the new-task form affordance.
+  const bumpPriority = useCallback((t: Task, d: 1 | -1) => {
+    const next = Math.max(0, Math.min(9, t.priority + d))
+    if (next === t.priority) return
+    patchDirect(t.id, { priority: next }, `${t.id} → P${next}`)
+  }, [patchDirect])
+
   type Act = { key: string; title: string; when: (t?: Task) => boolean; run: (t?: Task) => void }
   const ACTS = useMemo<Act[]>(() => [
     { key: "n", title: "New task",      when: () => true,            run: () => void create() },
@@ -523,14 +920,56 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   ], [create, assign, comment, unblock, archive, showLog, newBoard, dispatch])
 
   const isOpen = open.has(at)
+  const paneOpen = pane?.kind === "detail"
+  const paneFields = paneOpen ? fieldsFor(pane.d) : []
 
   useKeyboard((key) => {
     if (!props.focused || dialog.open()) return
-    if (key.name === "escape" && pane) return setPane(null)
+    if (key.name === "escape" && pane) {
+      // Pane-tier → step back to grid first (pane stays open); pane
+      // closes on the next Esc.
+      if (tier === "pane") { setTier("grid"); return }
+      return setPane(null)
+    }
     if (keys.match("list.refresh", key)) return load()
-    // Tab = jump. Shell's double-Tab-to-composer fires first (mount
-    // order) and swallows the completing tap; singles land here.
-    if (key.name === "tab") return goBoard(key.shift ? -1 : 1)
+    // Tab behavior:
+    //   pane open, not in pane → Tab enters pane (no board-jump).
+    //   pane tier → Tab cycles field rows.
+    //   otherwise → Tab jumps boards.
+    if (key.name === "tab") {
+      if (paneOpen && tier !== "pane") { setTier("pane"); setPaneSel(0); return }
+      if (tier === "pane") {
+        const n = paneFields.length
+        if (n === 0) return
+        const d = key.shift ? -1 : 1
+        setPaneSel(s => (s + d + n) % n)
+        return
+      }
+      return goBoard(key.shift ? -1 : 1)
+    }
+    if (tier === "pane") {
+      const t = live.current.task
+      if (!t || !paneOpen) return
+      const f = paneFields[Math.min(paneSel, paneFields.length - 1)]
+      if (key.name === "up") {
+        if (f === "priority") return bumpPriority(t, 1)
+        const n = paneFields.length
+        if (n === 0) return
+        return setPaneSel(s => (s - 1 + n) % n)
+      }
+      if (key.name === "down") {
+        if (f === "priority") return bumpPriority(t, -1)
+        const n = paneFields.length
+        if (n === 0) return
+        return setPaneSel(s => (s + 1) % n)
+      }
+      if (key.name === "return") return openField(f, t)
+      // Letter shortcuts still fire while in pane — operators expect
+      // `c` / `a` / `l` / `d` to work no matter where focus is.
+      const hit = ACTS.find(a => a.key === key.raw && a.when(t))
+      if (hit) return hit.run(t)
+      return
+    }
     if (key.name === "space" || key.name === " ") {
       if (tier === "head") return toggle(at)
       if (tier === "filter" && sec?.chips[chip]) return flip(sec.chips[chip])
@@ -582,8 +1021,9 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     const t = task
     const nav = tier === "head" ? "↑↓ nav  Space fold"
       : tier === "filter" ? "←→ chip  Space toggle"
+      : tier === "pane" ? "Tab/↑↓ field  Enter edit  Esc grid"
       : "←→↑↓ nav  Enter detail"
-    return ["Tab board", nav,
+    return [tier === "pane" ? "Esc grid" : "Tab board", nav,
       ...ACTS.filter(a => a.when(t)).map(a => `${a.key} ${a.title.toLowerCase()}`),
       "r reload"].join("  ")
   }, [ACTS, task, tier])
@@ -646,7 +1086,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
                             {s.cols.map((c, ci) => (
                               <Column key={c.status} slug={s.board.slug} status={c.status}
                                       tasks={c.tasks}
-                                      on={on && tier === "grid" && ci === clampCol}
+                                      on={on && (tier === "grid" || tier === "pane") && ci === clampCol}
                                       sel={on ? row : 0}
                                       onPick={ri => onPick(s.board.slug, ci, ri, c.tasks[ri].id)} />
                             ))}
@@ -665,7 +1105,9 @@ export const Kanban = memo((props: { focused?: boolean }) => {
           </box>
         </scrollbox>
       </TabShell>
-      {pane ? <SidePane pane={pane} /> : null}
+      {pane
+        ? <SidePane pane={pane} on={tier === "pane"} sel={paneSel} />
+        : null}
     </box>
   )
 })

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -806,7 +806,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     }))
     dialog.replace(
       <DialogSelect title={`Priority for ${t.id}`} options={opts}
-        current={String(t.priority)} placeholder="0–9…"
+        current={String(t.priority)} filterable={false}
         onSelect={o => {
           dialog.clear()
           patchDirect(t.id, { priority: Number(o.value) }, `${t.id} → P${o.value}`)
@@ -838,7 +838,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     opts.push({ title: "archived", value: "archive", description: "archive (terminal)" })
     dialog.replace(
       <DialogSelect title={`Status for ${t.id}`} options={opts}
-        current={t.status} placeholder="transition…"
+        current={t.status} filterable={false}
         onSelect={async o => {
           dialog.clear()
           if (o.value === "complete") {

--- a/src/ui/dialog-select.tsx
+++ b/src/ui/dialog-select.tsx
@@ -30,9 +30,14 @@ type Props = {
   readonly placeholder?: string
   readonly current?: string
   readonly footer?: ReactNode
+  /** Show the type-to-filter input. Default true. Set false for small
+   *  fixed-choice lists (priority, status, …) where filtering is noise
+   *  and Space/Enter should be the only way to pick. */
+  readonly filterable?: boolean
 }
 
 export const DialogSelect = (props: Props) => {
+  const filterable = props.filterable ?? true
   const [filter, setFilter] = useState("")
   const [cursor, setCursor] = useState(0)
   const sb = useRef<ScrollBoxRenderable | null>(null)
@@ -82,7 +87,9 @@ export const DialogSelect = (props: Props) => {
     if (key.name === "down") return move(1)
     if (key.name === "pageup") return move(-10)
     if (key.name === "pagedown") return move(10)
-    if (key.name === "return") {
+    // Space selects too when there's no filter input to type into.
+    const isSpace = key.name === "space" || key.name === " "
+    if (key.name === "return" || (!filterable && isSpace)) {
       const item = filtered[cursor]
       if (item) props.onSelect(item)
       return
@@ -100,20 +107,25 @@ export const DialogSelect = (props: Props) => {
         <strong>{props.title}</strong>
       </text>
       <box height={1} />
-      <input
-        value={filter}
-        onInput={setFilter}
-        placeholder={props.placeholder ?? "Type to filter..."}
-        focused={true}
-        textColor={theme.text}
-        placeholderColor={theme.textMuted}
-        backgroundColor={theme.backgroundElement}
-        focusedBackgroundColor={theme.backgroundElement}
-      />
-      <box height={1} />
+      {filterable ? (
+        <>
+          <input
+            value={filter}
+            onInput={setFilter}
+            placeholder={props.placeholder ?? "Type to filter..."}
+            focused={true}
+            textColor={theme.text}
+            placeholderColor={theme.textMuted}
+            backgroundColor={theme.backgroundElement}
+            focusedBackgroundColor={theme.backgroundElement}
+          />
+          <box height={1} />
+        </>
+      ) : null}
       {/* ScrollBox root is flex-row ([wrapper, v-scrollbar]); column stacking
-          belongs on the content box, not here. */}
-      <scrollbox ref={sb} scrollY maxHeight={16}
+          belongs on the content box, not here. With no filter input the
+          scrollbox itself takes focus so ↑↓ and Space/Enter work. */}
+      <scrollbox ref={sb} scrollY maxHeight={16} focused={!filterable}
         contentOptions={{ flexDirection: "column" }} paddingRight={1}>
         {filtered.length === 0 ? (
           <text fg={theme.textMuted}>{"No results found"}</text>

--- a/src/ui/dialog.tsx
+++ b/src/ui/dialog.tsx
@@ -19,10 +19,14 @@ import { useTheme } from "../theme"
 type DialogEntry = {
   readonly element: ReactNode
   readonly onClose?: () => void
+  /** When true, DialogProvider does NOT auto-close this entry on the
+   *  cancel key — the dialog owns Esc itself (e.g. a multi-view form
+   *  where Esc first backs out of a sub-picker). */
+  readonly ownCancel?: boolean
 }
 
 export type DialogContext = {
-  readonly replace: (element: ReactNode, onClose?: () => void) => void
+  readonly replace: (element: ReactNode, onClose?: () => void, opts?: { ownCancel?: boolean }) => void
   readonly clear: () => void
   readonly stack: ReadonlyArray<DialogEntry>
   /** Scheduling-independent open probe. `stack.length > 0` is only
@@ -45,9 +49,9 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
   // setters so callers observing through open() never see a gap.
   const gate = useRef(false)
 
-  const replace = useCallback((element: ReactNode, onClose?: () => void) => {
+  const replace = useCallback((element: ReactNode, onClose?: () => void, opts?: { ownCancel?: boolean }) => {
     gate.current = true
-    setStack([{ element, onClose }])
+    setStack([{ element, onClose, ownCancel: opts?.ownCancel }])
   }, [])
 
   const clear = useCallback(() => {
@@ -64,6 +68,8 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
   const keys = useKeys()
   useKeyboard((key) => {
     if (stack.length === 0) return
+    const top = stack[stack.length - 1]
+    if (top?.ownCancel) return // dialog handles its own Esc
     if (keys.match("dialog.cancel", key)) clear()
   })
 

--- a/src/utils/gateway-client.ts
+++ b/src/utils/gateway-client.ts
@@ -125,8 +125,11 @@ export class GatewayClient extends EventEmitter {
   start() {
     const root = this.root()
     const bin = python(root)
-    const cwd = process.env.HERMES_CWD || root
+    const cwd = process.env.HERMES_CWD || process.cwd()
     const env = { ...process.env } as Record<string, string>
+    // Ensure the gateway and agent tools resolve to the user's launch cwd.
+    // TERMINAL_CWD is the canonical env var the agent reads for working dir.
+    if (!env.TERMINAL_CWD) env.TERMINAL_CWD = cwd
     const pp = env.PYTHONPATH?.trim()
     env.PYTHONPATH = pp ? `${root}${delimiter}${pp}` : root
 

--- a/src/utils/gateway-types.ts
+++ b/src/utils/gateway-types.ts
@@ -150,6 +150,15 @@ export type SessionInfo = {
   skills?: Record<string, string[]>
   version?: string
   /**
+   * Live active-agent system prompt from `agent._cached_system_prompt`
+   * (gateway `_session_info`, tui_gateway/server.py). Prefer this over
+   * `readSystemPromptInfo()`'s state.db scan — the DB row is per-session
+   * and only written at turn boundaries, while this reflects the current
+   * prompt including mid-session personality/skin switches. Optional
+   * because older gateways don't send it.
+   */
+  system_prompt?: string
+  /**
    * Wire usage payload for the current session. Server builds this via
    * `_get_usage(agent)` (tui_gateway/server.py:826), which extends the
    * base Usage with ctx/compression fields when a ContextCompressor is

--- a/src/utils/hermes-kanban.ts
+++ b/src/utils/hermes-kanban.ts
@@ -15,9 +15,21 @@
 // Herm renders all boards at once; the "current" board only seeds
 // which section has focus on mount. Reads are sidecar SQLite per
 // board (WAL lets us read alongside the dispatcher's IMMEDIATE write
-// txns). Writes route through `shell.exec → hermes kanban --board
-// <slug> <verb>` so upstream kanban_db.py owns the state machine:
-// recompute_ready, cycle detection, event log, notify subscriptions.
+// txns). Writes split by verb:
+//
+//   Structured transitions → shell.exec → `hermes kanban --board
+//   <slug> <verb>` (complete/block/unblock/archive/assign/link/
+//   unlink/edit/dispatch). kanban_db.py owns the state machine —
+//   run closure, recompute_ready, notify-sub fanout.
+//
+//   Field edits (title/body/priority) → direct bun:sqlite writes in
+//   a BEGIN IMMEDIATE txn, mirroring plugins/kanban/dashboard/
+//   plugin_api.py PATCH /tasks/:id. Every raw write appends a
+//   matching task_events row inside the same txn so the audit
+//   trail and dashboard live feed stay intact. This pattern is
+//   deliberately scoped to the same fields the dashboard edits
+//   directly; tenant/workspace/skills/max_runtime stay
+//   create-time-only.
 
 import { Database } from "bun:sqlite"
 import { existsSync, readdirSync, statSync, openSync, readSync, closeSync, readFileSync } from "node:fs"
@@ -32,11 +44,32 @@ export type Task = {
   created_at: number; updated_at: number; completed_at: number | null
   result: string | null; error: string | null
   tenant: string | null; pid: number | null
+  workspace_kind: string | null; workspace_path: string | null
+  skills: string[]
+  max_runtime_seconds: number | null
+}
+
+export type Run = {
+  id: number; profile: string | null
+  status: string | null; outcome: string | null
+  started_at: number; ended_at: number | null
+  summary: string | null; error: string | null
+  worker_pid: number | null
+}
+
+export type Event = {
+  id: number; kind: string
+  payload: unknown | null
+  created_at: number
+  run_id: number | null
 }
 
 export type Detail = Task & {
   parents: string[]; children: string[]
   comments: Array<{ author: string; body: string; at: number }>
+  runs: Run[]
+  events: Event[]
+  latest_summary: string | null
 }
 
 export type Board = { slug: string; name: string }
@@ -57,9 +90,13 @@ const resolve = (): string => {
 }
 
 let slug = resolve()
-/** One RO handle per board slug. `null` = open attempted and failed
- *  (no DB yet); `undefined` = not yet attempted. */
-const handles = new Map<string, Database | null>()
+
+/** Two cached handles per board slug: [ro, rw]. `null` = open attempted
+ *  and failed (no DB yet); `undefined` = not yet attempted. Separate
+ *  handles because bun:sqlite's readonly flag is per-connection and we
+ *  want reads to never block on a write handle taking the lock. */
+type Handles = { ro: Database | null; rw: Database | null }
+const handles = new Map<string, Handles>()
 
 export const currentBoard = () => slug
 
@@ -70,18 +107,43 @@ const dbPath = (s: string) =>
 const logsDir = (s: string) =>
   hermesPath(s === DEFAULT ? "kanban/logs" : `kanban/boards/${s}/logs`)
 
-const dbOf = (s: string): Database | null => {
-  if (handles.has(s)) return handles.get(s) ?? null
-  let h: Database | null = null
-  try { h = new Database(dbPath(s), { readonly: true }) } catch {}
-  handles.set(s, h)
-  return h
+const pair = (s: string): Handles => {
+  const cached = handles.get(s)
+  if (cached) return cached
+  const next: Handles = { ro: null, rw: null }
+  handles.set(s, next)
+  return next
 }
 
-/** Close every cached RO handle and re-resolve the active board.
+const dbOf = (s: string): Database | null => {
+  const h = pair(s)
+  if (h.ro !== null) return h.ro
+  try { h.ro = new Database(dbPath(s), { readonly: true }) } catch { h.ro = null }
+  return h.ro
+}
+
+/** Open (or return) a read-write handle for `s`. WAL mode matches the
+ *  dispatcher so readers and this writer can coexist. Returns null if
+ *  the DB file doesn't exist yet (create via `hermes kanban init` or
+ *  the first CLI create). */
+const rwOf = (s: string): Database | null => {
+  const h = pair(s)
+  if (h.rw) return h.rw
+  if (!existsSync(dbPath(s))) return null
+  try {
+    const db = new Database(dbPath(s))
+    // Match kanban_db.connect() pragmas. WAL is a no-op after the first
+    // time but cheap; synchronous=NORMAL matches upstream.
+    db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA foreign_keys=ON")
+    h.rw = db
+    return db
+  } catch { return null }
+}
+
+/** Close every cached handle and re-resolve the active board.
  *  Call after a profile rehome, board create, or test seeding. */
 export const resetKanban = () => {
-  for (const h of handles.values()) h?.close()
+  for (const h of handles.values()) { h.ro?.close(); h.rw?.close() }
   handles.clear()
   slug = resolve()
 }
@@ -96,11 +158,15 @@ export function listBoards(): Board[] {
       let name = e.name
       try {
         const meta = JSON.parse(readFileSync(`${dir}/${e.name}/board.json`, "utf-8"))
-        if (typeof meta?.display_name === "string") name = meta.display_name
+        // Upstream writes "name" (hermes_cli/kanban_db.py write_board_metadata);
+        // older installs may have "display_name". Accept either.
+        const n = typeof meta?.name === "string" ? meta.name
+          : typeof meta?.display_name === "string" ? meta.display_name : null
+        if (n) name = n
       } catch {}
       out.set(e.name, name)
     }
-  return [...out].map(([s, name]) => ({ slug: s, name }))
+  return [...out].map(([s, n]) => ({ slug: s, name: n }))
     .sort((a, b) => a.slug === DEFAULT ? -1 : b.slug === DEFAULT ? 1 : a.slug.localeCompare(b.slug))
 }
 
@@ -108,6 +174,51 @@ export function listBoards(): Board[] {
 // tasks table has no updated_at; newest-of-the-three is close enough
 // for sort-by-recency without joining task_events on every list.
 const AT = "COALESCE(completed_at, started_at, created_at)"
+
+/** Schema on a live DB can lag the current upstream migrations —
+ *  tests seed a minimal table, ancient installs may not have run
+ *  `kanban init`. Query `PRAGMA table_info` once per handle and
+ *  expose a set so `boardOf`/`detailOf` can COALESCE optional
+ *  columns to NULL without exploding. */
+const cols = new WeakMap<Database, Set<string>>()
+const colsOf = (conn: Database): Set<string> => {
+  const cached = cols.get(conn)
+  if (cached) return cached
+  const set = new Set<string>()
+  try {
+    for (const r of conn.query("PRAGMA table_info(tasks)").all() as Array<{ name: string }>)
+      set.add(r.name)
+  } catch {}
+  cols.set(conn, set)
+  return set
+}
+
+/** Build a select clause that emits NULL for any column not present
+ *  on the current schema. Keeps old test DBs + fresh-install DBs
+ *  working without branching at every call site. */
+const selectCol = (have: Set<string>, name: string, alias?: string): string => {
+  const a = alias ?? name
+  return have.has(name) ? `${name} AS ${a}` : `NULL AS ${a}`
+}
+
+const taskColumns = (have: Set<string>): string => [
+  "id", "title", selectCol(have, "body"), selectCol(have, "assignee"),
+  "status", "priority", selectCol(have, "tenant"),
+  selectCol(have, "created_at"), selectCol(have, "completed_at"),
+  selectCol(have, "result"), selectCol(have, "last_spawn_error"),
+  selectCol(have, "worker_pid"),
+  selectCol(have, "workspace_kind"), selectCol(have, "workspace_path"),
+  selectCol(have, "skills"), selectCol(have, "max_runtime_seconds"),
+  `${AT} AS updated_at`,
+].join(", ")
+
+const parseSkills = (raw: unknown): string[] => {
+  if (typeof raw !== "string" || !raw) return []
+  try {
+    const j = JSON.parse(raw)
+    return Array.isArray(j) ? j.filter((v): v is string => typeof v === "string" && !!v) : []
+  } catch { return [] }
+}
 
 const toTask = (r: Record<string, unknown>): Task => ({
   id: String(r.id), title: String(r.title ?? ""),
@@ -122,7 +233,36 @@ const toTask = (r: Record<string, unknown>): Task => ({
   error: (r.last_spawn_error as string) ?? null,
   tenant: (r.tenant as string) ?? null,
   pid: (r.worker_pid as number) ?? null,
+  workspace_kind: (r.workspace_kind as string) ?? null,
+  workspace_path: (r.workspace_path as string) ?? null,
+  skills: parseSkills(r.skills),
+  max_runtime_seconds: (r.max_runtime_seconds as number) ?? null,
 })
+
+const toRun = (r: Record<string, unknown>): Run => ({
+  id: Number(r.id),
+  profile: (r.profile as string) ?? null,
+  status: (r.status as string) ?? null,
+  outcome: (r.outcome as string) ?? null,
+  started_at: Number(r.started_at) || 0,
+  ended_at: (r.ended_at as number) ?? null,
+  summary: (r.summary as string) ?? null,
+  error: (r.error as string) ?? null,
+  worker_pid: (r.worker_pid as number) ?? null,
+})
+
+const toEvent = (r: Record<string, unknown>): Event => {
+  const raw = r.payload as string | null
+  let payload: unknown = null
+  if (raw) try { payload = JSON.parse(raw) } catch { payload = raw }
+  return {
+    id: Number(r.id),
+    kind: String(r.kind ?? ""),
+    payload,
+    created_at: Number(r.created_at) || 0,
+    run_id: (r.run_id as number) ?? null,
+  }
+}
 
 /** All non-archived tasks on `s`, grouped by status column. Each
  *  column sorted by (priority desc, updated_at desc) so the
@@ -134,9 +274,7 @@ export function boardOf(s: string): Map<Status, Task[]> {
   if (!conn) return out
   try {
     const rows = conn.query(
-      `SELECT id, title, body, assignee, status, priority, tenant,
-              created_at, completed_at, result, last_spawn_error, worker_pid,
-              ${AT} AS updated_at
+      `SELECT ${taskColumns(colsOf(conn))}
        FROM tasks WHERE status != 'archived'
        ORDER BY priority DESC, updated_at DESC`,
     ).all() as Array<Record<string, unknown>>
@@ -148,12 +286,14 @@ export function boardOf(s: string): Map<Status, Task[]> {
   return out
 }
 
+const EVENT_TAIL = 20
+
 export function detailOf(s: string, id: string): Detail | null {
   const conn = dbOf(s)
   if (!conn) return null
   try {
     const row = conn.query(
-      `SELECT *, ${AT} AS updated_at FROM tasks WHERE id = ?`,
+      `SELECT ${taskColumns(colsOf(conn))} FROM tasks WHERE id = ?`,
     ).get(id) as Record<string, unknown> | null
     if (!row) return null
     const parents = (conn.query(
@@ -166,7 +306,48 @@ export function detailOf(s: string, id: string): Detail | null {
       "SELECT author, body, created_at FROM task_comments WHERE task_id = ? ORDER BY created_at",
     ).all(id) as Array<{ author: string; body: string; created_at: number }>)
       .map(c => ({ author: c.author, body: c.body, at: c.created_at }))
-    return { ...toTask(row), parents, children, comments }
+    // task_runs / task_events may not exist on ancient DBs; swallow and
+    // return [] so the detail pane keeps working.
+    const runs = runsOf(conn, id)
+    const events = eventsOf(conn, id)
+    const latest = latestSummary(conn, id)
+    return {
+      ...toTask(row), parents, children, comments,
+      runs, events, latest_summary: latest,
+    }
+  } catch { return null }
+}
+
+const runsOf = (conn: Database, id: string): Run[] => {
+  try {
+    return (conn.query(
+      `SELECT id, profile, status, outcome, started_at, ended_at,
+              summary, error, worker_pid
+       FROM task_runs WHERE task_id = ? ORDER BY id`,
+    ).all(id) as Array<Record<string, unknown>>).map(toRun)
+  } catch { return [] }
+}
+
+const eventsOf = (conn: Database, id: string): Event[] => {
+  try {
+    // Newest-20 DESC from SQL, then reverse so callers see chronological
+    // order (matches `hermes kanban show` last-20-events output).
+    const rows = conn.query(
+      `SELECT id, kind, payload, created_at, run_id
+       FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT ?`,
+    ).all(id, EVENT_TAIL) as Array<Record<string, unknown>>
+    return rows.map(toEvent).reverse()
+  } catch { return [] }
+}
+
+const latestSummary = (conn: Database, id: string): string | null => {
+  try {
+    const row = conn.query(
+      `SELECT summary FROM task_runs
+       WHERE task_id = ? AND summary IS NOT NULL AND summary != ''
+       ORDER BY id DESC LIMIT 1`,
+    ).get(id) as { summary: string } | null
+    return row?.summary ?? null
   } catch { return null }
 }
 
@@ -207,6 +388,90 @@ export function assignees(s: string = slug): string[] {
     ).all() as Array<{ assignee: string }>) seen.add(r.assignee)
   } catch {}
   return [...seen].sort()
+}
+
+// ── Direct writes ──────────────────────────────────────────────────
+// Scoped to the same field set plugins/kanban/dashboard/plugin_api.py
+// PATCH /tasks/:id writes directly: title, body, priority. Every raw
+// write is wrapped in BEGIN IMMEDIATE and followed by a task_events
+// row in the same transaction so the audit trail stays intact.
+//
+// NOTE: status transitions are deliberately NOT here — use the CLI
+// verbs (complete/block/unblock/archive) which close runs, emit
+// notify-subs, and recompute_ready on children. The dashboard's
+// _set_status_direct helper exists for drag-drop between non-terminal
+// states only; herm doesn't have a drag affordance, so the simpler
+// "verbs for status, raw for fields" split is enough.
+
+/** Wrap `fn` in a BEGIN IMMEDIATE txn on `conn`. Mirrors
+ *  kanban_db.write_txn — IMMEDIATE takes the reserved lock up front so
+ *  concurrent writers fail fast instead of racing mid-txn. */
+function writeTxn<T>(conn: Database, fn: () => T): T {
+  conn.exec("BEGIN IMMEDIATE")
+  try {
+    const out = fn()
+    conn.exec("COMMIT")
+    return out
+  } catch (err) {
+    try { conn.exec("ROLLBACK") } catch {}
+    throw err
+  }
+}
+
+const now = () => Math.floor(Date.now() / 1000)
+
+export type PatchFields = {
+  title?: string
+  body?: string | null
+  priority?: number
+}
+
+/** Apply `patch` to task `id` on board `s`. Returns true on success,
+ *  false if the task doesn't exist. Throws on malformed input (empty
+ *  title, DB error). Mirrors the dashboard's PATCH /tasks/:id write
+ *  discipline: one txn per field group, matching event kind. */
+export function patchTask(s: string, id: string, patch: PatchFields): boolean {
+  const conn = rwOf(s)
+  if (!conn) return false
+
+  const exists = conn.query("SELECT 1 FROM tasks WHERE id = ?").get(id) as unknown
+  if (!exists) return false
+
+  // Priority first (dashboard orders it this way; each field is its
+  // own sub-txn so partial failures surface per-field).
+  if (patch.priority !== undefined) {
+    const p = Math.max(0, Math.min(9, Math.floor(patch.priority)))
+    writeTxn(conn, () => {
+      conn.query("UPDATE tasks SET priority = ? WHERE id = ?").run(p, id)
+      conn.query(
+        "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) " +
+        "VALUES (?, NULL, 'reprioritized', ?, ?)",
+      ).run(id, JSON.stringify({ priority: p }), now())
+    })
+  }
+
+  if (patch.title !== undefined || patch.body !== undefined) {
+    const sets: string[] = []
+    const vals: Array<string | null> = []
+    if (patch.title !== undefined) {
+      const t = patch.title.trim()
+      if (!t) throw new Error("title cannot be empty")
+      sets.push("title = ?"); vals.push(t)
+    }
+    if (patch.body !== undefined) {
+      sets.push("body = ?"); vals.push(patch.body)
+    }
+    vals.push(id)
+    writeTxn(conn, () => {
+      conn.query(`UPDATE tasks SET ${sets.join(", ")} WHERE id = ?`).run(...vals)
+      conn.query(
+        "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) " +
+        "VALUES (?, NULL, 'edited', NULL, ?)",
+      ).run(id, now())
+    })
+  }
+
+  return true
 }
 
 // ── Current-board shims ────────────────────────────────────────────

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -49,6 +49,25 @@ interface TuiPreferences {
    *  "suspend" — 10s-countdown confirm, then `systemctl suspend`
    *  any other string — 10s-countdown confirm, then run it via sh */
   onGoalDone?: string
+  /** Per-tab state that should survive restarts. Keep this shallow —
+   *  only durable UX choices (filter masks, collapsed sections), never
+   *  cursor position or transient toggles. */
+  kanban?: KanbanPrefs
+}
+
+/** Persisted Kanban-tab state. Keyed by board slug so masks on one
+ *  board don't follow you to another. */
+export type KanbanPrefs = {
+  /** Boards that should mount expanded. Absent = collapsed. Stored as
+   *  an array for JSON-friendliness; consumer rehydrates to a Set. */
+  open?: string[]
+  /** Per-board filter-chip tri-state. Maps decomposed as entry arrays
+   *  because JSON has no native Map support. */
+  masks?: Record<string, {
+    who?: Array<[string, "in" | "ex"]>
+    pri?: Array<[number, "in" | "ex"]>
+    status?: Array<[string, "in" | "ex"]>
+  }>
 }
 
 const DEFAULTS: Required<Pick<TuiPreferences, "mouse" | "targetFps">> = {

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -21,17 +21,17 @@ describe("app", () => {
     t.destroy()
   })
 
-  test("ctrl+left/right switches tabs", async () => {
+  test("alt+left/right switches tabs", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    // Chat is index 0; ctrl+left should clamp (no Overview anymore)
-    act(() => t.keys.pressArrow("left", { ctrl: true }))
+    // Chat is index 0; alt+left should clamp (no Overview anymore)
+    act(() => t.keys.pressArrow("left", { meta: true }))
     await t.settle()
     expect(t.frame()).toContain("Message Hermes")
 
     // → Sessions (index 2)
-    act(() => { for (let i = 0; i < 2; i++) t.keys.pressArrow("right", { ctrl: true }) })
+    act(() => { for (let i = 0; i < 2; i++) t.keys.pressArrow("right", { meta: true }) })
     // Sandboxed HERMES_HOME has no state.db → empty state
     await until(t, () => t.frame().includes("No sessions"))
 
@@ -102,7 +102,7 @@ describe("app", () => {
     await until(t, () => t.frame().includes("Ready"))
 
     // Default chord no longer switches.
-    act(() => t.keys.pressArrow("right", { ctrl: true }))
+    act(() => t.keys.pressArrow("right", { meta: true }))
     await t.settle()
     expect(t.frame()).toContain("Message Hermes")
 
@@ -147,8 +147,8 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    // Ctrl+→ to Env (index 9). Land on content, not the composer.
-    act(() => { for (let i = 0; i < 9; i++) t.keys.pressArrow("right", { ctrl: true }) })
+    // Alt+→ to Env (index 9). Land on content, not the composer.
+    act(() => { for (let i = 0; i < 9; i++) t.keys.pressArrow("right", { meta: true }) })
     await t.settle()
     await until(t, () => t.frame().includes("Env / API Keys"))
     expect(t.frame()).not.toContain("Env (searching)")
@@ -173,7 +173,7 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    act(() => { for (let i = 0; i < 9; i++) t.keys.pressArrow("right", { ctrl: true }) })
+    act(() => { for (let i = 0; i < 9; i++) t.keys.pressArrow("right", { meta: true }) })
     await until(t, () => t.frame().includes("Env / API Keys"))
 
     // Single Tab: content keeps focus (arrow still moves selection).
@@ -530,9 +530,9 @@ describe("app", () => {
     await act(async () => { await t.keys.typeText("/") })
     await until(t, () => t.frame().includes("/clear"))
 
-    act(() => t.keys.pressArrow("right", { ctrl: true }))
+    act(() => t.keys.pressArrow("right", { meta: true }))
     await t.settle()
-    act(() => t.keys.pressArrow("left", { ctrl: true }))
+    act(() => t.keys.pressArrow("left", { meta: true }))
     await t.settle(); await t.settle()
 
     // Content tab remounted after Composer in the parent's paint order;

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -5,7 +5,7 @@
 //   t.gw.emit("event", { type: "message.delta", payload: { text: "hi" } })
 //   await t.settle()
 //   expect(t.frame()).toContain("hi")
-//   t.keys.pressArrow("right", { ctrl: true })
+//   t.keys.pressArrow("right", { meta: true })
 //   t.destroy()
 
 import { EventEmitter } from "events"

--- a/test/help.test.tsx
+++ b/test/help.test.tsx
@@ -21,7 +21,7 @@ describe("HelpDialog", () => {
 
     // Sample chord labels
     expect(f).toContain("Ctrl+X E")   // editor.open (leader substituted)
-    expect(f).toContain("Ctrl+→")     // tab.next
+    expect(f).toContain("Alt+→")       // tab.next
     expect(f).toContain("Shift+Enter")// input.newline first alternate
     t.destroy()
   })
@@ -32,7 +32,7 @@ describe("HelpDialog", () => {
     await until(t, () => t.frame().includes("Keyboard Shortcuts"))
     const f = t.frame()
     expect(f).toContain("Ctrl+N")
-    expect(f).not.toContain("Ctrl+→")
+    expect(f).not.toContain("Alt+→")
     expect(f).not.toContain("Copy last assistant")
     t.destroy()
   })

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -454,7 +454,7 @@ describe("Kanban tab", () => {
     act(() => t.keys.pressArrow("down")); await t.settle() // workspace
     await until(t, () => /▸ Workspace/.test(t.frame()))
     await act(async () => { await t.keys.typeText(" ") })   // open workspace picker
-    await until(t, () => /Pick a workspace kind/.test(t.frame()))
+    await until(t, () => /isolated temp dir under the board root/.test(t.frame()))
     // scratch (0), worktree (1), dir (2) — ↓↓ to dir, Enter → path prompt
     act(() => t.keys.pressArrow("down")); await t.settle()
     act(() => t.keys.pressArrow("down")); await t.settle()
@@ -522,16 +522,47 @@ describe("Kanban tab", () => {
     act(() => t.keys.pressArrow("down")); await t.settle() // tenant
     act(() => t.keys.pressArrow("down")); await t.settle() // workspace
     await act(async () => { await t.keys.typeText(" ") })   // open workspace picker
-    await until(t, () => /Pick a workspace kind/.test(t.frame()))
+    await until(t, () => /isolated temp dir under the board root/.test(t.frame()))
     act(() => t.keys.pressArrow("down")); await t.settle()
     act(() => t.keys.pressArrow("down")); await t.settle() // → dir:…
     act(() => t.keys.pressEnter()); await t.settle()       // → dir-path prompt
     await until(t, () => /Directory path/.test(t.frame()))
     act(() => t.keys.pressEscape()); await t.settle()      // Esc → back to workspace picker
-    expect(t.frame()).toMatch(/Pick a workspace kind/)
+    expect(t.frame()).toMatch(/isolated temp dir under the board root/)
     act(() => t.keys.pressEscape()); await t.settle()      // Esc → back to form
     expect(t.frame()).toContain("New Task")
-    expect(t.frame()).not.toMatch(/Pick a workspace kind/)
+    expect(t.frame()).not.toMatch(/isolated temp dir under the board root/)
+    t.destroy()
+  })
+
+  test("create form: Priority picker is filter-free; Space selects", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "tp", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("prio pick") })
+    await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle() // body
+    act(() => t.keys.pressArrow("down")); await t.settle() // assignee
+    act(() => t.keys.pressArrow("down")); await t.settle() // priority
+    await until(t, () => /▸ Priority/.test(t.frame()))
+    await act(async () => { await t.keys.typeText(" ") })   // open priority picker
+    await until(t, () => /P0 \(none\)/.test(t.frame()))
+    // No filter input — typing a digit must NOT filter; it is ignored.
+    expect(t.frame()).not.toMatch(/Type to filter/)
+    // ↓↓↓ to P3, Space selects (not just Enter).
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    await act(async () => { await t.keys.typeText(" ") })   // Space = select
+    await until(t, () => /▸ Priority\s+P3/.test(t.frame()))
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => cmds.length === 1)
+    expect(cmds[0]).toBe("hermes kanban --board default create 'prio pick' --priority 3")
     t.destroy()
   })
 

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -432,6 +432,51 @@ describe("Kanban tab", () => {
     t.destroy()
   })
 
+  test("create form: ↑/↓ in a multi-line body move the cursor, only escape at the edges", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "tb", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("multiline body") })
+    await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle() // into body (empty → enters)
+    await until(t, () => /▸ Body/.test(t.frame()))
+    // Three lines; cursor ends on line 3 (last).
+    await act(async () => { await t.keys.typeText("one") })
+    act(() => t.keys.pressEnter())
+    await act(async () => { await t.keys.typeText("two") })
+    act(() => t.keys.pressEnter())
+    await act(async () => { await t.keys.typeText("three") })
+    await t.settle()
+    // ↑ twice: cursor row 2 → 1 → 0. Focus must stay on Body.
+    act(() => t.keys.pressArrow("up")); await t.settle()
+    expect(t.frame()).toMatch(/▸ Body/)
+    act(() => t.keys.pressArrow("up")); await t.settle()
+    expect(t.frame()).toMatch(/▸ Body/)
+    // Now at row 0 — one more ↑ spills over to the previous field (Title).
+    act(() => t.keys.pressArrow("up")); await t.settle()
+    expect(t.frame()).toMatch(/▸ Title/)
+    // ↓ from Title re-enters Body at row 0; ↓ again stays (row 0 → 1), etc.
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    expect(t.frame()).toMatch(/▸ Body/)
+    act(() => t.keys.pressArrow("down")); await t.settle() // row 0 → 1
+    expect(t.frame()).toMatch(/▸ Body/)
+    act(() => t.keys.pressArrow("down")); await t.settle() // row 1 → 2 (last)
+    expect(t.frame()).toMatch(/▸ Body/)
+    // row 2 is the last line — one more ↓ spills to the next field (Assignee).
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    expect(t.frame()).toMatch(/▸ Assignee/)
+    // Body text survived all of that.
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => cmds.length === 1)
+    expect(cmds[0]).toBe("hermes kanban --board default create 'multiline body' --body 'one\ntwo\nthree'")
+    t.destroy()
+  })
+
   test("create form: More section hidden until expanded; Workspace dir: → --workspace dir:<path>", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -334,6 +334,159 @@ describe("Kanban tab", () => {
     t.destroy()
   })
 
+  test("create form: empty title blocks submit; footer nags", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "x", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    // No title typed. Enter is a no-op; Ctrl+Enter is a no-op.
+    expect(t.frame()).toContain("type a title")
+    act(() => t.keys.pressEnter())
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await t.settle()
+    expect(cmds.length).toBe(0)
+    expect(t.frame()).toContain("New Task") // still open
+    t.destroy()
+  })
+
+  test("create form: ↓ walks fields; Space toggles triage; Ctrl+Enter submits", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t7", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("spike the thing") })
+    await t.settle()
+    // title → body (empty, ↓ escapes) → assignee → priority → triage
+    act(() => t.keys.pressArrow("down")); await t.settle() // body
+    act(() => t.keys.pressArrow("down")); await t.settle() // assignee
+    act(() => t.keys.pressArrow("down")); await t.settle() // priority
+    act(() => t.keys.pressArrow("down")); await t.settle() // triage
+    await until(t, () => /▸ Triage/.test(t.frame()))
+    await act(async () => { await t.keys.typeText(" ") })
+    await until(t, () => /Triage\s+yes/.test(t.frame()))
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => cmds.length === 1)
+    expect(cmds[0]).toBe("hermes kanban --board default create 'spike the thing' --triage")
+    t.destroy()
+  })
+
+  test("create form: Space on Assignee opens picker; selection feeds --assignee", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t8", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("needs an owner") })
+    await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle() // body
+    act(() => t.keys.pressArrow("down")); await t.settle() // assignee
+    await until(t, () => /▸ Assignee/.test(t.frame()))
+    await act(async () => { await t.keys.typeText(" ") })   // open picker
+    await until(t, () => /Search profiles/.test(t.frame()))
+    // ↓ past "(unassigned)" to the first real profile, Enter.
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => /▸ Assignee\s+\S/.test(t.frame()) && !/\(unassigned\)/.test(t.frame().split("Assignee")[1] ?? ""))
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => cmds.length === 1)
+    expect(cmds[0]).toMatch(/^hermes kanban --board default create 'needs an owner' --assignee \S+$/)
+    t.destroy()
+  })
+
+  test("create form: body textarea — ↓ enters, Enter newlines, Tab leaves; body feeds --body", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t9", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("has a body") })
+    await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle() // into body
+    await until(t, () => /▸ Body/.test(t.frame()))
+    await act(async () => { await t.keys.typeText("para one") })
+    act(() => t.keys.pressEnter())                          // newline (not submit)
+    await act(async () => { await t.keys.typeText("para two") })
+    await t.settle()
+    expect(cmds.length).toBe(0)                             // Enter did NOT submit
+    expect(t.frame()).toContain("para one")
+    expect(t.frame()).toContain("para two")
+    act(() => t.keys.pressTab()); await t.settle()          // Tab leaves body → assignee
+    await until(t, () => /▸ Assignee/.test(t.frame()))
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => cmds.length === 1)
+    expect(cmds[0]).toBe("hermes kanban --board default create 'has a body' --body 'para one\npara two'")
+    t.destroy()
+  })
+
+  test("create form: More section hidden until expanded; Workspace dir: → --workspace dir:<path>", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t10", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("in a dir") })
+    await t.settle()
+    expect(t.frame()).not.toContain("Workspace") // collapsed
+    // title→body→assignee→priority→triage→more
+    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    await until(t, () => /▸ More/.test(t.frame()))
+    await act(async () => { await t.keys.typeText(" ") })   // expand
+    await until(t, () => /Workspace/.test(t.frame()))
+    // more→tenant→workspace
+    act(() => t.keys.pressArrow("down")); await t.settle() // tenant
+    act(() => t.keys.pressArrow("down")); await t.settle() // workspace
+    await until(t, () => /▸ Workspace/.test(t.frame()))
+    await act(async () => { await t.keys.typeText(" ") })   // open workspace picker
+    await until(t, () => /Pick a workspace kind/.test(t.frame()))
+    // scratch (0), worktree (1), dir (2) — ↓↓ to dir, Enter → path prompt
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => /Directory path/.test(t.frame()))
+    await act(async () => { await t.keys.typeText("/tmp/work") })
+    await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()        // confirm path
+    await until(t, () => /Workspace\s+dir @ \/tmp\/work/.test(t.frame()))
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => cmds.length === 1)
+    expect(cmds[0]).toBe("hermes kanban --board default create 'in a dir' --workspace dir:/tmp/work")
+    t.destroy()
+  })
+
+  test("create form: Esc cancels — no command", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "x", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("never mind") })
+    await t.settle()
+    act(() => t.keys.pressEscape())
+    await until(t, () => !t.frame().includes("New Task"))
+    expect(cmds.length).toBe(0)
+    t.destroy()
+  })
+
   test("D → confirm → dispatch", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -17,13 +17,25 @@ const schema = (db: Database) => {
     id TEXT PRIMARY KEY, title TEXT, body TEXT, assignee TEXT,
     status TEXT, priority INTEGER DEFAULT 0, tenant TEXT,
     created_at INTEGER, started_at INTEGER, completed_at INTEGER,
-    result TEXT, last_spawn_error TEXT, worker_pid INTEGER
+    result TEXT, last_spawn_error TEXT, worker_pid INTEGER,
+    workspace_kind TEXT, workspace_path TEXT,
+    skills TEXT, max_runtime_seconds INTEGER
   )`)
   db.run(`CREATE TABLE IF NOT EXISTS task_links (
     parent_id TEXT, child_id TEXT, PRIMARY KEY (parent_id, child_id))`)
   db.run(`CREATE TABLE IF NOT EXISTS task_comments (
     id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT,
     author TEXT, body TEXT, created_at INTEGER)`)
+  // Append-only audit tables. kanban_db.py writes to these on every
+  // write; herm reads them for the detail pane's Runs/Events sections
+  // and the patchTask event-row sibling INSERTs.
+  db.run(`CREATE TABLE IF NOT EXISTS task_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT, run_id INTEGER,
+    kind TEXT, payload TEXT, created_at INTEGER)`)
+  db.run(`CREATE TABLE IF NOT EXISTS task_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT, profile TEXT,
+    status TEXT, outcome TEXT, started_at INTEGER, ended_at INTEGER,
+    summary TEXT, error TEXT, worker_pid INTEGER)`)
 }
 
 beforeAll(() => {
@@ -489,5 +501,146 @@ describe("Kanban tab", () => {
       rmSync(hermesPath("kanban/boards/tall"), { recursive: true, force: true })
       resetKanban()
     }
+  })
+})
+
+// ─── Direct-write path (bun:sqlite, matches dashboard PATCH) ─────────
+describe("patchTask direct writes", () => {
+  const read = (id: string): Record<string, unknown> | null => {
+    const db = new Database(hermesPath("kanban.db"), { readonly: true })
+    try {
+      return db.query("SELECT * FROM tasks WHERE id = ?").get(id) as Record<string, unknown> | null
+    } finally { db.close() }
+  }
+  const events = (id: string): Array<{ kind: string; payload: string | null }> => {
+    const db = new Database(hermesPath("kanban.db"), { readonly: true })
+    try {
+      return db.query(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+      ).all(id) as Array<{ kind: string; payload: string | null }>
+    } finally { db.close() }
+  }
+
+  test("title + body in one txn ⇒ single 'edited' event", async () => {
+    const { patchTask } = await import("../src/utils/hermes-kanban")
+    // Seed by re-using t4 (done) so we have a stable target.
+    expect(patchTask("default", "t4", {
+      title: "draft memo v2", body: "revised body",
+    })).toBe(true)
+    const row = read("t4")!
+    expect(row.title).toBe("draft memo v2")
+    expect(row.body).toBe("revised body")
+    const es = events("t4").filter(e => e.kind === "edited")
+    expect(es.length).toBeGreaterThanOrEqual(1)
+    expect(es[es.length - 1].payload).toBeNull()
+  })
+
+  test("priority ⇒ 'reprioritized' event with JSON payload", async () => {
+    const { patchTask } = await import("../src/utils/hermes-kanban")
+    expect(patchTask("default", "t4", { priority: 7 })).toBe(true)
+    expect(read("t4")!.priority).toBe(7)
+    const es = events("t4").filter(e => e.kind === "reprioritized")
+    expect(es.length).toBeGreaterThanOrEqual(1)
+    expect(JSON.parse(es[es.length - 1].payload!)).toEqual({ priority: 7 })
+    // Clamp: negative collapses to 0, 10+ collapses to 9.
+    expect(patchTask("default", "t4", { priority: 42 })).toBe(true)
+    expect(read("t4")!.priority).toBe(9)
+    expect(patchTask("default", "t4", { priority: -3 })).toBe(true)
+    expect(read("t4")!.priority).toBe(0)
+  })
+
+  test("empty title rejected, unknown id returns false", async () => {
+    const { patchTask } = await import("../src/utils/hermes-kanban")
+    expect(() => patchTask("default", "t4", { title: "   " })).toThrow(/empty/)
+    expect(patchTask("default", "does-not-exist", { title: "x" })).toBe(false)
+  })
+})
+
+// ─── Tab-into-pane nav + field editors ───────────────────────────────
+describe("Kanban detail pane", () => {
+  test("Tab with pane open enters pane; Tab inside pane walks fields", async () => {
+    const t = await mountNode(<Kanban focused />, { width: 180, height: 48 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    // → → to 'ready' (t1), Enter opens detail.
+    act(() => t.keys.pressArrow("right")); await t.settle()
+    act(() => t.keys.pressArrow("right")); await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => /Assignee\s+researcher/.test(t.frame()))
+    // Hint while grid-tier + pane open: "Tab into pane".
+    expect(t.frame()).toContain("Tab into pane")
+    // Tab → pane tier. Title is the first field, gets the edit hint.
+    act(() => t.keys.pressTab()); await t.settle()
+    await until(t, () => t.frame().includes("Enter edit"))
+    // First Esc → back to grid (pane stays open).
+    act(() => t.keys.pressEscape()); await t.settle()
+    await until(t, () => t.frame().includes("Tab into pane"))
+    expect(t.frame()).toMatch(/Assignee\s+researcher/)  // pane still open
+    // Second Esc → pane closes.
+    act(() => t.keys.pressEscape()); await t.settle()
+    await until(t, () => !/Assignee\s+researcher/.test(t.frame()))
+    t.destroy()
+  })
+
+  test("Enter on priority row in pane → DialogSelect → direct write", async () => {
+    // Re-seed t1's priority so we have a known starting value.
+    const db = new Database(hermesPath("kanban.db"))
+    db.run("UPDATE tasks SET priority = 3 WHERE id = 't1'")
+    db.close()
+    resetKanban()
+    const t = await mountNode(<Kanban focused />, { width: 180, height: 48 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    act(() => t.keys.pressArrow("right")); await t.settle()
+    act(() => t.keys.pressArrow("right")); await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => /Assignee\s+researcher/.test(t.frame()))
+    // Tab in, then Tab twice more (title → body → assignee → priority).
+    act(() => t.keys.pressTab()); await t.settle()
+    act(() => t.keys.pressTab()); await t.settle()
+    act(() => t.keys.pressTab()); await t.settle()
+    act(() => t.keys.pressTab()); await t.settle()
+    // Priority row shows its hint when focused.
+    await until(t, () => t.frame().includes("↑↓ / Enter"))
+    // ↑ bumps priority directly (patchTask path, no dialog).
+    act(() => t.keys.pressArrow("up")); await t.settle()
+    // Read back via a fresh RO handle — herm's internal cache is RW/RO
+    // split and the write went through the RW handle.
+    const check = new Database(hermesPath("kanban.db"), { readonly: true })
+    const row = check.query("SELECT priority FROM tasks WHERE id = 't1'")
+      .get() as { priority: number }
+    check.close()
+    expect(row.priority).toBe(4)
+    t.destroy()
+  })
+})
+
+// ─── Persistence (filter masks + open boards) ────────────────────────
+describe("Kanban preferences round-trip", () => {
+  test("filter chip toggle persists across remount", async () => {
+    const prefsMod = await import("../src/utils/preferences")
+    prefsMod.reset()
+    // Start clean — no saved kanban prefs.
+    prefsMod.set("kanban", undefined as never)
+
+    const t1 = await mountNode(<Kanban focused />, { width: 180, height: 44 })
+    await until(t1, () => t1.frame().includes("Kanban · 3 boards"))
+    // Flip 'analyst' chip to include via the filter tier.
+    act(() => t1.keys.pressArrow("up")); await t1.settle()
+    act(() => t1.keys.pressKey(" "))
+    await until(t1, () => t1.frame().includes("1/5 task"))
+    t1.destroy()
+
+    // Saved?
+    prefsMod.reset()
+    const saved = prefsMod.load().kanban
+    expect(saved?.masks?.default?.who).toEqual([["analyst", "in"]])
+
+    // Remount — mask rehydrates without user input.
+    const t2 = await mountNode(<Kanban focused />, { width: 180, height: 44 })
+    await until(t2, () => t2.frame().includes("1/5 task"))
+    expect(t2.frame()).toContain("synthesize")
+    expect(t2.frame()).not.toContain("research cost")
+    // Cleanup for the rest of the suite.
+    t2.destroy()
+    prefsMod.set("kanban", undefined as never)
   })
 })

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -487,6 +487,54 @@ describe("Kanban tab", () => {
     t.destroy()
   })
 
+  test("create form: Esc in a picker returns to the form, not out", async () => {
+    const t = await mountNode(<Kanban focused />, { width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("keep me") })
+    await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle() // body
+    act(() => t.keys.pressArrow("down")); await t.settle() // assignee
+    await until(t, () => /▸ Assignee/.test(t.frame()))
+    await act(async () => { await t.keys.typeText(" ") })   // open assignee picker
+    await until(t, () => /Search profiles/.test(t.frame()))
+    act(() => t.keys.pressEscape()); await t.settle()       // Esc → back to form
+    expect(t.frame()).toContain("New Task")                 // form still open
+    expect(t.frame()).not.toMatch(/Search profiles/)        // picker closed
+    expect(t.frame()).toContain("keep me")                  // title preserved
+    // Esc again on the bare form → closes creation.
+    act(() => t.keys.pressEscape())
+    await until(t, () => !t.frame().includes("New Task"))
+    t.destroy()
+  })
+
+  test("create form: Esc in dir-path prompt backs to the workspace picker", async () => {
+    const t = await mountNode(<Kanban focused />, { width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("nested esc") })
+    await t.settle()
+    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() } // → More
+    await act(async () => { await t.keys.typeText(" ") })   // expand
+    await until(t, () => /Workspace/.test(t.frame()))
+    act(() => t.keys.pressArrow("down")); await t.settle() // tenant
+    act(() => t.keys.pressArrow("down")); await t.settle() // workspace
+    await act(async () => { await t.keys.typeText(" ") })   // open workspace picker
+    await until(t, () => /Pick a workspace kind/.test(t.frame()))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle() // → dir:…
+    act(() => t.keys.pressEnter()); await t.settle()       // → dir-path prompt
+    await until(t, () => /Directory path/.test(t.frame()))
+    act(() => t.keys.pressEscape()); await t.settle()      // Esc → back to workspace picker
+    expect(t.frame()).toMatch(/Pick a workspace kind/)
+    act(() => t.keys.pressEscape()); await t.settle()      // Esc → back to form
+    expect(t.frame()).toContain("New Task")
+    expect(t.frame()).not.toMatch(/Pick a workspace kind/)
+    t.destroy()
+  })
+
   test("D → confirm → dispatch", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({

--- a/test/keys.test.tsx
+++ b/test/keys.test.tsx
@@ -27,11 +27,11 @@ describe("KeysProvider", () => {
       ctrl: false, meta: false, shift: false, option: false, number: false,
       sequence: o.name, raw: o.name, eventType: "press" as const, source: "raw" as const, ...o,
     })
-    expect(keys.match("tab.next", ev({ name: "right", ctrl: true }))).toBe(true)
+    expect(keys.match("tab.next", ev({ name: "right", meta: true }))).toBe(true)
     expect(keys.match("tab.next", ev({ name: "right" }))).toBe(false)
     expect(keys.match("input.newline", ev({ name: "return", shift: true }))).toBe(true)
     expect(keys.match("input.newline", ev({ name: "j", ctrl: true }))).toBe(true)
-    expect(keys.print("tab.next")).toBe("Ctrl+→")
+    expect(keys.print("tab.next")).toBe("Alt+→")
     expect(keys.print("editor.open")).toBe("Ctrl+X E")
     t.destroy()
   })

--- a/test/preload.ts
+++ b/test/preload.ts
@@ -6,6 +6,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import { afterEach } from "bun:test"
+import { getTreeSitterClient } from "@opentui/core"
 
 const root = mkdtempSync(join(tmpdir(), "herm-test-"))
 const cfg = join(root, "config")
@@ -16,6 +17,20 @@ process.env.HERMES_AGENT_ROOT = join(root, "agent")
 process.env.HERM_IO_INLINE = "1"
 process.env.CONTROL = ""
 process.env.PERF = ""
+
+// OpenTUI's own Markdown.test.ts pattern: one TreeSitterClient for the
+// whole suite, created in beforeAll, destroyed in afterAll. Under bun
+// test every t.destroy() drops rendererTracker's set to 0, which
+// destroys + re-singletons the client — ~16 worker spawn/terminate
+// cycles per run. Bun 1.3.x segfaults in the worker's node:module
+// bootstrap (generateNativeModule_NodeModule → getPropertySlot @ 0x5,
+// oven-sh/bun#19650/#27463) under that churn. Seed the singleton once
+// and pin a sentinel in the tracker so size never hits 0; the single
+// worker lives for the process and tears down with it.
+await getTreeSitterClient().initialize()
+const bag = (globalThis as Record<symbol, unknown>)[Symbol.for("@opentui/core/singleton")] as
+  { RendererTracker?: { addRenderer: (r: unknown) => void } }
+bag.RendererTracker?.addRenderer({})
 
 // tips.ts scrapes <agent>/hermes_cli/tips.py at first call and caches
 // module-level. Provide a fixture so loadTips() exercises the scraper


### PR DESCRIPTION
Kanban tab
- Editable detail pane; Tab navigates into pane; filter state persists (df26ebe)
- Form-style new-task dialog (9c0fab6)
- filterable=false mode for fixed-choice select dialogs (65c73ed)
- Esc in a new-task sub-picker backs out one level, not all (4d255a0)
- ↑/↓ in the new-task body move the cursor, not field focus (631166e)
- Tighter pane spacing; fix markdown-body overlap (227139f)
Chat
- /steer + display.busy_input_mode work now (#7, f4b6c7d + 9000e17). session.steer response shape corrected; slash commands typed while streaming dispatch immediately instead of waiting for turn end; plain text while streaming honours queue/steer/interrupt from config.
- /reload-skills calls the skills.reload RPC (e4f8d07)
- Context tab reads the live system prompt from the gateway instead of state.db (53493a9)
Keys
- Tab nav moved to Alt+←/→; Ctrl+←/→ freed for word-nav / terminal pane bindings (413a6b0)
- Alt+1..9 jumps straight to tab N, no leader (#14, 7c19018). Works on kitty/wezterm/alacritty/iTerm2; intercepted on GNOME Terminal/Konsole and default macOS Terminal.
Infra
- Gateway spawns with the launch cwd, not the hermes-agent package root (#8, fb56183)
- Test suite pins one TreeSitterClient for the whole run; fixes the ~1/6 Bun worker-spawn segfault (#15, d1e9003)
- AGENTS.md: never run standalone scripts against real ~/.hermes (cc4a73e)
- .gitignore: AGENTS.local.md (80ebe23)