### PR TITLE
fix(session): re-hydrate on /compress; close outgoing sid on /new + switch

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -240,14 +240,20 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   }, [])
 
   const newSession = useCallback(async () => {
+    const prev = sidRef.current
     reset()
     summoned.current = true
     setSplash(true)
+    // Close the outgoing session so the gateway finalizes it (ends the
+    // DB row, reaps its slash_worker subprocess, drops the AIAgent from
+    // `_sessions`). Fire-and-forget — create() doesn't depend on it.
+    if (prev) void session.close(prev)
     try { setSid(await session.create()); sessionStart.current = Date.now() }
     catch {}
   }, [reset, session])
 
   const switchSession = useCallback(async (target: string) => {
+    const prev = sidRef.current
     reset()
     // Keep splash visible while the resume RPC lands so the user sees
     // the ornate frame instead of the empty-transcript welcome. summoned
@@ -262,6 +268,11 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setSid(res.id)
       sessionStart.current = Date.now()
       if (res.messages.length) dispatch({ kind: "load", messages: res.messages })
+      // Close only after resume succeeds — a failed resume leaves the
+      // user in the outgoing session, which must stay live. Skip when
+      // resuming self (prev === res.id), e.g. the boot path reusing an
+      // empty stub.
+      if (prev && prev !== res.id) void session.close(prev)
       setSplash(false)
       summoned.current = false
     } catch (err) {
@@ -298,15 +309,29 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     gwRestart()
   }, [reset, goToTab, gwRestart, toast, gw])
 
-  // Compress wrapper — toasts on start, dispatches a transcript system
-  // message carrying the headline + token line from the gateway's
-  // summary payload on completion. Upstream emits intermediate
-  // status.update{kind:"compressing"} events that already feed the
-  // status bar via gatewayEvents.ts.
+  // Compress wrapper — re-hydrates transcript + session info from the
+  // RPC response, toasts, and dispatches a summary system message.
+  //
+  // Why the re-hydrate matters: session.compress rewrites history on the
+  // gateway and `agent._compress_context` ends the old SessionDB session,
+  // opening a continuation with a new session_id. The RPC returns the
+  // post-compaction `messages` + fresh `info`. Without dispatching them
+  // here, `turn.messages` stays stuck on the pre-compaction list until
+  // the user reopens the session — at which point the old messages
+  // vanish, reading as corruption. Mirrors the Ink TUI (upstream
+  // ui-tui/src/app/slash/commands/session.ts compress handler). Upstream
+  // also emits intermediate status.update{kind:"compressing"} events that
+  // already feed the status bar via gatewayEvents.ts.
   const runCompress = useCallback(async () => {
     toast.show({ variant: "info", message: "Compressing session…" })
     const r = await session.compress()
-    if (!r || !r.summary) return
+    if (!r) return
+    if (r.info) setInfo(r.info)
+    if (r.usage) setUsage(r.usage)
+    if (Array.isArray(r.messages)) {
+      dispatch({ kind: "load", messages: transcriptToMessages(r.messages) })
+    }
+    if (!r.summary) return
     const s = r.summary
     if (s.noop) {
       toast.show({ variant: "info",
@@ -492,7 +517,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
             })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
-        case "quit": quit(renderer, sid, title); return
+        case "quit": quit(renderer, sid, title, gw); return
         case "queue":
           if (!arg) { dispatch({ kind: "system", text: `${queue.length} queued` }); return }
           setQueue(q => [...q, arg]); return
@@ -923,7 +948,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     // the head once turn.streaming flips false.
     queued: queue.length,
     onFlushQueue: doInterrupt,
-    onQuit: () => quit(renderer, sid, title),
+    onQuit: () => quit(renderer, sid, title, gw),
     onInterruptNotice: () => dispatch({ kind: "interrupt.notice", text: "Press Escape again to interrupt" }),
     onCopyLast: () => { copyLast() },
     onAttachClipboard: attachClipboard,

--- a/src/app/exit.ts
+++ b/src/app/exit.ts
@@ -19,9 +19,16 @@ export function quit(
   renderer: { destroy: () => void },
   sid?: string,
   title?: string,
+  gw?: { kill: () => void },
 ): never {
   if (done) process.exit(0)
   done = true
+  // Explicit SIGTERM to the gateway so its signal handler runs the
+  // graceful sys.exit(0) → atexit → _shutdown_sessions path inside the
+  // grace window. Without this we rely on stdin EOF, which works, but
+  // the explicit signal starts cleanup sooner and matches Ink TUI's
+  // setupGracefulExit cleanup.
+  try { gw?.kill() } catch {}
   renderer.destroy()
   if (process.stdout.isTTY && sid) {
     const t = title ? `  —  ${title.slice(0, 60)}` : ""

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -6,10 +6,22 @@ import * as sdb from "../utils/sessions-db"
 import { useGateway } from "./gateway"
 import { transcriptToMessages } from "./turnReducer"
 import type { Launch } from "./launch"
-import type { SessionResumeResponse, SessionCreateResponse } from "../utils/gateway-types"
-import type { Message } from "../types/message"
+import type {
+  SessionResumeResponse,
+  SessionCreateResponse,
+  SessionInfo,
+  TranscriptMessage,
+} from "../utils/gateway-types"
+import type { Message, Usage } from "../types/message"
 
-/** session.compress response shape — see upstream fc7f55f49. */
+/** session.compress response shape — see upstream fc7f55f49.
+ *
+ *  `messages` + `info` carry the post-compaction transcript and fresh
+ *  session metadata; the gateway rewrites history in place and rotates
+ *  session_id (agent._compress_context ends the old DB session and opens
+ *  a continuation). Callers MUST re-hydrate local transcript state from
+ *  `messages` — otherwise the TUI keeps the pre-compaction list and the
+ *  next resume snaps it to the compacted history, looking like data loss. */
 export type CompressResult = {
   status?: "compressed" | "skipped"
   removed?: number
@@ -17,6 +29,9 @@ export type CompressResult = {
   after_messages?: number
   before_tokens?: number
   after_tokens?: number
+  messages?: TranscriptMessage[]
+  info?: SessionInfo
+  usage?: Usage
   summary?: {
     noop?: boolean
     headline?: string
@@ -32,6 +47,8 @@ type SessionOps = {
   boot: (launch: Launch) => Promise<Booted>
   create: () => Promise<string>
   resume: (sid: string) => Promise<{ id: string; messages: Message[] }>
+  /** Finalize a gateway session (best-effort — swallows errors). */
+  close: (sid: string) => Promise<void>
   interrupt: () => Promise<void>
   branch: (name?: string) => Promise<string | null>
   compress: () => Promise<CompressResult | null>
@@ -54,6 +71,21 @@ export function useSession(): SessionOps {
     const res = await gw.request<SessionCreateResponse>("session.create", {})
     gw.setSession(res.session_id)
     return res.session_id
+  }, [gw])
+
+  // Finalize a gateway session: marks the DB row ended, tears down the
+  // per-session slash_worker subprocess, unregisters the approval
+  // notifier, and drops the AIAgent from the gateway's `_sessions` map.
+  // Without this, /new and session-switch leak one HermesCLI child
+  // (slash_worker) + one live AIAgent per hop until quit, and the row's
+  // `ended_at IS NULL` throws off lineage classification in Sessions
+  // tab (sessions-db.ts SUB/CONT predicates). Parity with Ink TUI's
+  // useSessionLifecycle.closeSession. Pass `session_id` explicitly so
+  // auto-injection doesn't close whatever sid the gateway already
+  // switched to.
+  const close = useCallback(async (sid: string) => {
+    if (!sid) return
+    try { await gw.request("session.close", { session_id: sid }) } catch {}
   }, [gw])
 
   const boot = useCallback(async (launch: Launch): Promise<Booted> => {
@@ -96,7 +128,7 @@ export function useSession(): SessionOps {
   }, [gw])
 
   return useMemo(
-    () => ({ boot, create, resume, interrupt, branch, compress, undo }),
-    [boot, create, resume, interrupt, branch, compress, undo],
+    () => ({ boot, create, resume, close, interrupt, branch, compress, undo }),
+    [boot, create, resume, close, interrupt, branch, compress, undo],
   )
 }

--- a/test/compress.test.tsx
+++ b/test/compress.test.tsx
@@ -1,0 +1,123 @@
+// Regression: /compress must re-hydrate the local transcript from the
+// gateway's response.  Without this, `turn.messages` stays stuck on the
+// pre-compaction list until the user reopens the session — at which
+// point the old messages vanish from the UI, reading as data loss.
+//
+// Upstream session.compress returns { messages, info, usage, summary, ... };
+// the gateway also rotates session_id (agent._compress_context ends the
+// old DB session and opens a continuation).  See the compress handler
+// in ui-tui/src/app/slash/commands/session.ts for the canonical flow
+// we mirror.
+
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+
+const preCompactMessages = [
+  { role: "user" as const, text: "draft the rfc" },
+  { role: "assistant" as const, text: "Here's a long draft of the RFC …" },
+  { role: "user" as const, text: "shorter" },
+  { role: "assistant" as const, text: "Tighter version …" },
+]
+
+const postCompactMessages = [
+  { role: "user" as const, text: "MARKER_POST_COMPACT_USER" },
+  { role: "assistant" as const, text: "Tighter version …" },
+]
+
+const mkGw = () => new MockGateway({
+  "commands.catalog": () => ({ pairs: [["/compress", "compress transcript"]] }),
+  "session.resume": () => ({
+    session_id: "pre-sid",
+    messages: preCompactMessages,
+  }),
+  "session.compress": () => ({
+    status: "compressed",
+    removed: 2,
+    before_messages: 4,
+    after_messages: 3,
+    before_tokens: 8000,
+    after_tokens: 2500,
+    messages: postCompactMessages,
+    info: { model: "test-model", session_id: "post-sid", tools: {}, skills: {} },
+    usage: { input: 1000, output: 500, total: 1500, context_used: 2500, context_max: 200000, context_percent: 1, compressions: 1 },
+    summary: { headline: "Compacted 4→3 messages", token_line: "8.0k → 2.5k" },
+  }),
+})
+
+const run = async (t: Awaited<ReturnType<typeof mount>>) => {
+  await act(async () => { await t.keys.typeText("/compress") })
+  act(() => t.keys.pressEnter())
+}
+
+describe("/compress", () => {
+  test("re-hydrates transcript from rpc response messages", async () => {
+    const gw = mkGw()
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
+    await until(t, () => t.frame().includes("draft the rfc"))
+
+    await run(t)
+
+    // Transcript reflects the compacted history: marker row present,
+    // the now-removed pre-compaction turn ("draft the rfc") is gone.
+    await until(t, () => t.frame().includes("MARKER_POST_COMPACT_USER"))
+    expect(t.frame()).not.toContain("draft the rfc")
+
+    t.destroy()
+  })
+
+  test("absorbs info.session_id rotation", async () => {
+    const gw = mkGw()
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
+    await until(t, () => t.frame().includes("draft the rfc"))
+
+    await run(t)
+    await until(t, () => t.frame().includes("MARKER_POST_COMPACT_USER"))
+
+    // setInfo() fed the new session_id; follow-up RPCs target the
+    // continuation, not the ended parent. session.title after /compress
+    // is the cheapest probe — its response flows back into state.
+    await act(async () => { await t.keys.typeText("/title After Compress") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("session.title")?.params.title === "After Compress")
+
+    t.destroy()
+  })
+
+  test("summary headline dispatches as system line + toast", async () => {
+    const gw = mkGw()
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
+    await until(t, () => t.frame().includes("draft the rfc"))
+
+    await run(t)
+
+    // Headline lands in transcript (system row).
+    await until(t, () => t.frame().includes("Compacted 4→3 messages"))
+    expect(t.frame()).toContain("8.0k → 2.5k")
+
+    t.destroy()
+  })
+
+  test("noop response doesn't wipe the transcript", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/compress", "compress transcript"]] }),
+      "session.resume": () => ({ session_id: "pre-sid", messages: preCompactMessages }),
+      "session.compress": () => ({
+        status: "skipped",
+        removed: 0,
+        summary: { noop: true, headline: "No changes — 4 messages" },
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
+    await until(t, () => t.frame().includes("draft the rfc"))
+
+    await run(t)
+    await t.settle()
+
+    // Messages untouched (no `messages` field in response) — original
+    // turns still visible.
+    expect(t.frame()).toContain("draft the rfc")
+
+    t.destroy()
+  })
+})

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -51,6 +51,7 @@ export class MockGateway extends EventEmitter implements Gateway {
     this.on$("cli.exec", () => ({ blocked: false, code: 0, output: "✓" }))
     this.on$("session.title", p => ({ title: p.title ?? "" }))
     this.on$("session.undo", () => ({ removed: 2 }))
+    this.on$("session.close", () => ({ closed: true }))
     this.on$("session.history", () => ({ count: 0, messages: [] }))
     this.on$("session.save", () => ({ file: "/tmp/conv.json" }))
     this.on$("session.usage", () => ({}))

--- a/test/session-close.test.tsx
+++ b/test/session-close.test.tsx
@@ -1,0 +1,97 @@
+// Regression: /new and session-switch must finalize the outgoing
+// gateway session via session.close. Without it the gateway leaks one
+// slash_worker subprocess + one live AIAgent per hop and leaves the
+// DB row's `ended_at IS NULL`, which breaks lineage classification
+// (sessions-db.ts SUB/CONT predicates) until quit. Parity with Ink
+// TUI's useSessionLifecycle.closeSession.
+
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+
+describe("session.close", () => {
+  test("/new closes the outgoing session", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/new", "new session"]] }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    // Boot path created (or resumed) → sid is test-sid.
+    expect(t.gw.last("session.close")).toBeUndefined()
+
+    await act(async () => { await t.keys.typeText("/new") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("session.close") !== undefined)
+
+    expect(t.gw.last("session.close")?.params.session_id).toBe("test-sid")
+    expect(t.gw.last("session.create")).toBeDefined()
+
+    t.destroy()
+  })
+
+  test("switchSession closes prev after resume succeeds", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "first", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    // Boot resumed "first"; no close yet.
+    expect(t.gw.last("session.close")).toBeUndefined()
+
+    // Switch via /resume <sid> — routes through switchSession.
+    await act(async () => { await t.keys.typeText("/resume second") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("session.close") !== undefined)
+
+    expect(t.gw.last("session.close")?.params.session_id).toBe("first")
+    // Resume landed on the target — close ran only after that.
+    const ri = gw.calls.findIndex(c => c.method === "session.resume" && c.params.session_id === "second")
+    const ci = gw.calls.findIndex(c => c.method === "session.close")
+    expect(ri).toBeGreaterThan(-1)
+    expect(ci).toBeGreaterThan(ri)
+
+    t.destroy()
+  })
+
+  test("switchSession keeps prev live when resume fails", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "session.resume": p => {
+        if (p.session_id === "bad") throw new Error("nope")
+        return { session_id: p.session_id, messages: [] }
+      },
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "first", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/resume bad") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Failed to resume"))
+
+    // No close — user is still on "first", which must stay live.
+    expect(t.gw.last("session.close")).toBeUndefined()
+
+    t.destroy()
+  })
+
+  test("switchSession to self does not close", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "same", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/resume same") })
+    act(() => t.keys.pressEnter())
+    // Wait for the second resume (first was boot) to land.
+    await until(t, () => gw.calls.filter(c => c.method === "session.resume").length >= 2)
+
+    expect(t.gw.last("session.close")).toBeUndefined()
+
+    t.destroy()
+  })
+})


### PR DESCRIPTION
Two session-lifecycle sync gaps with tui_gateway, both behind reported "session corruption/loss" in herm.

## /compress left the transcript stale

`session.compress` returns `{messages, info, usage, ...}` and rotates `agent.session_id` (ends the old DB row, opens a continuation). herm's `CompressResult` type omitted `messages`/`info`/`usage` and `runCompress` only toasted the headline, so `turn.messages` stayed at the pre-compaction list. The next resume/undo snapped to server truth and the old messages vanished from view, which users read as data loss.

Now `runCompress` dispatches `{kind:"load"}` from `r.messages` and applies `r.info`/`r.usage`, matching Ink TUI's compress handler (`ui-tui/src/app/slash/commands/session.ts`).

## /new, switch, /branch leaked the outgoing session

herm never called `session.close` on the outgoing sid. Each hop leaked one live `AIAgent` + one `slash_worker` HermesCLI subprocess in the gateway until quit, and left the DB row's `ended_at IS NULL` so `sessions-db.ts` SUB/CONT lineage predicates misclassified continuations as subagents mid-run.

`useSession` now exposes `close(sid)`. `newSession` closes prev before create; `switchSession` closes prev after resume succeeds (failed resume keeps prev live; resume-to-self skips). `fork()` is covered transitively via `switchSession`. `quit()` now SIGTERMs the gateway explicitly instead of relying on stdin EOF, matching Ink's `setupGracefulExit` cleanup.

## Not addressed

Mid-turn auto-compaction (threshold-triggered inside `run_conversation`) still has no event carrying the post-compaction transcript. Same gap exists in the Ink TUI. Needs either an upstream tui_gateway event or a client-side `session.history` refetch when `usage.compressions` bumps.

## Tests

`test/compress.test.tsx` (4), `test/session-close.test.tsx` (4). 735 pass, 0 fail. `bunx tsc --noEmit`: only pre-existing `test/context.test.tsx(136,15)`.