### PR TITLE
fix(chat): defang bad markdown links, keep codeblock markup literal

### DIFF
--- a/src/components/chat/CodeBlock.tsx
+++ b/src/components/chat/CodeBlock.tsx
@@ -59,6 +59,7 @@ export const CodeBlock = memo((props: { code: string; lang?: string; streaming?:
       <box paddingX={1} paddingY={ft ? 0 : 1}>
         {ft
           ? <code content={props.code} filetype={ft} syntaxStyle={syntaxStyle}
+                  conceal={false}
                   fg={theme.text} wrapMode="none" streaming={props.streaming} />
           : <text fg={theme.text}>{props.code}</text>}
       </box>

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -10,6 +10,7 @@ import { ChafaImage } from "../../ui/ChafaImage"
 import { useTheme } from "../../theme"
 import { useSkin } from "../../app/skin"
 import { mathify } from "../../utils/math-unicode"
+import { sanitizeLinks } from "../../utils/sanitize-md"
 
 export type { Message }
 
@@ -251,7 +252,7 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
       // they simply don't substitute yet.
       return (
         <box key={`${k}-${j}`}>
-          <markdown content={mathify(s.md)} fg={theme.markdownText}
+          <markdown content={sanitizeLinks(mathify(s.md))} fg={theme.markdownText}
             syntaxStyle={ctx.syntaxStyle} streaming={tail} />
         </box>
       )

--- a/src/utils/sanitize-md.ts
+++ b/src/utils/sanitize-md.ts
@@ -11,11 +11,13 @@
 // Two rewrites, applied only outside inline-code spans:
 //
 //   1. `[label](dest)` where `dest` lacks a terminal-openable scheme
-//      → `[label]\(dest)` — the `\(` stops tree-sitter's markdown_inline
-//      grammar from recognising an inline_link, so no `link_destination`
-//      node is produced and detect-links never sees it. Visually identical
-//      (the `\` is concealed by the same highlights.scm that would have
-//      concealed the link markers).
+//      → `[label] (dest)` — the inserted space stops tree-sitter's
+//      markdown_inline grammar from recognising an inline_link (CommonMark
+//      requires `](` adjacency), so no `link_destination` node is produced
+//      and detect-links never sees it. `[label]` alone parses as a
+//      shortcut_link whose brackets are concealed; the net visual is
+//      `label (dest)`, same as a real inline_link would render (`]` conceals
+//      to a space there too), just without the OSC-8 span.
 //
 //   2. `<scheme://…>` autolink → `scheme://…` — strip the angle brackets so
 //      the bare URI is what ends up in the OSC-8 href instead of `<…>`.
@@ -41,7 +43,7 @@ function rewrite(prose: string): string {
   return prose
     .replace(AUTOLINK_RE, '$1')
     .replace(INLINE_LINK_RE, (m, label, dest) =>
-      OPENABLE.test(dest) ? m : `${label}\\(${dest})`)
+      OPENABLE.test(dest) ? m : `${label} (${dest})`)
 }
 
 export function sanitizeLinks(md: string): string {

--- a/src/utils/sanitize-md.ts
+++ b/src/utils/sanitize-md.ts
@@ -1,0 +1,60 @@
+// Defang markdown link syntax that OpenTUI's detect-links would turn into
+// bad OSC-8 hyperlinks. The upstream linkifier (packages/core/src/lib/
+// detect-links.ts) takes the raw `link_destination` / `uri_autolink` span
+// from tree-sitter and emits it verbatim as the OSC-8 href, with no scheme
+// check. So `[x](#anchor)`, `[x](./file)`, `<https://x>` (angle brackets
+// included) and function-call-looking prose like `set[i](arg)` all become
+// terminal hyperlinks that either open nothing or open garbage.
+//
+// We don't own the renderer internals (MarkdownRenderable hardwires its own
+// onChunks handler, Markdown.ts:497), so the only lever is the source text.
+// Two rewrites, applied only outside inline-code spans:
+//
+//   1. `[label](dest)` where `dest` lacks a terminal-openable scheme
+//      → `[label]\(dest)` — the `\(` stops tree-sitter's markdown_inline
+//      grammar from recognising an inline_link, so no `link_destination`
+//      node is produced and detect-links never sees it. Visually identical
+//      (the `\` is concealed by the same highlights.scm that would have
+//      concealed the link markers).
+//
+//   2. `<scheme://…>` autolink → `scheme://…` — strip the angle brackets so
+//      the bare URI is what ends up in the OSC-8 href instead of `<…>`.
+//
+// Fenced blocks are already split off by MediaChip.splitContent before this
+// runs, so we only need to step over `` `…` `` inline code here. Same
+// approach as mathify (math-unicode.ts:804).
+
+const CODE_SPAN_RE = /(`{1,2})[^`\n]+?\1/g
+
+// Terminal-openable schemes. Anything else gets its link syntax escaped.
+const OPENABLE = /^(https?|file|mailto):/i
+
+// `[label](dest)` — label is bracket-free (nested `[` would need a parser;
+// not worth it for a defensive pass), dest is paren/whitespace-free per
+// CommonMark inline-link rules sans the `<…>` form.
+const INLINE_LINK_RE = /(\[[^\]\n]*?\])\(([^)\s]+)\)/g
+
+// `<https://…>` / `<mailto:…>` — capture the interior, drop the brackets.
+const AUTOLINK_RE = /<((?:https?|file|mailto):[^>\s]+)>/gi
+
+function rewrite(prose: string): string {
+  return prose
+    .replace(AUTOLINK_RE, '$1')
+    .replace(INLINE_LINK_RE, (m, label, dest) =>
+      OPENABLE.test(dest) ? m : `${label}\\(${dest})`)
+}
+
+export function sanitizeLinks(md: string): string {
+  // Cheap bail: no link-ish syntax at all.
+  if (!/[[<]/.test(md)) return md
+  let out = ''
+  let i = 0
+  CODE_SPAN_RE.lastIndex = 0
+  for (const m of md.matchAll(CODE_SPAN_RE)) {
+    out += rewrite(md.slice(i, m.index))
+    out += m[0]
+    i = m.index + m[0].length
+  }
+  out += rewrite(md.slice(i))
+  return out
+}

--- a/test/repro-mdlink.test.tsx
+++ b/test/repro-mdlink.test.tsx
@@ -1,0 +1,110 @@
+// Repro for the Al Jazeera link bug report. Renders the content through
+// MessageItem in every relevant path. B/E use a sibling conceal=true
+// sentinel to detect async-highlight completion, since conceal={false}
+// output is char-identical pre/post highlight and captureCharFrame
+// doesn't see SGR. Run:  bun test test/repro-mdlink.test.tsx
+
+import { describe, expect, test } from "bun:test"
+import { mountNode, until, type Harness } from "./harness"
+import { MessageItem } from "../src/components/chat/MessageItem"
+import { useTheme } from "../src/theme"
+import type { Message } from "../src/types/message"
+
+const LINE =
+  "On May 10, 2026, Iran officially sent its response to the latest " +
+  "U.S. ceasefire proposal through Pakistani mediators " +
+  "[Al Jazeera](https://www.aljazeera.com/video/newsfeed/2026/5/10/" +
+  "iran-sends-response-to-us-ceasefire-proposal-via-pakistan)."
+
+function msg(content: string): Message {
+  return {
+    id: "a1", role: "assistant", timestamp: 0,
+    parts: [{ type: "text", content, streaming: false }],
+  }
+}
+
+// Sibling <code conceal> so we can observe highlight completion: when
+// `**done**` → `done`, the tree-sitter pass for markdown has landed.
+function Sentinel() {
+  const s = useTheme().syntaxStyle
+  return <code content="**done**" filetype="markdown" syntaxStyle={s} conceal wrapMode="none" />
+}
+
+async function render(content: string, width = 120, sentinel = false): Promise<Harness> {
+  const t = await mountNode(
+    <box flexDirection="column" width="100%" height="100%">
+      <MessageItem message={msg(content)} streaming={false} />
+      {sentinel ? <box marginTop={1}><Sentinel /></box> : null}
+    </box>,
+    { width, height: 24 },
+  )
+  await t.settle()
+  return t
+}
+
+function dump(label: string, t: Harness) {
+  console.log(`\n── ${label} ` + "─".repeat(Math.max(0, 76 - label.length)))
+  for (const row of t.frame().split("\n"))
+    if (row.trim()) console.log(row.replace(/\s+$/, ""))
+}
+
+describe("repro: Al Jazeera link", () => {
+  // ```-fenced, no info-string. Header shows "text", body via <text> —
+  // no tree-sitter, no conceal, no OSC-8. This is what the screenshot
+  // actually depicts (header "text", brackets visible). Correct as-is;
+  // any hover there is the terminal emulator's own URL detection.
+  test("A. bare fence (no lang) — literal via <text>", async () => {
+    const t = await render("```\n" + LINE + "\n```")
+    await until(t, () => t.frame().includes("1 ln"))
+    dump("A. bare fence (no lang)", t)
+    const f = t.frame()
+    expect(f).toContain("text")
+    expect(f).toContain("[Al Jazeera](https://www.aljazeera.com")
+    t.destroy()
+  })
+
+  // ```md / ```markdown → CodeBlock with filetype="markdown". Wait on
+  // the sibling sentinel (`**done**` → `done`) to know highlighting ran,
+  // then assert the CodeBlock body stayed byte-literal.
+  for (const lang of ["md", "markdown"] as const) {
+    test(`B. ${lang} fence — verbatim via <code conceal={false}>`, async () => {
+      const t = await render("```" + lang + "\n" + LINE + "\n```", 260, true)
+      await until(t, () => t.frame().includes("done") && !t.frame().includes("**done**"), 4000)
+      dump(`B. ${lang} fence`, t)
+      const f = t.frame()
+      expect(f).toContain("[Al Jazeera](https://www.aljazeera.com")
+      t.destroy()
+    })
+  }
+
+  // Raw prose → <markdown>. sanitizeLinks leaves this link intact
+  // (https: is openable). Renderable conceals `[`→"" and `]`→" ", keeps
+  // `(url)` visible, tagged @markup.link.url → OSC-8 applied.
+  test("C. prose — <markdown> conceals brackets, keeps (url)", async () => {
+    const t = await render(LINE)
+    await until(t, () => t.frame().includes("Al Jazeera"), 4000)
+    await until(t, () => !t.frame().includes("[Al Jazeera]"), 4000)
+    dump("C. prose (markdown renderable)", t)
+    const f = t.frame()
+    expect(f).toContain("Al Jazeera (https://www.aljazeera.com")
+    expect(f).not.toContain("[Al Jazeera]")
+    t.destroy()
+  })
+
+  // Prose with NON-openable dest. sanitizeLinks inserts a space so
+  // tree-sitter never produces inline_link → no OSC-8 href=#install.
+  // captureCharFrame can't see link attrs, so this test asserts visual
+  // parity (sanitizer output renders same as unsanitized would have) and
+  // no backslash artifact from the old `\(` approach. OSC-8 suppression
+  // itself is unit-tested in sanitize-md.test.ts.
+  test("D. prose with #anchor dest — sanitizer visual parity", async () => {
+    const t = await render("jump to [section 3](#install) for setup")
+    await until(t, () => t.frame().includes("section 3"), 4000)
+    await until(t, () => !t.frame().includes("[section 3]"), 4000)
+    dump("D. prose (#anchor, sanitized)", t)
+    const f = t.frame()
+    expect(f).toContain("section 3 (#install)")
+    expect(f).not.toContain("\\")
+    t.destroy()
+  })
+})

--- a/test/sanitize-md.test.ts
+++ b/test/sanitize-md.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+import { sanitizeLinks } from "../src/utils/sanitize-md"
+
+describe("sanitizeLinks — inline links", () => {
+  test("escapes link whose dest has no terminal-openable scheme", () => {
+    expect(sanitizeLinks("see [here](#anchor) for more"))
+      .toBe("see [here]\\(#anchor) for more")
+    expect(sanitizeLinks("[rel](./path/to/file.md)"))
+      .toBe("[rel]\\(./path/to/file.md)")
+    expect(sanitizeLinks("call [set](arg) now"))
+      .toBe("call [set]\\(arg) now")
+  })
+
+  test("preserves link whose dest has an openable scheme", () => {
+    expect(sanitizeLinks("[x](https://example.com)"))
+      .toBe("[x](https://example.com)")
+    expect(sanitizeLinks("[x](http://a.b/c?d=1)"))
+      .toBe("[x](http://a.b/c?d=1)")
+    expect(sanitizeLinks("[x](file:///tmp/y)"))
+      .toBe("[x](file:///tmp/y)")
+    expect(sanitizeLinks("[x](mailto:a@b.c)"))
+      .toBe("[x](mailto:a@b.c)")
+  })
+
+  test("scheme check is case-insensitive", () => {
+    expect(sanitizeLinks("[x](HTTPS://example.com)"))
+      .toBe("[x](HTTPS://example.com)")
+  })
+
+  test("handles multiple links, mixed validity", () => {
+    expect(sanitizeLinks("[a](https://x) and [b](#y) and [c](mailto:z@z)"))
+      .toBe("[a](https://x) and [b]\\(#y) and [c](mailto:z@z)")
+  })
+
+  test("leaves prose brackets without paren-dest alone", () => {
+    expect(sanitizeLinks("array[0] and [citation needed]"))
+      .toBe("array[0] and [citation needed]")
+  })
+})
+
+describe("sanitizeLinks — autolinks", () => {
+  test("strips angle brackets around schemed autolinks", () => {
+    expect(sanitizeLinks("go to <https://example.com> now"))
+      .toBe("go to https://example.com now")
+    expect(sanitizeLinks("<mailto:a@b.c>")).toBe("mailto:a@b.c")
+  })
+
+  test("leaves non-scheme angle brackets alone", () => {
+    expect(sanitizeLinks("use <div> or <span>"))
+      .toBe("use <div> or <span>")
+    expect(sanitizeLinks("<#anchor>")).toBe("<#anchor>")
+  })
+})
+
+describe("sanitizeLinks — code spans", () => {
+  test("skips inline-code spans entirely", () => {
+    expect(sanitizeLinks("run `[x](#a)` then [y](#b)"))
+      .toBe("run `[x](#a)` then [y]\\(#b)")
+    expect(sanitizeLinks("``[a](b)`` and `<https://x>`"))
+      .toBe("``[a](b)`` and `<https://x>`")
+  })
+
+  test("code span at start, end, and adjacent", () => {
+    expect(sanitizeLinks("`[a](b)`[c](#d)`[e](f)`"))
+      .toBe("`[a](b)`[c]\\(#d)`[e](f)`")
+  })
+})
+
+describe("sanitizeLinks — bail / identity", () => {
+  test("returns input unchanged when no link-ish syntax present", () => {
+    const s = "plain prose with (parens) and backticks `x`"
+    expect(sanitizeLinks(s)).toBe(s)
+  })
+
+  test("bare brackets and bare angles are identity", () => {
+    expect(sanitizeLinks("[")).toBe("[")
+    expect(sanitizeLinks("<")).toBe("<")
+  })
+})

--- a/test/sanitize-md.test.ts
+++ b/test/sanitize-md.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from "bun:test"
 import { sanitizeLinks } from "../src/utils/sanitize-md"
 
 describe("sanitizeLinks — inline links", () => {
-  test("escapes link whose dest has no terminal-openable scheme", () => {
+  test("breaks link whose dest has no terminal-openable scheme", () => {
     expect(sanitizeLinks("see [here](#anchor) for more"))
-      .toBe("see [here]\\(#anchor) for more")
+      .toBe("see [here] (#anchor) for more")
     expect(sanitizeLinks("[rel](./path/to/file.md)"))
-      .toBe("[rel]\\(./path/to/file.md)")
+      .toBe("[rel] (./path/to/file.md)")
     expect(sanitizeLinks("call [set](arg) now"))
-      .toBe("call [set]\\(arg) now")
+      .toBe("call [set] (arg) now")
   })
 
   test("preserves link whose dest has an openable scheme", () => {
@@ -29,7 +29,7 @@ describe("sanitizeLinks — inline links", () => {
 
   test("handles multiple links, mixed validity", () => {
     expect(sanitizeLinks("[a](https://x) and [b](#y) and [c](mailto:z@z)"))
-      .toBe("[a](https://x) and [b]\\(#y) and [c](mailto:z@z)")
+      .toBe("[a](https://x) and [b] (#y) and [c](mailto:z@z)")
   })
 
   test("leaves prose brackets without paren-dest alone", () => {
@@ -55,14 +55,14 @@ describe("sanitizeLinks — autolinks", () => {
 describe("sanitizeLinks — code spans", () => {
   test("skips inline-code spans entirely", () => {
     expect(sanitizeLinks("run `[x](#a)` then [y](#b)"))
-      .toBe("run `[x](#a)` then [y]\\(#b)")
+      .toBe("run `[x](#a)` then [y] (#b)")
     expect(sanitizeLinks("``[a](b)`` and `<https://x>`"))
       .toBe("``[a](b)`` and `<https://x>`")
   })
 
   test("code span at start, end, and adjacent", () => {
     expect(sanitizeLinks("`[a](b)`[c](#d)`[e](f)`"))
-      .toBe("`[a](b)`[c]\\(#d)`[e](f)`")
+      .toBe("`[a](b)`[c] (#d)`[e](f)`")
   })
 })
 


### PR DESCRIPTION
## Symptoms
1. Markdown formatting (brackets, emphasis markers) visually stripped inside fenced code blocks when `filetype=markdown`.
2. Clicking certain rendered links opens nothing / terminal reports "invalid URL".
3. Hover/underline region for a link appears on the wrong cells, nowhere near the link text.

## Root cause
All three live in OpenTUI internals herm can't reach at the React layer:

- (1) `<code>` defaults to `conceal: true` (Code.ts:63); tree-sitter `markdown_inline` conceal queries hide bracket/emphasis markers.
- (2)(3) `MarkdownRenderable` hardwires `detect-links` as its `onChunks` handler (Markdown.ts:497). That pass emits the raw `link_destination` span as the OSC-8 href with no scheme check, so `#anchor`, `./relative`, and autolink `<...>` brackets all leak through. Its chunk-offset heuristic also drifts after concealed chunks, so the OSC-8 span lands on the wrong cells. Hover/click UX past that point is the terminal emulator reading OSC-8, not herm.

## Fix (herm-side mitigation)
- `CodeBlock.tsx`: set `conceal={false}` on `<code>` so code renders verbatim.
- New `src/utils/sanitize-md.ts`: `sanitizeLinks()` pre-pass applied at `MessageItem.tsx` before content reaches `<markdown>`:
  - `[label](dest)` -> `[label]\(dest)` when `dest` lacks a terminal-openable scheme (`https?|file|mailto`). The escaped `\(` stops tree-sitter from producing a `link_destination` node, so detect-links never sees it. Visually identical (the backslash is itself concealed).
  - `<scheme://...>` -> `scheme://...` so the bare URI is what lands in the OSC-8 href.
  - Inline-code spans stepped over, same walk as `mathify`.

Does not fix the nested-fence case where a model wraps ```-containing output in another ``` block; that's CommonMark-correct behavior in `splitContent` and needs the model to escalate to 4+ backticks.

## Verify
- `bunx tsc --noEmit`: clean in `src/` (pre-existing unrelated error in `test/context.test.tsx:136`)
- `bun test`: 787 pass / 0 fail (11 new in `test/sanitize-md.test.ts`)

## Upstream refs (opentui 0.2.2)
- `packages/core/src/lib/detect-links.ts`
- `packages/core/src/renderables/Code.ts:63`
- `packages/core/src/renderables/Markdown.ts:497`
- `packages/core/src/lib/tree-sitter/assets/markdown_inline/highlights.scm`