### PR TITLE
feat(tabs): consolidate 12 top-level tabs into 4 groups with sub-tabs

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,17 +13,9 @@ import type { AvatarState } from "./components/avatar/states"
 import { TabBar } from "./components/tabs/TabBar"
 import { Sidebar } from "./components/sidebar/Sidebar"
 import { Chat } from "./tabs/Chat"
-import { Context } from "./tabs/Context"
-import { Sessions } from "./tabs/Sessions"
-import { Agents } from "./tabs/Agents"
-import { Analytics } from "./tabs/Analytics"
-import { Memory } from "./tabs/Memory"
-import { Skills } from "./tabs/Skills"
-import { Config } from "./tabs/Config"
-import { Cron } from "./tabs/Cron"
-import { Toolsets } from "./tabs/Toolsets"
-import { Env } from "./tabs/Env"
-import { Kanban } from "./tabs/Kanban"
+import { SessionsGroup } from "./tabs/SessionsGroup"
+import { Automation } from "./tabs/Automation"
+import { ConfigGroup } from "./tabs/ConfigGroup"
 import type { Usage } from "./types/message"
 import { copySelection, copy as clipCopy } from "./utils/clipboard"
 import { ThemeProvider, useTheme } from "./theme"
@@ -62,7 +54,7 @@ import { useSession } from "./app/useSession"
 import { SkinProvider, deriveSkin, SKINS, type SkinState } from "./app/skin"
 import { useAppKeys, redraw } from "./app/useAppKeys"
 import { quit } from "./app/exit"
-import { TABS, TAB_MAX, CHAT_TAB, TAB_SLASH } from "./app/tabs"
+import { TABS, TAB_MAX, CHAT_TAB, SESSIONS_TAB, AUTOMATION_TAB, CONFIG_TAB, SUB_TABS, TAB_SLASH } from "./app/tabs"
 import { activeProfileName } from "./utils/hermes-profiles"
 import { rehome } from "./home/rehome"
 import { useHome, home } from "./home"
@@ -104,6 +96,14 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [sid, setSid] = useState("")
   const sidRef = useRef(sid); sidRef.current = sid
   const [tab, setTab] = useState(CHAT_TAB)
+  // Sub-tab per group — Chat has none, so key 0 is unused.
+  // Defensive clamp lives inside each group (SessionsGroup/Automation/
+  // ConfigGroup) so a shrinking SUB_TABS list doesn't render blank.
+  const [subTabs, setSubTabs] = useState<Record<number, number>>(
+    () => ({ [SESSIONS_TAB]: 0, [AUTOMATION_TAB]: 0, [CONFIG_TAB]: 0 }),
+  )
+  const setSub = useCallback((tabIdx: number, sub: number) =>
+    setSubTabs(prev => prev[tabIdx] === sub ? prev : { ...prev, [tabIdx]: sub }), [])
   const [hideSidebar, setHideSidebar] = useState(false)
   const [usage, setUsage] = useState<Usage | undefined>(undefined)
   const [info, setInfo] = useState<SessionInfo | null>(null)
@@ -111,6 +111,14 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [focusRegion, setFocusRegion] = useState<"input" | "content">("input")
   const goToTab = useCallback((t: number) => {
     setTab(t)
+    setFocusRegion(t === CHAT_TAB ? "input" : "content")
+  }, [])
+  // Slash-driven deep-link: jumps to a top-level tab AND sets its
+  // sub-tab. goToTab preserves whatever sub-tab the user last picked;
+  // goTo overrides it (what /memory or /cron should do).
+  const goTo = useCallback((t: number, sub: number) => {
+    setTab(t)
+    setSubTabs(prev => prev[t] === sub ? prev : { ...prev, [t]: sub })
     setFocusRegion(t === CHAT_TAB ? "input" : "content")
   }, [])
   const [status, setStatus] = useState("")
@@ -537,7 +545,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
         // ── parity: session-mutating (slash-worker can't service these) ──
         case "resume":
           if (arg) { void switchSession(arg); return }
-          goToTab(TAB_SLASH.sessions); return
+          goTo(TAB_SLASH.sessions.tab, TAB_SLASH.sessions.sub); return
         case "branch":
           session.branch(arg || undefined).then(id => id
             ? void switchSession(id)
@@ -685,7 +693,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     }
     if (c.target !== "gateway" || !ready) return
     const jump = TAB_SLASH[c.name]
-    if (jump !== undefined && !arg) { goToTab(jump); return }
+    if (jump !== undefined && !arg) { goTo(jump.tab, jump.sub); return }
     const full = `/${c.name}${arg ? " " + arg : ""}`
     // slash.exec owns the persistent HermesCLI subprocess; mid-stream it
     // races the agent turn. Enqueue as `/cmd arg` and let the drain path
@@ -728,7 +736,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       })
   }, [ready, turn.streaming, turn.messages, dialog, themeCtx, newSession, gw, pickEikon, editTitle,
       applyTitle, toast, info, sid, title, switchSession, session, runCompress, rewind, renderer,
-      attachClipboard, goToTab, queue.length, goalHook, skin, destructive])
+      attachClipboard, goToTab, goTo, queue.length, goalHook, skin, destructive])
 
   // ── Send ──────────────────────────────────────────────────────────
   const send = useCallback(async (raw: string) => {
@@ -984,8 +992,20 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   intr.current = doInterrupt
 
   // ── Keyboard ──────────────────────────────────────────────────────
+  const subCount = SUB_TABS[tab]?.length ?? 0
+  const cycleSub = useCallback((dir: -1 | 1) => {
+    const labels = SUB_TABS[tab]
+    if (!labels || labels.length === 0) return
+    setSubTabs(prev => {
+      const cur = prev[tab] ?? 0
+      const next = (cur + dir + labels.length) % labels.length
+      return next === cur ? prev : { ...prev, [tab]: next }
+    })
+  }, [tab])
   useAppKeys({
-    tab, tabMax: TAB_MAX, chatTab: CHAT_TAB, setTab, focusRegion, setFocusRegion,
+    tab, tabMax: TAB_MAX, chatTab: CHAT_TAB, setTab,
+    subCount, cycleSub,
+    focusRegion, setFocusRegion,
     streaming: turn.streaming,
     dialogOpen: dialog.open,
     composer,
@@ -1066,23 +1086,24 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const content = () => {
     const inner = (() => {
       switch (tab) {
-        case 0: return <Chat messages={turn.messages} streaming={turn.streaming}
-                             prompt={promptWire}
-                             cloud={cloud} cloudH={cloudH} pick={pick}
-                             onResize={setCloudH} onPick={onPick} onClose={closeCloud} onRewind={msgMenu} />
-        case 1: return <Context description={TABS[tab].description} messages={turn.messages}
-                               sessionStart={sessionStart.current} info={info ?? undefined}
-                               focused={contentFocused} />
-        case 2: return <Sessions onSwitch={switchSession} currentId={sid} focused={contentFocused} />
-        case 3: return <Agents focused={contentFocused} sessionId={sid} onSwitchProfile={switchProfile} />
-        case 4: return <Analytics focused={contentFocused} />
-        case 5: return <Skills focused={contentFocused} />
-        case 6: return <Cron focused={contentFocused} />
-        case 7: return <Toolsets focused={contentFocused} />
-        case 8: return <Config focused={contentFocused} />
-        case 9: return <Env focused={contentFocused} />
-        case 10: return <Memory focused={contentFocused} />
-        case 11: return <Kanban focused={contentFocused} />
+        case CHAT_TAB: return <Chat messages={turn.messages} streaming={turn.streaming}
+                                    prompt={promptWire}
+                                    cloud={cloud} cloudH={cloudH} pick={pick}
+                                    onResize={setCloudH} onPick={onPick} onClose={closeCloud} onRewind={msgMenu} />
+        case SESSIONS_TAB: return <SessionsGroup focused={contentFocused}
+                                                 sub={subTabs[SESSIONS_TAB] ?? 0}
+                                                 setSub={(i) => setSub(SESSIONS_TAB, i)}
+                                                 onSwitch={switchSession} currentId={sid}
+                                                 messages={turn.messages}
+                                                 sessionStart={sessionStart.current}
+                                                 info={info ?? undefined} />
+        case AUTOMATION_TAB: return <Automation focused={contentFocused}
+                                                sub={subTabs[AUTOMATION_TAB] ?? 0}
+                                                setSub={(i) => setSub(AUTOMATION_TAB, i)}
+                                                sessionId={sid} onSwitchProfile={switchProfile} />
+        case CONFIG_TAB: return <ConfigGroup focused={contentFocused}
+                                             sub={subTabs[CONFIG_TAB] ?? 0}
+                                             setSub={(i) => setSub(CONFIG_TAB, i)} />
         default: return null
       }
     })()

--- a/src/app/tabs.ts
+++ b/src/app/tabs.ts
@@ -21,8 +21,8 @@ export const AUTOMATION_TAB = 2
 export const CONFIG_TAB = 3
 
 export const SUB_TABS: Record<number, readonly string[]> = {
-  [SESSIONS_TAB]:   ["Sessions", "Context", "Analytics"],
-  [AUTOMATION_TAB]: ["Profiles", "Cron", "Kanban"],
+  [SESSIONS_TAB]:   ["List", "Context", "Analytics"],
+  [AUTOMATION_TAB]: ["Kanban", "Profiles", "Cron"],
   [CONFIG_TAB]:     ["Config", "Skills", "Toolsets", "Env", "Memory"],
 }
 
@@ -34,11 +34,11 @@ export const TAB_SLASH: Record<string, { tab: number; sub: number }> = {
   context:    { tab: SESSIONS_TAB,   sub: 1 },
   analytics:  { tab: SESSIONS_TAB,   sub: 2 },
   insights:   { tab: SESSIONS_TAB,   sub: 2 },
-  profiles:   { tab: AUTOMATION_TAB, sub: 0 },
-  agents:     { tab: AUTOMATION_TAB, sub: 0 },
+  kanban:     { tab: AUTOMATION_TAB, sub: 0 },
   automation: { tab: AUTOMATION_TAB, sub: 0 },
-  cron:       { tab: AUTOMATION_TAB, sub: 1 },
-  kanban:     { tab: AUTOMATION_TAB, sub: 2 },
+  profiles:   { tab: AUTOMATION_TAB, sub: 1 },
+  agents:     { tab: AUTOMATION_TAB, sub: 1 },
+  cron:       { tab: AUTOMATION_TAB, sub: 2 },
   config:     { tab: CONFIG_TAB,     sub: 0 },
   skills:     { tab: CONFIG_TAB,     sub: 1 },
   toolsets:   { tab: CONFIG_TAB,     sub: 2 },

--- a/src/app/tabs.ts
+++ b/src/app/tabs.ts
@@ -1,23 +1,47 @@
+// Top-level tab registry. The four groups consolidate the earlier 12-tab
+// sprawl; inner views are reached via each group's sub-tab bar (see
+// tabs/SessionsGroup / Automation / ConfigGroup).
+//
+// SUB_TABS keys MUST match TABS indices; each entry is the ordered list of
+// sub-tab names shown in the group's sub-tab strip. SLASH_SUB maps slash
+// command names to the sub-tab label they jump to, so `/memory` opens the
+// Memory sub-tab inside Config.
+
 export const TABS = [
-  { name: "Chat",      description: "Main chat interface" },
-  { name: "Context",   description: "Context and session info" },
-  { name: "Sessions",  description: "Session history" },
-  { name: "Agents",    description: "Profiles and running subagents" },
-  { name: "Analytics", description: "Token usage and costs" },
-  { name: "Skills",    description: "Installed skills browser" },
-  { name: "Cron",      description: "Scheduled job manager" },
-  { name: "Toolsets",  description: "Available toolsets manager" },
-  { name: "Config",    description: "Configuration editor" },
-  { name: "Env",       description: "API keys & env variables" },
-  { name: "Memory",    description: "Agent memory browser" },
-  { name: "Kanban",    description: "Multi-agent task board" },
+  { name: "Chat",                 description: "Main chat interface" },
+  { name: "Sessions",             description: "Sessions, context, analytics" },
+  { name: "Profiles & Automation",description: "Profiles, cron jobs, kanban boards" },
+  { name: "Config",               description: "Config, env, skills, toolsets, memory" },
 ] as const
 
 export const TAB_MAX = TABS.length - 1
 export const CHAT_TAB = 0
+export const SESSIONS_TAB = 1
+export const AUTOMATION_TAB = 2
+export const CONFIG_TAB = 3
 
-/** Slash-command names that jump to a tab (F5.3). */
-export const TAB_SLASH: Record<string, number> = Object.fromEntries(
-  TABS.map((t, i) => [t.name.toLowerCase(), i]),
-)
-TAB_SLASH.insights = TAB_SLASH.analytics
+export const SUB_TABS: Record<number, readonly string[]> = {
+  [SESSIONS_TAB]:   ["Sessions", "Context", "Analytics"],
+  [AUTOMATION_TAB]: ["Profiles", "Cron", "Kanban"],
+  [CONFIG_TAB]:     ["Config", "Skills", "Toolsets", "Env", "Memory"],
+}
+
+/** Slash-command name → {tab, sub}. `sub` is the sub-tab index within that
+ *  group (0 when the slash targets the group's landing view). */
+export const TAB_SLASH: Record<string, { tab: number; sub: number }> = {
+  chat:       { tab: CHAT_TAB,       sub: 0 },
+  sessions:   { tab: SESSIONS_TAB,   sub: 0 },
+  context:    { tab: SESSIONS_TAB,   sub: 1 },
+  analytics:  { tab: SESSIONS_TAB,   sub: 2 },
+  insights:   { tab: SESSIONS_TAB,   sub: 2 },
+  profiles:   { tab: AUTOMATION_TAB, sub: 0 },
+  agents:     { tab: AUTOMATION_TAB, sub: 0 },
+  automation: { tab: AUTOMATION_TAB, sub: 0 },
+  cron:       { tab: AUTOMATION_TAB, sub: 1 },
+  kanban:     { tab: AUTOMATION_TAB, sub: 2 },
+  config:     { tab: CONFIG_TAB,     sub: 0 },
+  skills:     { tab: CONFIG_TAB,     sub: 1 },
+  toolsets:   { tab: CONFIG_TAB,     sub: 2 },
+  env:        { tab: CONFIG_TAB,     sub: 3 },
+  memory:     { tab: CONFIG_TAB,     sub: 4 },
+}

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -31,6 +31,10 @@ type Opts = {
   tabMax: number
   chatTab: number
   setTab: (fn: (t: number) => number) => void
+  /** Sub-tab count for the active top-level tab (0 if no sub-tabs, e.g. Chat). */
+  subCount: number
+  /** Cycle sub-tab within the active top-level tab. dir: -1 = prev, +1 = next. */
+  cycleSub: (dir: -1 | 1) => void
   focusRegion: Region
   setFocusRegion: (r: Region | ((r: Region) => Region)) => void
   streaming: boolean
@@ -169,6 +173,14 @@ export function useAppKeys(o: Opts) {
     if (keys.match("tab.next", key)) {
       o.setTab(t => { const n = Math.min(o.tabMax, t + 1); o.setFocusRegion(regionFor(n)); return n })
       return
+    }
+    // Shift+←/→ cycles sub-tab within the active group. No-op on Chat
+    // (subCount=0). Structural, not catalog — sub-tabs are a layout
+    // property of a group, not a rebindable concept.
+    if (o.subCount > 0 && key.shift && !key.ctrl && !key.meta
+        && key.eventType !== "release") {
+      if (key.name === "left")  { o.cycleSub(-1); key.stopPropagation(); return }
+      if (key.name === "right") { o.cycleSub(1);  key.stopPropagation(); return }
     }
     // <leader> 1..0 → tab 1..10 (1-indexed), <leader> - → tab 11.
     // Structural, not catalog — ten near-identical rebindable actions is

--- a/src/components/tabs/SubTabBar.tsx
+++ b/src/components/tabs/SubTabBar.tsx
@@ -1,5 +1,8 @@
 import { memo } from "react"
-import { useTheme } from "../../theme"
+import { TabStrip } from "./TabStrip"
+
+// Sub-tab row inside a group tab. Same visual treatment as the top
+// bar (docs/nav.md § Tab Bars); keyboard is Shift+←/→ via useAppKeys.
 
 type Props = {
   tabs: readonly string[]
@@ -8,35 +11,4 @@ type Props = {
   hint?: string
 }
 
-// Narrow horizontal strip shown at the top of group tabs. Visually lower-
-// weight than the primary TabBar: no bold, no background block, a thin
-// underline on the active entry. Mouse click switches; keyboard switching
-// lives in useAppKeys (Shift+←/→).
-export const SubTabBar = memo(({ tabs, active, onChange, hint }: Props) => {
-  const theme = useTheme().theme
-  return (
-    <box width="100%" flexDirection="row" height={1} overflow="hidden">
-      {tabs.map((name, i) => (
-        <box
-          key={i}
-          onMouseDown={() => onChange(i)}
-          paddingX={1}
-          marginRight={1}
-          flexShrink={0}
-        >
-          <text>
-            <span fg={i === active ? theme.accent : theme.textMuted}>
-              {i === active ? `● ${name}` : `  ${name}`}
-            </span>
-          </text>
-        </box>
-      ))}
-      <box flexGrow={1} minWidth={0} />
-      {hint ? (
-        <box paddingX={1} flexShrink={1} minWidth={0} overflow="hidden">
-          <text fg={theme.borderSubtle}>{hint}</text>
-        </box>
-      ) : null}
-    </box>
-  )
-})
+export const SubTabBar = memo((props: Props) => <TabStrip {...props} />)

--- a/src/components/tabs/SubTabBar.tsx
+++ b/src/components/tabs/SubTabBar.tsx
@@ -1,0 +1,42 @@
+import { memo } from "react"
+import { useTheme } from "../../theme"
+
+type Props = {
+  tabs: readonly string[]
+  active: number
+  onChange: (i: number) => void
+  hint?: string
+}
+
+// Narrow horizontal strip shown at the top of group tabs. Visually lower-
+// weight than the primary TabBar: no bold, no background block, a thin
+// underline on the active entry. Mouse click switches; keyboard switching
+// lives in useAppKeys (Shift+←/→).
+export const SubTabBar = memo(({ tabs, active, onChange, hint }: Props) => {
+  const theme = useTheme().theme
+  return (
+    <box width="100%" flexDirection="row" height={1} overflow="hidden">
+      {tabs.map((name, i) => (
+        <box
+          key={i}
+          onMouseDown={() => onChange(i)}
+          paddingX={1}
+          marginRight={1}
+          flexShrink={0}
+        >
+          <text>
+            <span fg={i === active ? theme.accent : theme.textMuted}>
+              {i === active ? `● ${name}` : `  ${name}`}
+            </span>
+          </text>
+        </box>
+      ))}
+      <box flexGrow={1} minWidth={0} />
+      {hint ? (
+        <box paddingX={1} flexShrink={1} minWidth={0} overflow="hidden">
+          <text fg={theme.borderSubtle}>{hint}</text>
+        </box>
+      ) : null}
+    </box>
+  )
+})

--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -1,50 +1,31 @@
 import { memo } from "react"
-import { useTheme } from "../../theme"
 import { useKeys } from "../../keys"
+import { TabStrip } from "./TabStrip"
 
-type Tab = {
-  name: string
-  description: string
-}
+// Top-level tab row. Thin adapter over TabStrip that maps the TABS
+// registry's {name, description} entries down to bare names and
+// supplies the top-level nav hint. The <leader>+N / Alt+N direct-jump
+// chords still work (useAppKeys) — they're just no longer painted per
+// label, since with four consolidated groups the row has room and the
+// hint already advertises the chord.
 
-type TabBarProps = {
+type Tab = { name: string; description: string }
+
+type Props = {
   tabs: ReadonlyArray<Tab>
   activeTab: number
-  onTabChange: (index: number) => void
+  onTabChange: (i: number) => void
 }
 
-// 1..9, 0, - — mirrors the <leader>+digit map in useAppKeys.
-const idx = (i: number) => i < 9 ? String(i + 1) : i === 9 ? "0" : "-"
-
-export const TabBar = memo(({ tabs, activeTab, onTabChange }: TabBarProps) => {
-  const theme = useTheme().theme
+export const TabBar = memo(({ tabs, activeTab, onTabChange }: Props) => {
   const keys = useKeys()
-
+  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} or ${keys.print("leader")} N`
   return (
-    <box width="100%" flexDirection="column" height={1}>
-      <box flexDirection="row" overflow="hidden">
-        {tabs.map((tab, i) => (
-          <box
-            key={i}
-            onMouseDown={() => onTabChange(i)}
-            paddingX={2}
-            marginRight={1}
-            flexShrink={0}
-            backgroundColor={i === activeTab ? theme.backgroundElement : undefined}
-          >
-            <text attributes={3}>
-              <span fg={theme.borderSubtle}>{idx(i)} </span>
-              <span fg={i === activeTab ? theme.primary : theme.textMuted}>{tab.name}</span>
-            </text>
-          </box>
-        ))}
-        <box flexGrow={1} minWidth={0} />
-        <box paddingX={1} flexShrink={1} minWidth={0} overflow="hidden">
-          <text fg={theme.borderSubtle}>
-            {`${keys.print("tab.prev")}/${keys.print("tab.next")} or ${keys.print("leader")} N`}
-          </text>
-        </box>
-      </box>
-    </box>
+    <TabStrip
+      tabs={tabs.map(t => t.name)}
+      active={activeTab}
+      onChange={onTabChange}
+      hint={hint}
+    />
   )
 })

--- a/src/components/tabs/TabStrip.tsx
+++ b/src/components/tabs/TabStrip.tsx
@@ -1,0 +1,44 @@
+import { memo } from "react"
+import { useTheme } from "../../theme"
+
+// Shared horizontal tab strip. Top-level TabBar and per-group SubTabBar
+// both render this so the two levels read as the same control (see
+// docs/nav.md § Tab Bars) — they differ only in nav chord and hint text,
+// which callers supply. No digit prefix, no bullet; active entry gets a
+// bold label on a backgroundElement block, inactive entries are muted.
+// Keyboard lives in useAppKeys; this is click + paint only.
+
+type Props = {
+  tabs: readonly string[]
+  active: number
+  onChange: (i: number) => void
+  hint?: string
+}
+
+export const TabStrip = memo(({ tabs, active, onChange, hint }: Props) => {
+  const theme = useTheme().theme
+  return (
+    <box width="100%" flexDirection="row" height={1} overflow="hidden">
+      {tabs.map((name, i) => (
+        <box
+          key={i}
+          onMouseDown={() => onChange(i)}
+          paddingX={2}
+          marginRight={1}
+          flexShrink={0}
+          backgroundColor={i === active ? theme.backgroundElement : undefined}
+        >
+          <text fg={i === active ? theme.primary : theme.textMuted}>
+            <strong>{name}</strong>
+          </text>
+        </box>
+      ))}
+      <box flexGrow={1} minWidth={0} />
+      {hint ? (
+        <box paddingX={1} flexShrink={1} minWidth={0} overflow="hidden">
+          <text fg={theme.borderSubtle}>{hint}</text>
+        </box>
+      ) : null}
+    </box>
+  )
+})

--- a/src/tabs/Automation.tsx
+++ b/src/tabs/Automation.tsx
@@ -30,14 +30,14 @@ export const Automation = memo((props: Props) => {
       <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />
       <box flexGrow={1} minWidth={0} flexDirection="column">
         <Pane visible={props.sub === 0}>
-          <Agents focused={!!props.focused && props.sub === 0}
-                  sessionId={props.sessionId} onSwitchProfile={props.onSwitchProfile} />
+          <Kanban focused={!!props.focused && props.sub === 0} />
         </Pane>
         <Pane visible={props.sub === 1}>
-          <Cron focused={!!props.focused && props.sub === 1} />
+          <Agents focused={!!props.focused && props.sub === 1}
+                  sessionId={props.sessionId} onSwitchProfile={props.onSwitchProfile} />
         </Pane>
         <Pane visible={props.sub === 2}>
-          <Kanban focused={!!props.focused && props.sub === 2} />
+          <Cron focused={!!props.focused && props.sub === 2} />
         </Pane>
       </box>
     </box>

--- a/src/tabs/Automation.tsx
+++ b/src/tabs/Automation.tsx
@@ -1,0 +1,48 @@
+import { memo, useEffect, type ReactNode } from "react"
+import { Agents } from "./Agents"
+import { Cron } from "./Cron"
+import { Kanban } from "./Kanban"
+import { SubTabBar } from "../components/tabs/SubTabBar"
+import { SUB_TABS, AUTOMATION_TAB } from "../app/tabs"
+import { useKeys } from "../keys"
+
+type Props = {
+  focused?: boolean
+  sub: number
+  setSub: (i: number) => void
+  // Agents
+  sessionId: string
+  onSwitchProfile: (newHome: string, name: string) => void
+}
+
+// Consolidates Agents (profiles + running subagents), Cron, and Kanban.
+// Each sub-tab owns its own keybindings via useKeyboard({focused}); the
+// group only forwards `focused` to whichever is active.
+export const Automation = memo((props: Props) => {
+  const keys = useKeys()
+  const labels = SUB_TABS[AUTOMATION_TAB]
+  useEffect(() => {
+    if (props.sub >= labels.length) props.setSub(0)
+  }, [props.sub, labels.length])
+  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
+  return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />
+      <box flexGrow={1} minWidth={0} flexDirection="column">
+        <Pane visible={props.sub === 0}>
+          <Agents focused={!!props.focused && props.sub === 0}
+                  sessionId={props.sessionId} onSwitchProfile={props.onSwitchProfile} />
+        </Pane>
+        <Pane visible={props.sub === 1}>
+          <Cron focused={!!props.focused && props.sub === 1} />
+        </Pane>
+        <Pane visible={props.sub === 2}>
+          <Kanban focused={!!props.focused && props.sub === 2} />
+        </Pane>
+      </box>
+    </box>
+  )
+})
+
+const Pane = ({ visible, children }: { visible: boolean; children: ReactNode }) =>
+  visible ? <box flexGrow={1} minWidth={0} flexDirection="column">{children}</box> : null

--- a/src/tabs/ConfigGroup.tsx
+++ b/src/tabs/ConfigGroup.tsx
@@ -1,0 +1,52 @@
+import { memo, useEffect, type ReactNode } from "react"
+import { Config } from "./Config"
+import { Skills } from "./Skills"
+import { Toolsets } from "./Toolsets"
+import { Env } from "./Env"
+import { Memory } from "./Memory"
+import { SubTabBar } from "../components/tabs/SubTabBar"
+import { SUB_TABS, CONFIG_TAB } from "../app/tabs"
+import { useKeys } from "../keys"
+
+type Props = {
+  focused?: boolean
+  sub: number
+  setSub: (i: number) => void
+}
+
+// Consolidates Config / Skills / Toolsets / Env / Memory. Order is
+// Config first so a bare click on the top-level tab lands on the most
+// common target; the rest are alphabetical-ish by frequency of use.
+export const ConfigGroup = memo((props: Props) => {
+  const keys = useKeys()
+  const labels = SUB_TABS[CONFIG_TAB]
+  useEffect(() => {
+    if (props.sub >= labels.length) props.setSub(0)
+  }, [props.sub, labels.length])
+  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
+  return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />
+      <box flexGrow={1} minWidth={0} flexDirection="column">
+        <Pane visible={props.sub === 0}>
+          <Config focused={!!props.focused && props.sub === 0} />
+        </Pane>
+        <Pane visible={props.sub === 1}>
+          <Skills focused={!!props.focused && props.sub === 1} />
+        </Pane>
+        <Pane visible={props.sub === 2}>
+          <Toolsets focused={!!props.focused && props.sub === 2} />
+        </Pane>
+        <Pane visible={props.sub === 3}>
+          <Env focused={!!props.focused && props.sub === 3} />
+        </Pane>
+        <Pane visible={props.sub === 4}>
+          <Memory focused={!!props.focused && props.sub === 4} />
+        </Pane>
+      </box>
+    </box>
+  )
+})
+
+const Pane = ({ visible, children }: { visible: boolean; children: ReactNode }) =>
+  visible ? <box flexGrow={1} minWidth={0} flexDirection="column">{children}</box> : null

--- a/src/tabs/SessionsGroup.tsx
+++ b/src/tabs/SessionsGroup.tsx
@@ -1,0 +1,61 @@
+import { memo, useEffect, type ReactNode } from "react"
+import type { Message } from "../types/message"
+import type { SessionInfo } from "../utils/gateway-types"
+import { Sessions } from "./Sessions"
+import { Context } from "./Context"
+import { Analytics } from "./Analytics"
+import { SubTabBar } from "../components/tabs/SubTabBar"
+import { SUB_TABS, SESSIONS_TAB } from "../app/tabs"
+import { useKeys } from "../keys"
+
+type Props = {
+  focused?: boolean
+  sub: number
+  setSub: (i: number) => void
+  // Sessions
+  onSwitch?: (sid: string) => void
+  currentId?: string
+  // Context
+  messages?: Message[]
+  sessionStart: number
+  info?: SessionInfo
+}
+
+// Consolidates the former Sessions / Context / Analytics tabs under a
+// single top-level Sessions tab. Sub-tab state is owned by app.tsx so
+// slash routes (e.g. `/context`) and the shell's Shift+←/→ cycle can
+// address a sub-tab directly. Only the active sub-tab is mounted —
+// each sub-tab runs its own fetches/useHome subscriptions and double-
+// mounting would duplicate traffic without a visible payoff (state is
+// cheap to rebuild from ~/.hermes on next switch).
+export const SessionsGroup = memo((props: Props) => {
+  const keys = useKeys()
+  const labels = SUB_TABS[SESSIONS_TAB]
+  // Clamp defensively — if the sub-tab list shrinks later, drifted
+  // indices would render nothing.
+  useEffect(() => {
+    if (props.sub >= labels.length) props.setSub(0)
+  }, [props.sub, labels.length])
+  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
+  return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />
+      <box flexGrow={1} minWidth={0} flexDirection="column">
+        <Pane visible={props.sub === 0}>
+          <Sessions focused={!!props.focused && props.sub === 0}
+                    onSwitch={props.onSwitch} currentId={props.currentId} />
+        </Pane>
+        <Pane visible={props.sub === 1}>
+          <Context focused={!!props.focused && props.sub === 1}
+                   messages={props.messages} sessionStart={props.sessionStart} info={props.info} />
+        </Pane>
+        <Pane visible={props.sub === 2}>
+          <Analytics focused={!!props.focused && props.sub === 2} />
+        </Pane>
+      </box>
+    </box>
+  )
+})
+
+const Pane = ({ visible, children }: { visible: boolean; children: ReactNode }) =>
+  visible ? <box flexGrow={1} minWidth={0} flexDirection="column">{children}</box> : null

--- a/src/utils/control.ts
+++ b/src/utils/control.ts
@@ -66,16 +66,28 @@ const json = (data: unknown, status = 200) =>
 // module load — hardcoded indexes drift every time a tab is inserted.
 // Throws if a named tab is missing so the app refuses to start with a
 // broken safety table rather than silently leaving Chat's Enter unguarded.
+//
+// The top-level tabs are now groups that host multiple sub-tabs (e.g.
+// "Config" hosts Config/Skills/Toolsets/Env/Memory). Since control.ts
+// only sees the top-level tab, the guarded key set for a group is the
+// UNION of every sub-tab's dangerous keys — err on the side of requiring
+// safe=false when a sub-tab could mutate. Acceptable: Skills/Memory
+// don't mutate on plain return, so only the worst-case sub-tab matters.
 const idx = (name: string) => {
   const n = TAB_NAMES.indexOf(name)
   if (n < 0) throw new Error(`control.ts DANGEROUS: tab '${name}' missing from TAB_NAMES`)
   return n
 }
 const DANGEROUS: Record<number, Set<string>> = {
-  [idx("Chat")]:     new Set(["return"]),                                     // Enter sends message
-  [idx("Sessions")]: new Set(["d", "delete", "return"]),                      // d=delete, Enter=switch
-  [idx("Config")]:   new Set(["space", "return", "h", "l", "]", "[", "ctrl+s"]), // toggles, edits, save
-  [idx("Env")]:      new Set(["return", "space", "d", "delete"]),             // potential mutations
+  [idx("Chat")]:                   new Set(["return"]),                         // Enter sends message
+  // Sessions sub-tab: d/delete/return; Context/Analytics sub-tabs: no mutations.
+  [idx("Sessions")]:               new Set(["d", "delete", "return"]),
+  // Profiles sub-tab: k (kill subagent), d (delete). Cron sub-tab: return, space,
+  // d/delete. Kanban sub-tab: d/delete, return (activate/start).
+  [idx("Profiles & Automation")]:  new Set(["return", "space", "d", "delete", "k"]),
+  // Config sub-tab: space, return, h, l, ]/[, ctrl+s. Env sub-tab:
+  // return, space, d/delete. Toolsets/Skills/Memory: space for toggles.
+  [idx("Config")]:                 new Set(["space", "return", "h", "l", "]", "[", "ctrl+s", "d", "delete"]),
 }
 
 export function isDangerous(tab: number, keyName: string, ctrl: boolean): boolean {

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -42,8 +42,8 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    // Tab bar shows index prefixes. New 4-tab layout.
-    expect(t.frame()).toMatch(/1 Chat.*2 Sessions.*3 Profiles & Automation.*4 Config/)
+    // Tab bar shows bare labels (no digit prefix). New 4-tab layout.
+    expect(t.frame()).toMatch(/Chat.*Sessions.*Profiles & Automation.*Config/)
 
     // <leader>2 → Sessions group (landing sub-tab is Sessions).
     act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("2") })
@@ -362,8 +362,9 @@ describe("app", () => {
 
     // Unlike the old dialog, tab-nav is NOT blocked — the prompt is
     // in the transcript, not an overlay. But it snaps back to Chat
-    // on arrival and that's where the card lives.
-    expect(t.frame()).toContain("1 Chat")
+    // on arrival and that's where the card lives. Tab bar still
+    // paints — no backdrop covering it.
+    expect(t.frame()).toMatch(/Chat.*Sessions.*Profiles & Automation/)
 
     // Esc denies the prompt and does NOT arm interrupt (card.feed
     // consumed it and stopPropagation'd).

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -25,13 +25,13 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    // Chat is index 0; alt+left should clamp (no Overview anymore)
+    // Chat is index 0; alt+left should clamp.
     act(() => t.keys.pressArrow("left", { meta: true }))
     await t.settle()
     expect(t.frame()).toContain("Message Hermes")
 
-    // → Sessions (index 2)
-    act(() => { for (let i = 0; i < 2; i++) t.keys.pressArrow("right", { meta: true }) })
+    // → Sessions (index 1, the consolidated Sessions/Context/Analytics group).
+    act(() => t.keys.pressArrow("right", { meta: true }))
     // Sandboxed HERMES_HOME has no state.db → empty state
     await until(t, () => t.frame().includes("No sessions"))
 
@@ -42,19 +42,21 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    // Tab bar shows index prefixes.
-    expect(t.frame()).toMatch(/1 Chat.*2 Context.*3 Sessions/)
+    // Tab bar shows index prefixes. New 4-tab layout.
+    expect(t.frame()).toMatch(/1 Chat.*2 Sessions.*3 Profiles & Automation.*4 Config/)
 
-    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("3") })
+    // <leader>2 → Sessions group (landing sub-tab is Sessions).
+    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("2") })
     await until(t, () => t.frame().includes("No sessions"))
 
-    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("0") })
-    await until(t, () => t.frame().includes("Env / API Keys"))
-    // Focus landed on content: arrow moves Env selection, doesn't type.
+    // <leader>4 → Config group. Landing sub-tab is Config.
+    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("4") })
+    await until(t, () => t.frame().includes("general") && t.frame().includes("models"))
+    // Focus landed on content: arrow moves Config selection, doesn't type.
     act(() => t.keys.pressArrow("down"))
     await t.settle()
-    const sel = t.frame().split("\n").find(l => l.includes("▸"))!
-    expect(sel).not.toMatch(/LLM Providers/)
+    // Composer should still be empty — arrow didn't bounce to input.
+    expect(t.frame()).not.toMatch(/> [a-z]/)
 
     act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("1") })
     await t.settle()
@@ -106,12 +108,10 @@ describe("app", () => {
     await t.settle()
     expect(t.frame()).toContain("Message Hermes")
 
-    // Rebound chord does.
-    act(() => { t.keys.pressKey("]", { ctrl: true }); t.keys.pressKey("]", { ctrl: true }) })
+    // Rebound chord does (one step → Sessions group).
+    act(() => t.keys.pressKey("]", { ctrl: true }))
     await until(t, () => t.frame().includes("No sessions"))
 
-    act(() => t.keys.pressKey("[", { ctrl: true }))
-    await t.settle()
     act(() => t.keys.pressKey("[", { ctrl: true }))
     await t.settle()
     expect(t.frame()).toContain("Message Hermes")
@@ -147,8 +147,10 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    // Alt+→ to Env (index 9). Land on content, not the composer.
-    act(() => { for (let i = 0; i < 9; i++) t.keys.pressArrow("right", { meta: true }) })
+    // Alt+→×3 lands on Config group; Shift+→×3 walks to Env sub-tab.
+    act(() => { for (let i = 0; i < 3; i++) t.keys.pressArrow("right", { meta: true }) })
+    await t.settle()
+    act(() => { for (let i = 0; i < 3; i++) t.keys.pressArrow("right", { shift: true }) })
     await t.settle()
     await until(t, () => t.frame().includes("Env / API Keys"))
     expect(t.frame()).not.toContain("Env (searching)")
@@ -173,7 +175,9 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    act(() => { for (let i = 0; i < 9; i++) t.keys.pressArrow("right", { meta: true }) })
+    act(() => { for (let i = 0; i < 3; i++) t.keys.pressArrow("right", { meta: true }) })
+    await t.settle()
+    act(() => { for (let i = 0; i < 3; i++) t.keys.pressArrow("right", { shift: true }) })
     await until(t, () => t.frame().includes("Env / API Keys"))
 
     // Single Tab: content keeps focus (arrow still moves selection).
@@ -250,7 +254,8 @@ describe("app", () => {
     // Chat tab: sidebar visible at 130.
     expect(t.frame()).toMatch(/Profile\s+default/)
 
-    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("3") })
+    // <leader>2 → Sessions group (landing sub-tab: Sessions).
+    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("2") })
     await until(t, () => t.frame().includes("Sessions (1)"))
     // Sidebar dropped, detail pane kept.
     expect(t.frame()).not.toMatch(/Profile\s+default/)

--- a/test/control.test.ts
+++ b/test/control.test.ts
@@ -9,33 +9,33 @@ describe("control.isDangerous — guards the intended tabs by name, not hardcode
     expect(isDangerous(idx("Chat"), "return", false)).toBe(true)
   })
 
-  test("Sessions: d/delete/Enter guarded (regression — was drifted to Agents' index)", () => {
+  test("Sessions: d/delete/Enter guarded (session switch/delete via Sessions sub-tab)", () => {
     expect(isDangerous(idx("Sessions"), "d", false)).toBe(true)
     expect(isDangerous(idx("Sessions"), "delete", false)).toBe(true)
     expect(isDangerous(idx("Sessions"), "return", false)).toBe(true)
   })
 
-  test("Config: toggles, edits, Ctrl+S guarded", () => {
+  test("Config group: Config-sub toggles + Env-sub deletions + Ctrl+S guarded (union across sub-tabs)", () => {
     const c = idx("Config")
     expect(isDangerous(c, "space", false)).toBe(true)
     expect(isDangerous(c, "return", false)).toBe(true)
     expect(isDangerous(c, "h", false)).toBe(true)
+    expect(isDangerous(c, "l", false)).toBe(true)
+    expect(isDangerous(c, "[", false)).toBe(true)
+    expect(isDangerous(c, "]", false)).toBe(true)
+    expect(isDangerous(c, "d", false)).toBe(true)
+    expect(isDangerous(c, "delete", false)).toBe(true)
     expect(isDangerous(c, "s", true)).toBe(true)
     expect(isDangerous(c, "s", false)).toBe(false)  // bare 's' fine
   })
 
-  test("Env: return/space/d/delete guarded", () => {
-    const e = idx("Env")
-    expect(isDangerous(e, "return", false)).toBe(true)
-    expect(isDangerous(e, "space", false)).toBe(true)
-    expect(isDangerous(e, "d", false)).toBe(true)
-  })
-
-  test("Non-guarded tabs accept any key", () => {
-    for (const name of ["Context", "Agents", "Analytics", "Skills", "Cron", "Toolsets", "Memory", "Kanban"]) {
-      expect(isDangerous(idx(name), "return", false)).toBe(false)
-      expect(isDangerous(idx(name), "d", false)).toBe(false)
-    }
+  test("Profiles & Automation group: return/space/d/delete/k guarded (profile/cron/kanban mutations)", () => {
+    const p = idx("Profiles & Automation")
+    expect(isDangerous(p, "return", false)).toBe(true)
+    expect(isDangerous(p, "space", false)).toBe(true)
+    expect(isDangerous(p, "d", false)).toBe(true)
+    expect(isDangerous(p, "delete", false)).toBe(true)
+    expect(isDangerous(p, "k", false)).toBe(true)
   })
 
   test("Unknown tab index returns false (no crash)", () => {


### PR DESCRIPTION
Collapses the 12 top-level tabs into 4 groups with sub-tabs

### Groups

| Group | Sub-tabs |
| --- | --- |
| Chat | (none) |
| Sessions | List, Context, Analytics |
| Profiles & Automation | Kanban, Profiles, Cron |
| Config | Config, Skills, Toolsets, Env, Memory |

### Navigation

- `tab.prev` / `tab.next` cycles groups (unchanged)
- `shift+←` / `shift+→` cycles sub-tabs within the active group
- `<leader> N` jumps to group N; digit prefix no longer painted on labels
- Existing `/slash` routes (`/kanban`, `/profiles`, `/cron`, `/skills`, `/config`, etc.) resolve to the correct group + sub-tab via `TAB_SLASH`

### Rendering

- New `TabStrip` is the single renderer for both tiers: `paddingX={2}` cells, `theme.backgroundElement` block on active, `theme.primary` fg on active, `theme.textMuted` on inactive
- `TabBar` and `SubTabBar` are thin adapters over `TabStrip`
- Drops the bullet marker on sub-tabs and the digit prefix on top tabs so both tiers read the same

### Tests

- `test/app.test.tsx` updated for bare labels and group/sub-tab assertions (39 pass)
- `test/control.test.ts` updated for `TAB_SLASH` remap (5 pass)
