### PR TITLE
Nav/UI standards conformance + kanban diagnostics, skill-chip input, goal checklist

### DIFF
--- a/src/app/goalHook.ts
+++ b/src/app/goalHook.ts
@@ -35,11 +35,12 @@ const run = (cmd: string) =>
 const fired = new Map<string, string>()
 
 export function makeGoalHook(dialog: DialogContext, toast: Toast): GoalHook {
-  const act = (goal: string) => {
+  const act = (goal: string, done?: number, total?: number) => {
     const pref = (prefs.get("onGoalDone") ?? "toast").trim()
     const head = goal.length > 60 ? goal.slice(0, 57) + "…" : goal
+    const n = total && total > 0 ? `  ${done}/${total} items` : ""
     toast.show({
-      variant: "success", title: "Goal complete", message: head, duration: 8000,
+      variant: "success", title: "Goal complete", message: head + n, duration: 8000,
     })
     if (pref === "toast") return
     const cmd = pref === "suspend" ? SUSPEND : pref
@@ -58,7 +59,9 @@ export function makeGoalHook(dialog: DialogContext, toast: Toast): GoalHook {
         if (!s || s.status !== "done") return
         if (fired.get(sid) === s.goal) return
         fired.set(sid, s.goal)
-        act(s.goal)
+        const list = s.checklist ?? []
+        const done = list.filter(i => i.status === "completed" || i.status === "impossible").length
+        act(s.goal, done, list.length)
       }).catch(() => {})
     },
   }

--- a/src/dialogs/install-distribution.tsx
+++ b/src/dialogs/install-distribution.tsx
@@ -117,7 +117,7 @@ async function preview(
   // Pass ORIGINAL source to install so the persisted manifest's source:
   // points at the remote, not the temp dir we just staged.
   dialog.replace(
-    <Confirm
+    <ConfirmStep
       source={source}
       manifest={manifest}
       onConfirm={(r) => { cleanup(); done(r) }}
@@ -200,7 +200,10 @@ const ErrorBox = (p: { title: string; body: string; onClose: () => void }) => {
 
 // ── Step 3: preview + confirm ─────────────────────────────────────────
 
-const Confirm = (p: {
+type Field = "name" | "alias"
+const ORDER: readonly Field[] = ["name", "alias"] as const
+
+export const ConfirmStep = (p: {
   source: string
   manifest: DistributionManifest
   onConfirm: (r: InstallResult) => void
@@ -208,12 +211,12 @@ const Confirm = (p: {
 }) => {
   const theme = useTheme().theme
   const keys = useKeys()
-  // Three focusable fields: name input, alias checkbox, confirm.
-  // Keep it minimal — Tab cycles; 'y' confirms when not in the name
-  // input (Esc always cancels).
+  // Form dialog: Tab/Shift+Tab walks fields, Space toggles focused checkbox,
+  // Enter accepts, Esc cancels. No 'y'/'n' mnemonics here — those are
+  // reserved for openConfirm per nav spec.
   const [name, setName] = useState("")
   const [alias, setAlias] = useState(false)
-  const [editing, setEditing] = useState<"name" | null>(null)
+  const [field, setField] = useState<Field>("name")
 
   const fire = () => p.onConfirm({
     source: p.source,
@@ -222,27 +225,24 @@ const Confirm = (p: {
     alias,
   })
 
+  const move = (dir: 1 | -1) => {
+    const i = ORDER.indexOf(field)
+    setField(ORDER[(i + dir + ORDER.length) % ORDER.length])
+  }
+
   useKeyboard((key) => {
-    if (editing === "name") {
-      // Delegate Esc to the input's blur path so the user can back out of
-      // the field without cancelling the whole dialog on the first Esc.
-      if (key.name === "escape") return setEditing(null)
-      if (key.name === "return") return setEditing(null)
-      return
-    }
     if (key.name === "escape") return p.onCancel()
-    // 'n' enters the name field (takes precedence over dialog.deny, which
-    // would cancel on 'n' — users expect the letter-key verb on a confirm
-    // with a rename affordance to target the affordance).
-    if (key.raw === "n") return setEditing("name")
-    if (keys.match("dialog.confirm", key) || keys.match("dialog.accept", key)) return fire()
-    if (keys.match("dialog.deny", key)) return p.onCancel()
-    if (key.name === "tab") return setAlias(a => !a)
+    if (key.name === "tab") return move(key.shift ? -1 : 1)
+    // Enter submits from non-name fields; on name the <input> onSubmit
+    // fires the same path, so avoid double-firing by gating here.
+    if (field !== "name" && keys.match("dialog.accept", key)) return fire()
+    if (field === "alias" && (key.name === "space" || key.name === " ")) return setAlias(a => !a)
   })
 
   const m = p.manifest
   const reqEnv = m.env_requires.filter(e => e.required)
   const optEnv = m.env_requires.filter(e => !e.required)
+  const focusBg = (f: Field) => field === f ? theme.backgroundElement : undefined
   return (
     <box flexDirection="column" width={72}>
       <box height={1}><text fg={theme.primary}><strong>Install Distribution</strong></text></box>
@@ -264,15 +264,14 @@ const Confirm = (p: {
       <box height={1} />
 
       {/* --name override */}
-      <box height={1} flexDirection="row">
+      <box height={1} flexDirection="row" backgroundColor={focusBg("name")}>
         <box width={11}><text fg={theme.textMuted}>Name as</text></box>
-        <box flexGrow={1} minWidth={0} height={1} overflow="hidden"
-             backgroundColor={editing === "name" ? theme.backgroundElement : undefined}>
-          {editing === "name" ? (
+        <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
+          {field === "name" ? (
             <input
               value={name}
               onInput={setName}
-              onSubmit={() => setEditing(null)}
+              onSubmit={fire}
               focused
               textColor={theme.text}
               backgroundColor={theme.backgroundElement}
@@ -280,25 +279,23 @@ const Confirm = (p: {
             />
           ) : (
             <text fg={name ? theme.text : theme.textMuted}>
-              {name || `(${m.name}) — press 'n' to override`}
+              {name || `(${m.name})`}
             </text>
           )}
         </box>
       </box>
 
       {/* --alias */}
-      <box height={1} flexDirection="row">
+      <box height={1} flexDirection="row" backgroundColor={focusBg("alias")}>
         <box width={11}><text fg={theme.textMuted}>Alias</text></box>
         <text fg={alias ? theme.accent : theme.textMuted}>
-          {alias ? "[x] create shell wrapper" : "[ ] (Tab to toggle)"}
+          {alias ? "[x] create shell wrapper" : "[ ] create shell wrapper"}
         </text>
       </box>
 
       <box height={1} />
       <box height={1}><text fg={theme.textMuted}>
-        {editing === "name"
-          ? "Enter / Esc finish editing"
-          : `[${keys.print("dialog.confirm")}] install  ·  [${keys.print("dialog.deny")}] cancel  ·  Tab alias  ·  n rename`}
+        Enter install  ·  Tab next field  ·  Space toggle  ·  Esc cancel
       </text></box>
     </box>
   )

--- a/src/dialogs/new-profile.tsx
+++ b/src/dialogs/new-profile.tsx
@@ -5,6 +5,8 @@ import { validateName } from "../utils/hermes-profiles"
 import type { DialogContext } from "../ui/dialog"
 
 type Result = { name: string; cloneFrom: string | null; alias: boolean }
+type Field = "name" | "clone" | "alias"
+const ORDER: readonly Field[] = ["name", "clone", "alias"] as const
 
 export function openCreateProfile(dialog: DialogContext, opts: { existing: string[] }): Promise<Result | null> {
   return new Promise(resolve => {
@@ -18,51 +20,76 @@ const Form = ({ existing, done }: { existing: string[]; done: (r: Result | null)
   const [name, setName] = useState("")
   const [cloneIdx, setCloneIdx] = useState(0)
   const [alias, setAlias] = useState(true)
+  const [field, setField] = useState<Field>("name")
   const options = ["(fresh)", ...existing]
   const err = name ? validateName(name, existing) : null
   const valid = !!name && !err
 
+  const submit = () => {
+    if (!valid) return
+    done({ name, cloneFrom: cloneIdx === 0 ? null : options[cloneIdx], alias })
+  }
+
+  const moveField = (dir: 1 | -1) => {
+    const i = ORDER.indexOf(field)
+    setField(ORDER[(i + dir + ORDER.length) % ORDER.length])
+  }
+
   useKeyboard((key) => {
     if (key.name === "escape") return done(null)
-    if (key.name === "return") {
-      if (!valid) return
-      return done({ name, cloneFrom: cloneIdx === 0 ? null : options[cloneIdx], alias })
+    if (key.name === "tab") return moveField(key.shift ? -1 : 1)
+    if (key.name === "return") return submit()
+    if (field === "name") {
+      if (key.name === "backspace") return setName(n => n.slice(0, -1))
+      if (key.raw && key.raw.length === 1 && /[a-z0-9_-]/.test(key.raw))
+        return setName(n => n + key.raw)
+      return
     }
-    if (key.name === "up") return setCloneIdx(i => Math.max(0, i - 1))
-    if (key.name === "down") return setCloneIdx(i => Math.min(options.length - 1, i + 1))
-    if (key.name === "tab") return setAlias(a => !a)
-    if (key.name === "backspace") return setName(n => n.slice(0, -1))
-    if (key.raw && key.raw.length === 1 && /[a-z0-9_-]/.test(key.raw))
-      return setName(n => n + key.raw)
+    if (field === "clone") {
+      if (key.name === "up") return setCloneIdx(i => Math.max(0, i - 1))
+      if (key.name === "down") return setCloneIdx(i => Math.min(options.length - 1, i + 1))
+      return
+    }
+    if (field === "alias") {
+      if (key.name === "space" || key.name === " ") return setAlias(a => !a)
+    }
   })
+
+  const focusBg = (f: Field) => field === f ? theme.backgroundElement : undefined
 
   return (
     <box flexDirection="column" width={54}>
       <box height={1}><text fg={theme.primary}><strong>New Profile</strong></text></box>
       <box height={1} />
-      <box height={1} flexDirection="row">
+      <box height={1} flexDirection="row" backgroundColor={focusBg("name")}>
         <box width={11}><text fg={theme.textMuted}>Name</text></box>
         <text>
           <span fg={valid || !name ? theme.text : theme.error}>{name}</span>
-          <span fg={theme.accent}>█</span>
+          {field === "name" ? <span fg={theme.accent}>█</span> : null}
         </text>
       </box>
       <box height={1}><text fg={theme.textMuted}>  a-z 0-9 _ -  ·  lowercase</text></box>
       <box height={1} />
-      <box height={1}><text fg={theme.textMuted}>Clone from  (↑↓)</text></box>
+      <box height={1} backgroundColor={focusBg("clone")}>
+        <text fg={theme.textMuted}>Clone from  (↑↓)</text>
+      </box>
       {options.map((o, i) => (
-        <box key={o} height={1}>
+        <box key={o} height={1} backgroundColor={focusBg("clone")}>
           <text fg={i === cloneIdx ? theme.accent : theme.text}>
             {i === cloneIdx ? "▸ " : "  "}{o}
           </text>
         </box>
       ))}
       <box height={1} />
+      <box height={1} flexDirection="row" backgroundColor={focusBg("alias")}>
+        <box width={11}><text fg={theme.textMuted}>Alias</text></box>
+        <text fg={alias ? theme.accent : theme.textMuted}>
+          {alias ? "[x] shell alias" : "[ ] shell alias"}
+        </text>
+      </box>
+      <box height={1} />
       <box height={1}><text fg={theme.textMuted}>
-        {`[Tab] shell alias: ${alias ? "yes" : "no"}`}
-      </text></box>
-      <box height={1}><text fg={theme.textMuted}>
-        {valid ? "Enter create  ·  Esc cancel" : err ?? "type a name"}
+        {valid ? "Enter create  ·  Tab next field  ·  Space toggle  ·  Esc cancel" : err ?? "type a name"}
       </text></box>
     </box>
   )

--- a/src/dialogs/new-task.tsx
+++ b/src/dialogs/new-task.tsx
@@ -2,14 +2,15 @@
 //
 // Layout: a vertical form. Fields top-to-bottom: Title (input), Body
 // (textarea), Assignee / Priority / Triage always visible; Tenant /
-// Workspace / Max runtime live under a collapsed "More" section ('m'
-// toggles). Skills is intentionally absent in v1 — tracked separately
-// (tab-completion + chips is a bigger build).
+// Workspace / Max runtime / Skills live under a collapsed "More"
+// section ('m' toggles).
 //
 // Navigation:
 //   ↑/↓            move focus between visible fields (wraps)
 //   Tab / ⇧Tab     same, but also the ONLY way in/out of the Body
-//                  textarea (it owns ↑/↓ for cursor movement)
+//                  textarea (it owns ↑/↓ for cursor movement); on the
+//                  Skills field Tab commits the highlighted match to a
+//                  chip if the filter has matches, otherwise moves field
 //   ↑ at body top / ↓ at body bottom   escape the textarea to the
 //                  adjacent field (the textarea lets edge arrows
 //                  bubble; mid-buffer arrows move the cursor)
@@ -20,17 +21,28 @@
 //   Ctrl+Enter     submit from anywhere
 //   Esc            cancel
 //
+// Skills field:
+//   typing         filters the available skills; matches render inline
+//                  below the input
+//   ↑/↓            navigate matches (only when filter non-empty and
+//                  matches exist); otherwise move form field
+//   Tab            commit the highlighted match as a chip; clears the
+//                  filter. Falls through to field-nav when no matches.
+//   Backspace      with empty filter, pops the last chip
+//
 // The picker is rendered INSIDE this component (a `picker` state swaps
 // the field rows for a <DialogSelect>), so the form never unmounts and
 // the <input>/<textarea> buffers survive a round-trip through a picker.
 
-import { useState, useRef } from "react"
+import { useState, useRef, useEffect, useMemo } from "react"
 import { useKeyboard } from "@opentui/react"
 import type { TextareaRenderable } from "@opentui/core"
 import { useTheme } from "../theme"
+import { useGateway } from "../app/gateway"
 import type { DialogContext } from "../ui/dialog"
 import { DialogSelect } from "../ui/dialog-select"
 import type { SelectOption } from "../ui/dialog-select"
+import { FilterChip } from "../ui/filter-chip"
 
 export type Workspace =
   | { kind: "scratch" }
@@ -47,6 +59,7 @@ export type Draft = {
   tenant: string | null
   workspace: Workspace
   maxRuntime: string | null
+  skills: string[]
 }
 
 export function openCreateTask(
@@ -65,18 +78,18 @@ export function openCreateTask(
 // Visible-field identifiers. "More" is the collapsible header row.
 type Field =
   | "title" | "body" | "assignee" | "priority" | "triage"
-  | "more" | "tenant" | "workspace" | "maxRuntime"
+  | "more" | "tenant" | "workspace" | "maxRuntime" | "skills"
 
 const CORE: Field[] = ["title", "body", "assignee", "priority", "triage", "more"]
-const MORE: Field[] = ["tenant", "workspace", "maxRuntime"]
+const MORE: Field[] = ["tenant", "workspace", "maxRuntime", "skills"]
 
 // Fields that open a picker on Space.
 const SELECTY: ReadonlySet<Field> = new Set(["assignee", "priority", "workspace"])
-// Text-entry fields (plain arrows move form focus — single-line, no
-// vertical cursor to conflict with).
-const TEXTY: ReadonlySet<Field> = new Set(["title", "tenant", "maxRuntime"])
 
 const MAX_RUNTIME_RE = /^\d+[smhd]?$/
+
+// Cap on inline match rows to keep the dialog height bounded.
+const SKILL_MATCHES_MAX = 6
 
 const wsLabel = (w: Workspace): string =>
   w.kind === "scratch" ? "scratch"
@@ -90,12 +103,16 @@ type Picker =
   | { kind: "workspace" }
   | { kind: "dirPath"; value: string }
 
+// A single installed skill, as returned by `skills.manage action=list`.
+type Skill = { cat: string; name: string }
+
 const Form = (p: {
   pool: string[]
   parent?: { id: string; title: string }
   done: (r: Draft | null) => void
 }) => {
   const theme = useTheme().theme
+  const gw = useGateway()
   const body = useRef<TextareaRenderable | null>(null)
   // <textarea> has no onInput(value) — we mirror its content into state
   // via onContentChange (reading .plainText off the ref) so the text
@@ -115,6 +132,49 @@ const Form = (p: {
   const [workspace, setWorkspace] = useState<Workspace>({ kind: "scratch" })
   const [maxRuntime, setMaxRuntime] = useState("")
 
+  // Skills state.
+  const [catalog, setCatalog] = useState<Skill[]>([])
+  const [skills, setSkills] = useState<string[]>([])
+  const [filter, setFilter] = useState("")
+  const [matchIdx, setMatchIdx] = useState(0)
+
+  useEffect(() => {
+    let live = true
+    gw.request<{ skills: Record<string, string[]> }>("skills.manage", { action: "list" })
+      .then(r => {
+        if (!live) return
+        const raw = r.skills ?? {}
+        const out: Skill[] = []
+        for (const cat of Object.keys(raw)) {
+          for (const name of raw[cat] ?? []) out.push({ cat, name })
+        }
+        out.sort((a, b) => a.name.localeCompare(b.name))
+        setCatalog(out)
+      })
+      .catch(() => { /* leave catalog empty — typing still works, just no matches */ })
+    return () => { live = false }
+  }, [gw])
+
+  // Skill matches: case-insensitive substring over name, excluding
+  // already-picked skills. Capped at SKILL_MATCHES_MAX.
+  const matches = useMemo(() => {
+    if (!filter.trim()) return []
+    const q = filter.trim().toLowerCase()
+    const picked = new Set(skills)
+    const hits: Skill[] = []
+    for (const s of catalog) {
+      if (picked.has(s.name)) continue
+      if (s.name.toLowerCase().includes(q) || s.cat.toLowerCase().includes(q)) hits.push(s)
+      if (hits.length >= SKILL_MATCHES_MAX) break
+    }
+    return hits
+  }, [catalog, filter, skills])
+
+  // Clamp match cursor when the list shrinks.
+  useEffect(() => {
+    if (matchIdx > 0 && matchIdx >= matches.length) setMatchIdx(Math.max(0, matches.length - 1))
+  }, [matches.length, matchIdx])
+
   const order = (): Field[] => more ? [...CORE, ...MORE] : CORE
   const titleOk = title.trim().length > 0
   const runtimeOk = maxRuntime.trim() === "" || MAX_RUNTIME_RE.test(maxRuntime.trim())
@@ -132,6 +192,7 @@ const Form = (p: {
       tenant: tenant.trim() || null,
       workspace,
       maxRuntime: maxRuntime.trim() || null,
+      skills,
     })
   }
 
@@ -151,6 +212,18 @@ const Form = (p: {
     if (field === "workspace") return setPicker({ kind: "workspace" })
   }
 
+  // Commit the highlighted match as a chip and clear the filter.
+  const commitMatch = () => {
+    const hit = matches[matchIdx]
+    if (!hit) return false
+    setSkills(s => s.includes(hit.name) ? s : [...s, hit.name])
+    setFilter("")
+    setMatchIdx(0)
+    return true
+  }
+
+  const popSkill = () => setSkills(s => s.slice(0, -1))
+
   useKeyboard((key) => {
     // Picker owns the keyboard while open; DialogSelect has its own
     // useKeyboard. Esc backs out one level: dirPath → workspace picker
@@ -168,6 +241,40 @@ const Form = (p: {
       if (field !== "body") return submit()
       return // body textarea owns plain Enter (newline)
     }
+
+    // Skills field owns the input buffer — intercept Tab/Bksp/arrows
+    // and printable keys here so autocomplete works. Escape and Enter
+    // are handled above so the form still cancels/submits from Skills.
+    if (field === "skills") {
+      if (key.name === "tab") {
+        // Shift+Tab always moves fields (backwards). Plain Tab commits
+        // a match; falls through to field-nav when filter is empty or
+        // has no matches.
+        if (!key.shift && commitMatch()) return
+        return moveField(key.shift ? -1 : 1)
+      }
+      if (key.name === "backspace") {
+        if (filter.length > 0) return setFilter(f => f.slice(0, -1))
+        return popSkill()
+      }
+      if (key.name === "up") {
+        if (matches.length > 0) return setMatchIdx(i => Math.max(0, i - 1))
+        return moveField(-1)
+      }
+      if (key.name === "down") {
+        if (matches.length > 0) return setMatchIdx(i => Math.min(matches.length - 1, i + 1))
+        return moveField(1)
+      }
+      // Printable: append to filter. Limit to skill-name legal chars so
+      // stray shortcuts don't land in the buffer; skill names use
+      // [a-z0-9_-] plus `/` for "category/name" scoped search.
+      if (key.raw && key.raw.length === 1 && /[A-Za-z0-9_\-/ ]/.test(key.raw)) {
+        setFilter(f => f + key.raw)
+        setMatchIdx(0)
+      }
+      return
+    }
+
     if (key.name === "tab") return moveField(key.shift ? -1 : 1)
 
     // Arrow nav. ↑/↓ move focus between fields — EXCEPT inside the body
@@ -326,17 +433,72 @@ const Form = (p: {
     </box>
   )
 
+  // Skills row + inline match list. Chips render as FilterChip{state:in}
+  // so they match every other pill in herm. The filter text sits at the
+  // end of the chip row with a blinking cursor marker when focused.
+  const skillsRows = () => {
+    const focused = field === "skills"
+    const empty = skills.length === 0 && !focused
+    return (
+      <>
+        <box height={1} flexDirection="row">
+          {lbl("skills", "Skills")}
+          <box flexGrow={1} minWidth={0} height={1} flexDirection="row" overflow="hidden">
+            {skills.map(n => (
+              <FilterChip key={n} label={n} state="in" gap={0} />
+            ))}
+            {empty
+              ? <text fg={theme.textMuted}>(none — focus field to pick)</text>
+              : (
+                <box flexDirection="row" marginLeft={skills.length > 0 ? 1 : 0}>
+                  <text fg={theme.text}>{filter}</text>
+                  {focused ? <text fg={theme.accent}>█</text> : null}
+                </box>
+              )}
+          </box>
+        </box>
+        {focused && matches.length > 0 ? (
+          <box flexDirection="column">
+            {matches.map((s, i) => (
+              <box key={`${s.cat}/${s.name}`} height={1} flexDirection="row">
+                <box width={13} flexShrink={0}>
+                  <text fg={i === matchIdx ? theme.accent : theme.textMuted}>
+                    {i === matchIdx ? "  ▸ " : "    "}
+                  </text>
+                </box>
+                <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
+                  <text>
+                    <span fg={i === matchIdx ? theme.accent : theme.text}>{s.name}</span>
+                    <span fg={theme.textMuted}>{`  ${s.cat}`}</span>
+                  </text>
+                </box>
+              </box>
+            ))}
+          </box>
+        ) : null}
+      </>
+    )
+  }
+
+  const skillsFooter = () => {
+    if (matches.length > 0) return "Tab add  ·  ↑↓ pick  ·  Bksp remove  ·  Enter create  ·  Esc"
+    if (skills.length > 0) return "type to filter  ·  Bksp remove last  ·  Enter create  ·  ↑↓/Tab  ·  Esc"
+    return "type to filter  ·  Enter create  ·  ↑↓/Tab field  ·  Esc cancel"
+  }
+
   const footer = !valid
     ? (!titleOk ? "type a title" : "fix runtime (e.g. 30m, 2h, 1800)")
     : field === "body"
       ? "Ctrl+Enter create  ·  Tab leave  ·  ↑↓ cursor  ·  Esc cancel"
       : field === "more"
         ? `Space ${more ? "collapse" : "expand"}  ·  Ctrl+Enter create  ·  ↑↓/Tab  ·  Esc`
-        : SELECTY.has(field)
-          ? "Space pick  ·  Enter create  ·  ↑↓/Tab field  ·  Esc cancel"
-          : field === "triage"
-            ? "Space toggle  ·  Enter create  ·  ↑↓/Tab field  ·  Esc"
-            : "Enter create  ·  ↑↓/Tab field  ·  Esc cancel"
+        : field === "skills"
+          ? skillsFooter()
+          : SELECTY.has(field)
+            ? "Space pick  ·  Enter create  ·  ↑↓/Tab field  ·  Esc cancel"
+            : field === "triage"
+              ? "Space toggle  ·  Enter create  ·  ↑↓/Tab field  ·  Esc"
+              : "Enter create  ·  ↑↓/Tab field  ·  Esc cancel"
 
   return (
     <box flexDirection="column" width={66}>
@@ -384,7 +546,7 @@ const Form = (p: {
         </box>
         {!more ? (
           <box flexGrow={1} height={1} overflow="hidden">
-            <text fg={theme.textMuted}>tenant · workspace · max runtime</text>
+            <text fg={theme.textMuted}>tenant · workspace · runtime · skills</text>
           </box>
         ) : null}
       </box>
@@ -392,6 +554,7 @@ const Form = (p: {
       {more ? textRow("tenant", "Tenant", tenant, setTenant, "namespace (optional)") : null}
       {more ? valRow("workspace", "Workspace", wsLabel(workspace), "Space pick ▾") : null}
       {more ? textRow("maxRuntime", "Runtime", maxRuntime, setMaxRuntime, "e.g. 30m, 2h, 1800 (optional)") : null}
+      {more ? skillsRows() : null}
 
       <box height={1} />
       <box height={1}><text fg={theme.textMuted}>{footer}</text></box>

--- a/src/dialogs/profile.tsx
+++ b/src/dialogs/profile.tsx
@@ -84,7 +84,7 @@ export function openProfileMenu(dialog: DialogContext, p: ProfileInfo, ops: Prof
   )
 }
 
-// Update confirm. Quotes source + version, offers a Tab-toggled
+// Update confirm. Quotes source + version, offers a Space-toggled
 // `--force-config` checkbox, and warns when updating the active
 // profile (gateway will re-spawn; current session is lost).
 const UpdateForm = (props: { p: ProfileInfo; done: (force: boolean | null) => void }) => {
@@ -94,7 +94,7 @@ const UpdateForm = (props: { p: ProfileInfo; done: (force: boolean | null) => vo
   useKeyboard((key) => {
     if (keys.match("dialog.cancel", key) || keys.match("dialog.deny", key)) return props.done(null)
     if (keys.match("dialog.confirm", key) || keys.match("dialog.accept", key)) return props.done(force)
-    if (key.name === "tab") return setForce(f => !f)
+    if (key.name === "space" || key.name === " ") return setForce(f => !f)
   })
   const d = props.p.distribution!
   return (
@@ -129,7 +129,7 @@ const UpdateForm = (props: { p: ProfileInfo; done: (force: boolean | null) => vo
       </box>
       <box height={1}>
         <text fg={theme.textMuted}>
-          {`[${keys.print("dialog.confirm")}] update   [Tab] toggle force   [${keys.print("dialog.cancel")}] cancel`}
+          {`[${keys.print("dialog.confirm")}] update   [Space] toggle force   [${keys.print("dialog.cancel")}] cancel`}
         </text>
       </box>
     </box>

--- a/src/keys/catalog.ts
+++ b/src/keys/catalog.ts
@@ -95,6 +95,7 @@ export const DEFAULTS = {
   "agents.history":    def("h",                    "Spawn history",                      "agents"),	// k: keep
   "agents.install":    def("i",                    "Install distribution",               "agents"),	// ☨
   "config.save":       def("ctrl+s",               "Write config",                       "config"),
+  "config.mode":       def("m",                    "Toggle form ↔ YAML",                 "config"), // ☨
 } satisfies Record<string, Def>
 
 export type ActionId = keyof typeof DEFAULTS

--- a/src/tabs/Agents.tsx
+++ b/src/tabs/Agents.tsx
@@ -645,14 +645,30 @@ export const Agents = memo((props: Props) => {
       category: "Agents", description: "from git URL or local directory", onSelect: install },
   ]), [cmd, togglePause, deleg?.paused, install])
 
-  const sw = props.onSwitchProfile ? "s switch  " : ""
+  const pair = (k: string, v: string) => `[${k}] ${v}`
+  const join = (...parts: string[]) => parts.filter(Boolean).join("  ")
+  const sw = props.onSwitchProfile ? pair("s", "switch") : ""
   const pHint = pWide
-    ? `↑↓ nav  ${keys.print("list.activate")} actions  ${sw}${keys.print("list.new")} new  ${keys.print("agents.install")} install  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} refresh`
-    : pView === "list" ? `↑↓ nav  ${keys.print("list.activate")} detail  ${sw}${keys.print("list.new")} new  ${keys.print("list.delete")} delete`
-    : `${keys.print("list.activate")} actions  ${sw}Esc back  ${keys.print("list.delete")} delete`
+    ? join("[↑↓] nav", pair(keys.print("list.activate"), "actions"), sw,
+           pair(keys.print("list.new"), "new"),
+           pair(keys.print("agents.install"), "install"),
+           pair(keys.print("list.delete"), "delete"),
+           pair(keys.print("list.refresh"), "refresh"))
+    : pView === "list"
+      ? join("[↑↓] nav", pair(keys.print("list.activate"), "detail"), sw,
+             pair(keys.print("list.new"), "new"),
+             pair(keys.print("list.delete"), "delete"))
+      : join(pair(keys.print("list.activate"), "actions"), sw, "[Esc] back",
+             pair(keys.print("list.delete"), "delete"))
 
-  const profilesHint = `${pHint}  Tab ${wide ? "→" : "↔"} delegation`
-  const delegHint = `↑↓ nav  ${keys.print("agents.kill")} interrupt  ${keys.print("agents.history")} history  ${keys.print("list.refresh")} refresh  ·  ${dHint}`
+  const profilesHint = `${pHint}  ${pair("Tab", wide ? "→ delegation" : "↔ delegation")}`
+  const delegKeys = join(
+    "[↑↓] nav",
+    pair(keys.print("agents.kill"), "interrupt"),
+    pair(keys.print("agents.history"), "history"),
+    pair(keys.print("list.refresh"), "refresh"),
+  )
+  const delegHint = dHint ? `${delegKeys}  ·  ${dHint}` : delegKeys
   // Wide: both panes visible, footer joins hints by focused pane order.
   // Narrow: only one pane rendered, footer matches.
   const footerHint = wide

--- a/src/tabs/Agents.tsx
+++ b/src/tabs/Agents.tsx
@@ -14,6 +14,7 @@ import { openProfileMenu } from "../dialogs/profile"
 import { openCreateProfile } from "../dialogs/new-profile"
 import { openInstallDistribution } from "../dialogs/install-distribution"
 import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
 import { Spinner } from "../ui/spinner"
 import { KV, KVBlock } from "../ui/kv"
 import { KVLink } from "../components/ui/FileLink"
@@ -650,12 +651,20 @@ export const Agents = memo((props: Props) => {
     : pView === "list" ? `↑↓ nav  ${keys.print("list.activate")} detail  ${sw}${keys.print("list.new")} new  ${keys.print("list.delete")} delete`
     : `${keys.print("list.activate")} actions  ${sw}Esc back  ${keys.print("list.delete")} delete`
 
+  const profilesHint = `${pHint}  Tab ${wide ? "→" : "↔"} delegation`
+  const delegHint = `↑↓ nav  ${keys.print("agents.kill")} interrupt  ${keys.print("agents.history")} history  ${keys.print("list.refresh")} refresh  ·  ${dHint}`
+  // Wide: both panes visible, footer joins hints by focused pane order.
+  // Narrow: only one pane rendered, footer matches.
+  const footerHint = wide
+    ? (pane === "profiles" ? `${profilesHint}  ·  ${delegHint}` : `${delegHint}  ·  ${profilesHint}`)
+    : (pane === "profiles" ? profilesHint : delegHint)
+
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <box flexDirection="row" flexGrow={1}>
       {/* ── Profiles ── */}
       {showProfiles ? (
       <TabShell title={`Profiles (${profiles.length})${sticky ? `  ·  ★ ${sticky}` : ""}`}
-                hint={`${pHint}  Tab ${wide ? "→" : "↔"} delegation`}
                 error={err || null}
                 focus={pane === "profiles"} grow={3}>
         <box flexDirection="row" flexGrow={1} minWidth={0}>
@@ -688,7 +697,6 @@ export const Agents = memo((props: Props) => {
       {/* ── Delegation ── */}
       {showDeleg ? (
       <TabShell title={`Delegation (${active.length})`}
-                hint={`↑↓ nav  ${keys.print("agents.kill")} interrupt  ${keys.print("agents.history")} history  ${keys.print("list.refresh")} refresh  ·  ${dHint}`}
                 focus={pane === "deleg"} grow={2}>
         <box height={1} flexDirection="row" marginBottom={1}>
           <box flexShrink={0} paddingX={1}
@@ -730,6 +738,8 @@ export const Agents = memo((props: Props) => {
         )}
       </TabShell>
       ) : null}
+    </box>
+    <HintBar raw={footerHint} />
     </box>
   )
 })

--- a/src/tabs/Analytics.tsx
+++ b/src/tabs/Analytics.tsx
@@ -7,6 +7,7 @@ import { useKeys } from "../keys"
 import { useTheme } from "../theme"
 import { Spinner } from "../ui/spinner"
 import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
 import { Col, Hdr } from "../ui/table"
 import { fmt, cost, trunc } from "../ui/fmt"
 
@@ -148,9 +149,12 @@ export const Analytics = memo((props: { focused?: boolean }) => {
   const chartH = dims.height >= 40 ? 8 : 6
 
   if (!data) return (
-    <TabShell title={title} hint="1/7/3/9 period · r reload">
-      <box height={1}><Spinner label={`aggregating ${days}d…`} /></box>
-    </TabShell>
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <TabShell title={title}>
+        <box height={1}><Spinner label={`aggregating ${days}d…`} /></box>
+      </TabShell>
+      <HintBar raw="1/7/3/9 period · r reload" />
+    </box>
   )
 
   // Tools/Sources section height: header + n rows. Wide=side-by-side so
@@ -162,7 +166,8 @@ export const Analytics = memo((props: { focused?: boolean }) => {
   const ranksH = wide ? Math.max(nTools, nSrc) + 1 : nTools + nSrc + 3
 
   return (
-    <TabShell title={title} hint="1/7/3/9 period · r reload">
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
+    <TabShell title={title}>
       <box flexDirection="column" flexGrow={1} minWidth={0} overflow="hidden">
         {/* Summary + chart — fixed block */}
         <box flexShrink={0} flexDirection="column">
@@ -210,5 +215,7 @@ export const Analytics = memo((props: { focused?: boolean }) => {
         </box>
       </box>
     </TabShell>
+    <HintBar raw="1/7/3/9 period · r reload" />
+    </box>
   )
 })

--- a/src/tabs/Analytics.tsx
+++ b/src/tabs/Analytics.tsx
@@ -153,7 +153,10 @@ export const Analytics = memo((props: { focused?: boolean }) => {
       <TabShell title={title}>
         <box height={1}><Spinner label={`aggregating ${days}d…`} /></box>
       </TabShell>
-      <HintBar raw="1/7/3/9 period · r reload" />
+      <HintBar pairs={[
+        ["1/7/3/9", "period"],
+        [keys.print("list.refresh"), "reload"],
+      ]} />
     </box>
   )
 
@@ -215,7 +218,10 @@ export const Analytics = memo((props: { focused?: boolean }) => {
         </box>
       </box>
     </TabShell>
-    <HintBar raw="1/7/3/9 period · r reload" />
+    <HintBar pairs={[
+      ["1/7/3/9", "period"],
+      [keys.print("list.refresh"), "reload"],
+    ]} />
     </box>
   )
 })

--- a/src/tabs/Config.tsx
+++ b/src/tabs/Config.tsx
@@ -7,6 +7,7 @@ import { useToast } from "../ui/toast";
 import { useDialog } from "../ui/dialog";
 import { openConfirm } from "../dialogs/confirm";
 import { TabShell } from "../ui/shell";
+import { HintBar } from "../ui/hint";
 import { Col, Hdr, VBAR } from "../ui/table";
 import { stringify as yamlStringify, parse as yamlParse } from "yaml";
 import { writeConfig, verifyWrite, maxEffect } from "../config/lane";
@@ -460,7 +461,8 @@ export const Config = memo((props: { focused?: boolean }) => {
 
   if (mode === "yaml") {
     return (
-      <TabShell title="Config · YAML" hint={`Tab form  ${keys.print("config.save")} save`}>
+      <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <TabShell title="Config · YAML">
         <scrollbox scrollY flexGrow={1}>
           <text wrapMode="word">
             <span fg={theme.text}>{yaml}</span>
@@ -468,6 +470,8 @@ export const Config = memo((props: { focused?: boolean }) => {
           </text>
         </scrollbox>
       </TabShell>
+      <HintBar raw={`Tab form  ${keys.print("config.save")} save`} />
+      </box>
     );
   }
 
@@ -489,7 +493,7 @@ export const Config = memo((props: { focused?: boolean }) => {
       ) : null}
       <box flexDirection="row" flexGrow={1}>
         {searching ? null : (
-          <TabShell title="Config" hint="↑↓ → select" grow={1}
+          <TabShell title="Config" grow={1}
                     focus={focus === "categories"}>
             <scrollbox ref={catFollow.ref} scrollY flexGrow={1}>
               {groups.map((c, i) => {
@@ -522,11 +526,6 @@ export const Config = memo((props: { focused?: boolean }) => {
         <TabShell
           title={onSlots ? "models · applies immediately"
             : searching ? "Search" : nChanged > 0 ? `${active} · ${nChanged} unsaved` : active}
-          hint={managed
-            ? `read-only · managed by ${managed}`
-            : onSlots
-              ? "←→ pane  ↑↓ nav  Enter pick  x reset  X reset-all"
-              : `${dirty}Tab yaml  ←→ pane  ↑↓ nav  ${keys.print("list.search")} search  ${keys.print("config.save")} save`}
           grow={3} focus={focus === "fields" || searching}
         >
           {managed ? (
@@ -600,6 +599,13 @@ export const Config = memo((props: { focused?: boolean }) => {
           </>)}
         </TabShell>
       </box>
+      <HintBar raw={managed
+        ? `read-only · managed by ${managed}`
+        : onSlots
+          ? "←→ pane  ↑↓ nav  Enter pick  x reset  X reset-all"
+          : focus === "categories" && !searching
+            ? "↑↓ → select"
+            : `${dirty}Tab yaml  ←→ pane  ↑↓ nav  ${keys.print("list.search")} search  ${keys.print("config.save")} save`} />
     </box>
   );
 });

--- a/src/tabs/Config.tsx
+++ b/src/tabs/Config.tsx
@@ -457,8 +457,6 @@ export const Config = memo((props: { focused?: boolean }) => {
     }
   });
 
-  const dirty = nChanged > 0 ? `● ${nChanged} unsaved  ` : "";
-
   if (mode === "yaml") {
     return (
       <box flexDirection="column" flexGrow={1} minWidth={0}>
@@ -470,7 +468,10 @@ export const Config = memo((props: { focused?: boolean }) => {
           </text>
         </scrollbox>
       </TabShell>
-      <HintBar raw={`Tab form  ${keys.print("config.save")} save`} />
+      <HintBar pairs={[
+        ["Tab", "form"],
+        [keys.print("config.save"), "save"],
+      ]} />
       </box>
     );
   }
@@ -599,13 +600,28 @@ export const Config = memo((props: { focused?: boolean }) => {
           </>)}
         </TabShell>
       </box>
-      <HintBar raw={managed
-        ? `read-only · managed by ${managed}`
+      {managed
+        ? <HintBar raw={`read-only · managed by ${managed}`} />
         : onSlots
-          ? "←→ pane  ↑↓ nav  Enter pick  x reset  X reset-all"
+          ? <HintBar pairs={[
+              ["←→", "pane"],
+              ["↑↓", "nav"],
+              ["Enter", "pick"],
+              ["x", "reset"],
+              ["X", "reset-all"],
+            ]} />
           : focus === "categories" && !searching
-            ? "↑↓ → select"
-            : `${dirty}Tab yaml  ←→ pane  ↑↓ nav  ${keys.print("list.search")} search  ${keys.print("config.save")} save`} />
+            ? <HintBar pairs={[["↑↓→", "select"]]} />
+            : <HintBar
+                pairs={[
+                  ["Tab", "yaml"],
+                  ["←→", "pane"],
+                  ["↑↓", "nav"],
+                  [keys.print("list.search"), "search"],
+                  [keys.print("config.save"), "save"],
+                ]}
+                suffix={nChanged > 0 ? `● ${nChanged} unsaved` : undefined}
+              />}
     </box>
   );
 });

--- a/src/tabs/Config.tsx
+++ b/src/tabs/Config.tsx
@@ -345,7 +345,7 @@ export const Config = memo((props: { focused?: boolean }) => {
   const keys = useKeys();
   useKeyboard((key) => {
     if (!props.focused || dialog.open()) return;
-    if (key.name === "tab" && !editing && !searching) {
+    if (keys.match("config.mode", key) && !editing && !searching) {
       setMode(m => m === "form" ? "yaml" : "form");
       return;
     }
@@ -399,8 +399,10 @@ export const Config = memo((props: { focused?: boolean }) => {
       return;
     }
 
-    if (key.name === "left") { setFocus("categories"); return; }
-    if (key.name === "right") { setFocus("fields"); return; }
+    if (key.name === "tab") {
+      setFocus(f => f === "categories" ? "fields" : "categories");
+      return;
+    }
     if (keys.match("list.search", key)) { setSearching(true); setQuery(""); setCursor(0); return; }
 
     if (focus === "categories") {
@@ -460,7 +462,7 @@ export const Config = memo((props: { focused?: boolean }) => {
 
   if (mode === "yaml") {
     return (
-      <TabShell title="Config · YAML" hint={`Tab form  ${keys.print("config.save")} save`}>
+      <TabShell title="Config · YAML" hint={`${keys.print("config.mode")} form  ${keys.print("config.save")} save`}>
         <scrollbox scrollY flexGrow={1}>
           <text wrapMode="word">
             <span fg={theme.text}>{yaml}</span>
@@ -489,7 +491,7 @@ export const Config = memo((props: { focused?: boolean }) => {
       ) : null}
       <box flexDirection="row" flexGrow={1}>
         {searching ? null : (
-          <TabShell title="Config" hint="↑↓ → select" grow={1}
+          <TabShell title="Config" hint="↑↓ select  Tab fields" grow={1}
                     focus={focus === "categories"}>
             <scrollbox ref={catFollow.ref} scrollY flexGrow={1}>
               {groups.map((c, i) => {
@@ -525,8 +527,8 @@ export const Config = memo((props: { focused?: boolean }) => {
           hint={managed
             ? `read-only · managed by ${managed}`
             : onSlots
-              ? "←→ pane  ↑↓ nav  Enter pick  x reset  X reset-all"
-              : `${dirty}Tab yaml  ←→ pane  ↑↓ nav  ${keys.print("list.search")} search  ${keys.print("config.save")} save`}
+              ? "↑↓ nav  Enter pick  x reset  X reset-all  Tab categories"
+              : `${dirty}${keys.print("config.mode")} yaml  Tab categories  ↑↓ nav  ${keys.print("list.search")} search  ${keys.print("config.save")} save`}
           grow={3} focus={focus === "fields" || searching}
         >
           {managed ? (

--- a/src/tabs/Context.tsx
+++ b/src/tabs/Context.tsx
@@ -38,6 +38,7 @@ import {
 import { FileLink } from "../components/ui/FileLink"
 import { useTheme, type Theme } from "../theme"
 import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
 import { categorical } from "../utils/categorical"
 import type { RGBA } from "@opentui/core"
 
@@ -542,9 +543,9 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
   const focusSeg = focus ? findSeg(focus) : null
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <TabShell
       title={`Context · ${fmt(fill)} / ${fmt(ctxLen)} (${pct}%)`}
-      hint={crumb + escHint}
     >
       <box height={1}>
         {focusSeg ? (
@@ -600,5 +601,7 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
         </box>
       </box>
     </TabShell>
+    <HintBar raw={crumb + escHint} />
+    </box>
   )
 })

--- a/src/tabs/Cron.tsx
+++ b/src/tabs/Cron.tsx
@@ -291,7 +291,13 @@ export const Cron = memo((props: { focused?: boolean }) => {
 
       {showDetail ? <DetailPanel job={job} reloadKey={reloadKey} /> : null}
     </box>
-    <HintBar raw={`↑↓ nav  ${keys.print("list.new")} new  ${keys.print("list.toggle")} pause/resume  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} refresh`} />
+    <HintBar pairs={[
+      ["↑↓", "nav"],
+      [keys.print("list.new"), "new"],
+      [keys.print("list.toggle"), "pause/resume"],
+      [keys.print("list.delete"), "delete"],
+      [keys.print("list.refresh"), "refresh"],
+    ]} />
     </box>
   );
 });

--- a/src/tabs/Cron.tsx
+++ b/src/tabs/Cron.tsx
@@ -7,6 +7,7 @@ import { useDialog } from "../ui/dialog";
 import { useToast } from "../ui/toast";
 import { openConfirm } from "../dialogs/confirm";
 import { TabShell } from "../ui/shell";
+import { HintBar } from "../ui/hint";
 import { KVBlock } from "../ui/kv";
 import { Col, Hdr, VBAR } from "../ui/table";
 import { openTextPrompt } from "../dialogs/text-prompt";
@@ -130,7 +131,7 @@ const DetailPanel = memo((props: { job: CronJob; reloadKey: number }) => {
   }, [j.id, props.reloadKey]);
 
   return (
-    <TabShell title="Job Detail" hint="" grow={2}>
+    <TabShell title="Job Detail" grow={2}>
       <scrollbox scrollY flexGrow={1}>
         <box flexDirection="column" width="100%">
           <box minHeight={1}>
@@ -255,9 +256,9 @@ export const Cron = memo((props: { focused?: boolean }) => {
   const showDetail = dims.width >= 120 && job !== null;
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <box flexDirection="row" flexGrow={1}>
-      <TabShell title={`Cron Jobs (${jobs.length})`} error={err} grow={3}
-                hint={`↑↓ nav  ${keys.print("list.new")} new  ${keys.print("list.toggle")} pause/resume  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} refresh`}>
+      <TabShell title={`Cron Jobs (${jobs.length})`} error={err} grow={3}>
         {jobs.length === 0 ? (
           <box key="empty" flexGrow={1}>
             <text fg={theme.textMuted}>No cron jobs. Press n to create one.</text>
@@ -289,6 +290,8 @@ export const Cron = memo((props: { focused?: boolean }) => {
       </TabShell>
 
       {showDetail ? <DetailPanel job={job} reloadKey={reloadKey} /> : null}
+    </box>
+    <HintBar raw={`↑↓ nav  ${keys.print("list.new")} new  ${keys.print("list.toggle")} pause/resume  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} refresh`} />
     </box>
   );
 });

--- a/src/tabs/Env.tsx
+++ b/src/tabs/Env.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "../theme"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
 import { Col, Hdr, VBAR } from "../ui/table"
 import { openTextPrompt } from "../dialogs/text-prompt"
 import { openConfirm } from "../dialogs/confirm"
@@ -160,11 +161,9 @@ export const Env = memo((props: { focused?: boolean }) => {
   })
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <TabShell
       title={searching ? "Env (searching)" : "Env / API Keys"}
-      hint={searching
-        ? "↑↓ move  Enter reveal/edit  Esc cancel"
-        : `↑↓ move  ${keys.print("list.activate")} reveal/edit  ${keys.print("list.toggle")} show-all  ${keys.print("list.new")} new  ${keys.print("list.delete")} delete  ${keys.print("list.search")} search  ${keys.print("list.refresh")} reload`}
     >
       {searching ? (
         <box height={1}>
@@ -223,5 +222,9 @@ export const Env = memo((props: { focused?: boolean }) => {
         </scrollbox>
       )}
     </TabShell>
+    <HintBar raw={searching
+      ? "↑↓ move  Enter reveal/edit  Esc cancel"
+      : `↑↓ move  ${keys.print("list.activate")} reveal/edit  ${keys.print("list.toggle")} show-all  ${keys.print("list.new")} new  ${keys.print("list.delete")} delete  ${keys.print("list.search")} search  ${keys.print("list.refresh")} reload`} />
+    </box>
   )
 })

--- a/src/tabs/Env.tsx
+++ b/src/tabs/Env.tsx
@@ -222,9 +222,21 @@ export const Env = memo((props: { focused?: boolean }) => {
         </scrollbox>
       )}
     </TabShell>
-    <HintBar raw={searching
-      ? "↑↓ move  Enter reveal/edit  Esc cancel"
-      : `↑↓ move  ${keys.print("list.activate")} reveal/edit  ${keys.print("list.toggle")} show-all  ${keys.print("list.new")} new  ${keys.print("list.delete")} delete  ${keys.print("list.search")} search  ${keys.print("list.refresh")} reload`} />
+    <HintBar pairs={searching
+      ? [
+          ["↑↓", "move"],
+          ["Enter", "reveal/edit"],
+          ["Esc", "cancel"],
+        ]
+      : [
+          ["↑↓", "move"],
+          [keys.print("list.activate"), "reveal/edit"],
+          [keys.print("list.toggle"), "show-all"],
+          [keys.print("list.new"), "new"],
+          [keys.print("list.delete"), "delete"],
+          [keys.print("list.search"), "search"],
+          [keys.print("list.refresh"), "reload"],
+        ]} />
     </box>
   )
 })

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -1091,8 +1091,8 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       : "←→↑↓ nav  Enter detail"
     return [tier === "pane" ? "Esc grid" : "Tab board", nav,
       ...ACTS.filter(a => a.when(t)).map(a => `${a.key} ${a.title.toLowerCase()}`),
-      "r reload"].join("  ")
-  }, [ACTS, task, tier])
+      `${keys.print("list.refresh")} reload`].join("  ")
+  }, [ACTS, keys, task, tier])
 
   const onHead = useCallback((s: string) => {
     setAt(s); setTier("head"); toggle(s)

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -4,7 +4,9 @@ import type { BorderSides, ScrollBoxRenderable } from "@opentui/core"
 import {
   boardOf, detailOf, tailLogOf, assignees, q, STATUSES,
   currentBoard, listBoards, resetKanban, patchTask,
+  parseDiagnostics, maxSeverity, sortDiags,
   type Task, type Status, type Detail, type Board,
+  type Diag, type Severity,
 } from "../utils/hermes-kanban"
 import { useKeys } from "../keys"
 import { useTheme } from "../theme"
@@ -81,6 +83,8 @@ type Mask = {
 }
 
 const EMPTY: Mask = { who: new Map(), pri: new Map(), status: new Map() }
+const EMPTY_DIAG: Map<string, Diag[]> = new Map()
+const EMPTY_DIAGS: Diag[] = []
 
 const chipId = (c: Chip) =>
   c.kind === "who" ? `who:${c.v}` : c.kind === "pri" ? `pri:${c.v}` : `st:${c.v}`
@@ -102,6 +106,16 @@ function admits<V>(g: Map<V, Tri>, v: V): boolean {
 const pass = (t: Task, m: Mask) =>
   admits(m.who, t.assignee ?? null as unknown as string)
   && admits(m.pri, t.priority)
+
+/** Index parsed diagnostic rows by task_id for O(1) lookup from the
+ *  card renderer. Empty rows are stripped so maxSeverity() on an
+ *  absent map entry is always null. */
+const indexDiags = (rows: ReturnType<typeof parseDiagnostics>): Map<string, Diag[]> => {
+  const out = new Map<string, Diag[]>()
+  for (const r of rows)
+    if (r.diagnostics.length > 0) out.set(r.task_id, sortDiags(r.diagnostics))
+  return out
+}
 
 // ── Persistence (t_cce26780) ───────────────────────────────────────
 // Masks + open-set round-trip through ~/.config/herm/tui.json under
@@ -155,8 +169,17 @@ const persist = (masks: Map<string, Mask>, open: Set<string>) => {
 // last-hovered tracking could miss the stale element's onMouseOut,
 // leaving a row marqueeing after the pointer left.
 
+// Severity → one-glyph badge + color. Keeps cards one line regardless
+// of diagnostics count; the pane shows the full list.
+const SEV_GLYPH: Record<Severity, string> = {
+  warning: "⚠", error: "!!", critical: "‼",
+}
+type SevTheme = { warning: import("@opentui/core").RGBA; error: import("@opentui/core").RGBA }
+const sevColor = (sev: Severity, theme: SevTheme) =>
+  sev === "warning" ? theme.warning : theme.error
+
 const Card = memo((p: {
-  id: string; t: Task; on: boolean; hov: boolean
+  id: string; t: Task; on: boolean; hov: boolean; sev: Severity | null
   onHover: () => void; onPick: () => void
 }) => {
   const theme = useTheme().theme
@@ -167,6 +190,9 @@ const Card = memo((p: {
          onMouseDown={p.onPick}
          onMouseMove={p.onHover}>
       <Ticker active={p.on || p.hov} fg={p.on ? theme.accent : theme.text}>
+        {p.sev
+          ? <><span fg={sevColor(p.sev, theme)}>{SEV_GLYPH[p.sev]}</span>{" "}</>
+          : null}
         {p.t.title}
       </Ticker>
     </box>
@@ -175,6 +201,7 @@ const Card = memo((p: {
 
 const Column = memo((p: {
   slug: string; status: Status; tasks: Task[]; on: boolean; sel: number
+  diags: Map<string, Diag[]>
   onPick: (i: number) => void
 }) => {
   const theme = useTheme().theme
@@ -207,6 +234,7 @@ const Column = memo((p: {
           {p.tasks.map((t, i) => (
             <Card key={t.id} id={id(i)} t={t} on={p.on && i === p.sel}
                   hov={i === hov}
+                  sev={maxSeverity(p.diags.get(t.id) ?? [])}
                   onHover={() => { if (hov !== i) setHov(i) }}
                   onPick={() => p.onPick(i)} />
           ))}
@@ -275,7 +303,7 @@ type Pane =
   | { kind: "detail"; slug: string; d: Detail }
   | { kind: "log"; slug: string; id: string; text: string }
 
-const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
+const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] }) => {
   const { theme, syntaxStyle } = useTheme()
   if (p.pane.kind === "log") return (
     <box flexDirection="column" padding={1} border borderColor={theme.border}
@@ -428,6 +456,41 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number }) => {
                   : <text fg={theme.textMuted}>—</text>,
                 p.on && cur === "result" ? "Enter edit" : undefined)
             : null}
+          {p.diags.length > 0 ? <>
+            <box height={1} marginTop={1}>
+              <text>
+                <span fg={theme.textMuted}>Diagnostics </span>
+                <span fg={sevColor(p.diags[0].severity, theme)}>{`(${p.diags.length})`}</span>
+              </text>
+            </box>
+            {p.diags.map((dx, i) => (
+              <box key={`${dx.kind}-${i}`} flexDirection="column" marginTop={i === 0 ? 0 : 1}>
+                <box height={1}>
+                  <text>
+                    <span fg={sevColor(dx.severity, theme)}>{SEV_GLYPH[dx.severity]}</span>
+                    <span fg={theme.text}>{` [${dx.severity}] ${dx.kind}`}</span>
+                    {dx.count > 1 ? <span fg={theme.textMuted}>{`  ×${dx.count}`}</span> : null}
+                  </text>
+                </box>
+                <box paddingLeft={2} flexDirection="column">
+                  <text wrapMode="word" fg={theme.text}>{dx.title}</text>
+                  {dx.detail
+                    ? <text wrapMode="word" fg={theme.textMuted}>{dx.detail}</text>
+                    : null}
+                  {dx.actions.map((a, j) => (
+                    <box key={j} height={1}>
+                      <text>
+                        <span fg={a.suggested ? theme.accent : theme.textMuted}>
+                          {a.suggested ? "→ " : "· "}
+                        </span>
+                        <span fg={a.suggested ? theme.text : theme.textMuted}>{a.label}</span>
+                      </text>
+                    </box>
+                  ))}
+                </box>
+              </box>
+            ))}
+          </> : null}
           {d.runs.length > 0 ? <>
             <box height={1} marginTop={1}>
               <text fg={theme.textMuted}>{`Runs (${d.runs.length})`}</text>
@@ -508,6 +571,12 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const [data, setData] = useState<Map<string, Map<Status, Task[]>>>(
     () => new Map(boards.map(b => [b.slug, boardOf(b.slug)])),
   )
+  // diag[slug][taskId] = Diag[]. Shape keeps card lookup O(1) and
+  // lets the SidePane pull the current task's diagnostics without a
+  // second fetch. Missing slug / missing taskId both mean "none".
+  const [diags, setDiags] = useState<Map<string, Map<string, Diag[]>>>(
+    () => new Map(),
+  )
   const [masks, setMasks] = useState<Map<string, Mask>>(() =>
     maskFromPrefs(loadPrefs().kanban?.masks))
   const [open, setOpen] = useState<Set<string>>(() => {
@@ -536,7 +605,20 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     setData(new Map(bs.map(b => [b.slug, boardOf(b.slug)])))
     setPane(p => p?.kind === "detail"
       ? (d => d ? { ...p, d } : null)(detailOf(p.slug, p.d.id)) : p)
-  }, [])
+    // Diagnostics: one shell.exec per board. Compute in parallel; any
+    // per-board failure (CLI absent, board not initialized) falls back
+    // to "no diags" for that slug rather than blocking the others. A
+    // single request object is built per-board so stale fetches from a
+    // previous `load()` can't clobber newer results — `setDiags`
+    // replaces the map atomically per call.
+    Promise.all(bs.map(b =>
+      gw.request<Sh>("shell.exec",
+          { command: `hermes kanban --board ${q(b.slug)} diagnostics --json` })
+        .then(r => r.code === 0 ? parseDiagnostics(r.stdout) : [])
+        .catch(() => [] as ReturnType<typeof parseDiagnostics>)
+        .then(rows => [b.slug, indexDiags(rows)] as const),
+    )).then(pairs => setDiags(new Map(pairs)))
+  }, [gw])
   useEffect(load, [load])
 
   // Persist masks + open set whenever either changes.
@@ -1119,6 +1201,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
               const secOpen = open.has(s.board.slug)
               const m = maskOf(s.board.slug)
               const filt = m.who.size + m.pri.size + m.status.size
+              const dg = diags.get(s.board.slug) ?? EMPTY_DIAG
               return (
                 <box key={s.board.slug} id={`kb-sec-${s.board.slug}`}
                      flexDirection="column" flexShrink={0} marginBottom={1}>
@@ -1151,6 +1234,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
                             {s.cols.map((c, ci) => (
                               <Column key={c.status} slug={s.board.slug} status={c.status}
                                       tasks={c.tasks}
+                                      diags={dg}
                                       on={on && (tier === "grid" || tier === "pane") && ci === clampCol}
                                       sel={on ? row : 0}
                                       onPick={ri => onPick(s.board.slug, ci, ri, c.tasks[ri].id)} />
@@ -1171,7 +1255,10 @@ export const Kanban = memo((props: { focused?: boolean }) => {
         </scrollbox>
       </TabShell>
       {pane
-        ? <SidePane pane={pane} on={tier === "pane"} sel={paneSel} />
+        ? <SidePane pane={pane} on={tier === "pane"} sel={paneSel}
+            diags={pane.kind === "detail"
+              ? (diags.get(pane.slug)?.get(pane.d.id) ?? EMPTY_DIAGS)
+              : EMPTY_DIAGS} />
         : null}
     </box>
   )

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -18,6 +18,7 @@ import { openConfirm } from "../dialogs/confirm"
 import { openTextPrompt } from "../dialogs/text-prompt"
 import { openCreateTask } from "../dialogs/new-task"
 import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
 import { KVBlock } from "../ui/kv"
 import { ago, trunc } from "../ui/fmt"
 import { load as loadPrefs, set as setPref, type KanbanPrefs } from "../utils/preferences"
@@ -1107,10 +1108,10 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   }, [])
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <box flexDirection="row" flexGrow={1}>
       <TabShell
         title={`Kanban · ${sections.length} board${sections.length === 1 ? "" : "s"} · ${grand} task${grand === 1 ? "" : "s"}${running ? ` · ${running} running` : ""}`}
-        hint={hint}
       >
         <scrollbox ref={outer} scrollY flexGrow={1} verticalScrollbarOptions={NOBAR}>
           <box flexDirection="column" width="100%">
@@ -1173,6 +1174,8 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       {pane
         ? <SidePane pane={pane} on={tier === "pane"} sel={paneSel} />
         : null}
+    </box>
+    <HintBar raw={hint} />
     </box>
   )
 })

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -727,6 +727,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
         d.tenant ? `--tenant ${q(d.tenant)}` : "",
         ws,
         d.maxRuntime ? `--max-runtime ${q(d.maxRuntime)}` : "",
+        ...d.skills.map(s => `--skill ${q(s)}`),
       ].filter(Boolean).join(" ")
       return sh(`create ${q(d.title)} ${flags}`.trim(),
         `Created${d.triage ? " (triage)" : ""}${d.assignee ? ` → ${d.assignee}` : ""}`)

--- a/src/tabs/Memory.tsx
+++ b/src/tabs/Memory.tsx
@@ -145,7 +145,13 @@ export const Memory = memo((props: { focused?: boolean }) => {
         )}
       </TabShell>
     </box>
-    <HintBar raw={`${keys.print("list.up")}${keys.print("list.down")} select  ${keys.print("list.toggle")} activate  ·  ${on ? "● active" : "○ inactive"}`} />
+    <HintBar
+      pairs={[
+        ["↑↓", "select"],
+        [keys.print("list.toggle"), "activate"],
+      ]}
+      suffix={on ? "● active" : "○ inactive"}
+    />
     </box>
   )
 })

--- a/src/tabs/Memory.tsx
+++ b/src/tabs/Memory.tsx
@@ -10,6 +10,7 @@ import { useToast } from "../ui/toast"
 import { useGateway } from "../app/gateway"
 import { openConfirm } from "../dialogs/confirm"
 import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
 import { KVBlock } from "../ui/kv"
 
 // ─── Helpers ──────────────────────────────────────────────────────────
@@ -97,9 +98,9 @@ export const Memory = memo((props: { focused?: boolean }) => {
     : activity.filter(a => a.provider === cur.name)
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <box flexDirection="row" flexGrow={1}>
-      <TabShell title="Memory Providers" grow={1}
-                hint={`${keys.print("list.up")}${keys.print("list.down")} select  ${keys.print("list.toggle")} activate`}>
+      <TabShell title="Memory Providers" grow={1}>
         <scrollbox scrollY flexGrow={1}>
           {providers.map((p, i) => {
             const pOn = p.name === "builtin" || p.name === active
@@ -134,7 +135,6 @@ export const Memory = memo((props: { focused?: boolean }) => {
 
       <TabShell
         title={cur?.name ?? "Provider"}
-        hint={on ? "● active" : "○ inactive"}
         grow={2}
       >
         {cur ? (
@@ -144,6 +144,8 @@ export const Memory = memo((props: { focused?: boolean }) => {
           <text fg={theme.textMuted}>Select a provider</text>
         )}
       </TabShell>
+    </box>
+    <HintBar raw={`${keys.print("list.up")}${keys.print("list.down")} select  ${keys.print("list.toggle")} activate  ·  ${on ? "● active" : "○ inactive"}`} />
     </box>
   )
 })

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -806,9 +806,21 @@ export const Sessions = memo((props: Props) => {
           ? <Detail row={visible[sel].row} lineage={io.lineage} peek={io.peek} onSwitch={lineageSwitch} />
           : null}
     </box>
-    <HintBar raw={searching
-      ? "↑↓ navigate  Enter/click switch  Esc cancel"
-      : `↑↓ navigate  ←→ lineage  ${keys.print("list.activate")}/click switch  ${keys.print("list.search")} search  ${keys.print("sessions.rename")} rename  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} refresh`} />
+    <HintBar pairs={searching
+      ? [
+          ["↑↓", "navigate"],
+          ["Enter/click", "switch"],
+          ["Esc", "cancel"],
+        ]
+      : [
+          ["↑↓", "navigate"],
+          ["←→", "lineage"],
+          [`${keys.print("list.activate")}/click`, "switch"],
+          [keys.print("list.search"), "search"],
+          [keys.print("sessions.rename"), "rename"],
+          [keys.print("list.delete"), "delete"],
+          [keys.print("list.refresh"), "refresh"],
+        ]} />
     </box>
   )
 })

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -14,6 +14,7 @@ import { useTheme } from "../theme"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
 import { KVBlock } from "../ui/kv"
 import { Col, Hdr, Marquee, VBAR } from "../ui/table"
 import { Spinner } from "../ui/spinner"
@@ -183,7 +184,7 @@ const Detail = memo((props: {
   const go = (sid: string) => () => props.onSwitch?.(sid)
 
   return (
-    <TabShell title="Session Detail" hint="" grow={2}>
+    <TabShell title="Session Detail" grow={2}>
       <box flexDirection="column" width="100%" flexGrow={1} overflow="hidden">
         <box flexDirection="column" flexShrink={0}>
           <box minHeight={1}>
@@ -270,7 +271,7 @@ const SearchDetail = memo((props: { result: SessionHit }) => {
   }
 
   return (
-    <TabShell title="Search Match" hint="" grow={2}>
+    <TabShell title="Search Match" grow={2}>
       <scrollbox scrollY flexGrow={1}>
         <box flexDirection="column" width="100%">
           <box minHeight={1}>
@@ -747,14 +748,12 @@ export const Sessions = memo((props: Props) => {
   const showDetailPanel = dims.width >= 120
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <box flexDirection="row" flexGrow={1}>
       <TabShell
         title={searching
           ? `Search Results (${results.length})`
           : `Sessions (${rows.length}${pending ? "…" : ""})`}
-        hint={searching
-          ? "↑↓ navigate  Enter/click switch  Esc cancel"
-          : `↑↓ navigate  ←→ lineage  ${keys.print("list.activate")}/click switch  ${keys.print("list.search")} search  ${keys.print("sessions.rename")} rename  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} refresh`}
         error={warn || null}
         grow={3}
       >
@@ -806,6 +805,10 @@ export const Sessions = memo((props: Props) => {
         : showDetailPanel && !searching && visible[sel]?.row
           ? <Detail row={visible[sel].row} lineage={io.lineage} peek={io.peek} onSwitch={lineageSwitch} />
           : null}
+    </box>
+    <HintBar raw={searching
+      ? "↑↓ navigate  Enter/click switch  Esc cancel"
+      : `↑↓ navigate  ←→ lineage  ${keys.print("list.activate")}/click switch  ${keys.print("list.search")} search  ${keys.print("sessions.rename")} rename  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} refresh`} />
     </box>
   )
 })

--- a/src/tabs/Skills.tsx
+++ b/src/tabs/Skills.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, memo } from "react";
 import { useKeyboard } from "@opentui/react";
 import type { RGBA } from "@opentui/core";
 import { useKeys, handleListKey, useFollow } from "../keys";
+import type { Dispatch, SetStateAction } from "react";
 import { makeSource, readSkillFrontmatter, listCuratorRuns, readCuratorReport, indexCuratorLineage, type SkillInfo, type SkillUsage, type CuratorRun, type LineageEvent } from "../utils/hermes-home";
 import { count as tokenCount } from "../utils/tokens";
 import { useGateway } from "../app/gateway";
@@ -178,6 +179,8 @@ const EmptyState = memo((props: { searching: boolean }) => {
 
 const HistoryPanel = memo((props: { focused: boolean }) => {
   const { theme, syntaxStyle } = useTheme();
+  const keys = useKeys();
+  const follow = useFollow("skills-history");
   const [runs, setRuns] = useState<CuratorRun[]>(() => listCuratorRuns());
   const [sel, setSel] = useState(0);
   const [open, setOpen] = useState(false);
@@ -191,12 +194,20 @@ const HistoryPanel = memo((props: { focused: boolean }) => {
     return () => { live = false };
   }, [open, run?.id]);
 
-  useKeyboard((key) => {
+  // Collapse the expanded body whenever selection moves. Wraps setSel so
+  // handleListKey's ↑↓/PgUp/PgDn/Home/End all trigger it uniformly.
+  const moveSel: Dispatch<SetStateAction<number>> = useCallback(v => {
+    setOpen(false);
+    setSel(v);
+  }, []);
+
+  useKeyboard(key => {
     if (!props.focused) return;
-    if (key.name === "up") { setOpen(false); return setSel(p => Math.max(0, p - 1)) }
-    if (key.name === "down") { setOpen(false); return setSel(p => Math.min(runs.length - 1, p + 1)) }
-    if (key.name === "return") return setOpen(o => !o);
-    if (key.raw === "r") return setRuns(listCuratorRuns());
+    handleListKey(keys, key, {
+      count: runs.length, setSel: moveSel, ...follow.opts,
+      onActivate: () => setOpen(o => !o),
+      onRefresh: () => setRuns(listCuratorRuns()),
+    });
   });
 
   return (
@@ -211,17 +222,17 @@ const HistoryPanel = memo((props: { focused: boolean }) => {
           </span>
         </text>
       </box>
-      <box height={1}><text fg={theme.textMuted}>↑↓ select · Enter expand · h close</text></box>
+      <box height={1}><text fg={theme.textMuted}>{`↑↓ select · Enter expand · ${keys.print("list.refresh")} reload · h close`}</text></box>
       <box height={1} />
       {runs.length === 0
         ? <text fg={theme.textMuted}>no runs in ~/.hermes/logs/curator/</text>
         : (
-          <scrollbox scrollY flexGrow={1}>
+          <scrollbox ref={follow.ref} scrollY flexGrow={1}>
             <box flexDirection="column" width="100%">
               {runs.map((r, i) => {
                 const on = i === sel;
                 return (
-                  <box key={r.id} flexDirection="column">
+                  <box key={r.id} id={follow.id(i)} flexDirection="column">
                     <box height={1} flexDirection="row"
                          backgroundColor={on ? theme.backgroundElement : undefined}
                          onMouseDown={() => { setSel(i); setOpen(o => i === sel ? !o : true) }}>

--- a/src/tabs/Skills.tsx
+++ b/src/tabs/Skills.tsx
@@ -502,9 +502,20 @@ export const Skills = memo((props: { focused?: boolean }) => {
         : current ? <DetailPanel skill={current} usage={usage[current.name]}
                                   events={lineage.current.get(current.name) ?? NO_EVENTS} /> : null}
     </box>
-    <HintBar raw={searching
-      ? "↑↓ navigate  Enter install  Esc cancel"
-      : `↑↓ navigate  ${keys.print("list.search")} search hub  s sort  c curator  h history  ${keys.print("list.refresh")} refresh`} />
+    <HintBar pairs={searching
+      ? [
+          ["↑↓", "navigate"],
+          ["Enter", "install"],
+          ["Esc", "cancel"],
+        ]
+      : [
+          ["↑↓", "navigate"],
+          [keys.print("list.search"), "search hub"],
+          ["s", "sort"],
+          ["c", "curator"],
+          ["h", "history"],
+          [keys.print("list.refresh"), "refresh"],
+        ]} />
     </box>
   );
 });

--- a/src/tabs/Skills.tsx
+++ b/src/tabs/Skills.tsx
@@ -10,6 +10,7 @@ import { useToast } from "../ui/toast";
 import { useTheme } from "../theme";
 import { useHome } from "../home";
 import { TabShell } from "../ui/shell";
+import { HintBar } from "../ui/hint";
 import { KVBlock } from "../ui/kv";
 import { KVLink } from "../components/ui/FileLink";
 import { Col, Hdr, Marquee, VBAR } from "../ui/table";
@@ -412,12 +413,10 @@ export const Skills = memo((props: { focused?: boolean }) => {
   let skillIdx = -1;
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <box flexDirection="row" flexGrow={1}>
       <TabShell
         title={searching ? `Hub Search (${hits.length})` : `Skills (${skills.length}${sort === "used" ? " · by use" : ""})`}
-        hint={searching
-          ? "↑↓ navigate  Enter install  Esc cancel"
-          : `↑↓ navigate  ${keys.print("list.search")} search hub  s sort  c curator  h history  ${keys.print("list.refresh")} refresh`}
       >
         {/* Search bar */}
         {searching ? (
@@ -502,6 +501,10 @@ export const Skills = memo((props: { focused?: boolean }) => {
         ? <HistoryPanel focused={!!props.focused && !searching} />
         : current ? <DetailPanel skill={current} usage={usage[current.name]}
                                   events={lineage.current.get(current.name) ?? NO_EVENTS} /> : null}
+    </box>
+    <HintBar raw={searching
+      ? "↑↓ navigate  Enter install  Esc cancel"
+      : `↑↓ navigate  ${keys.print("list.search")} search hub  s sort  c curator  h history  ${keys.print("list.refresh")} refresh`} />
     </box>
   );
 });

--- a/src/tabs/Toolsets.tsx
+++ b/src/tabs/Toolsets.tsx
@@ -263,7 +263,11 @@ export const Toolsets = memo((props: { focused?: boolean }) => {
 
       {ts ? <DetailPanel ts={ts} /> : null}
     </box>
-    <HintBar raw={`↑↓ nav  ${keys.print("list.toggle")} toggle  ${keys.print("list.refresh")} refresh`} />
+    <HintBar pairs={[
+      ["↑↓", "nav"],
+      [keys.print("list.toggle"), "toggle"],
+      [keys.print("list.refresh"), "refresh"],
+    ]} />
     </box>
   );
 });

--- a/src/tabs/Toolsets.tsx
+++ b/src/tabs/Toolsets.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "../theme";
 import { useDialog } from "../ui/dialog";
 import { useToast } from "../ui/toast";
 import { TabShell } from "../ui/shell";
+import { HintBar } from "../ui/hint";
 import { KVBlock } from "../ui/kv";
 import { Col, Hdr, VBAR } from "../ui/table";
 
@@ -214,11 +215,11 @@ export const Toolsets = memo((props: { focused?: boolean }) => {
   });
 
   return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
     <box flexDirection="row" flexGrow={1}>
       <TabShell
         title={`Toolsets (${count})`}
         error={err}
-        hint={`↑↓ nav  ${keys.print("list.toggle")} toggle  ${keys.print("list.refresh")} refresh`}
       >
         <Hdr>
           <Col w={4} fg={theme.textMuted}>{""}</Col>
@@ -261,6 +262,8 @@ export const Toolsets = memo((props: { focused?: boolean }) => {
       </TabShell>
 
       {ts ? <DetailPanel ts={ts} /> : null}
+    </box>
+    <HintBar raw={`↑↓ nav  ${keys.print("list.toggle")} toggle  ${keys.print("list.refresh")} refresh`} />
     </box>
   );
 });

--- a/src/ui/dialog-select.tsx
+++ b/src/ui/dialog-select.tsx
@@ -1,7 +1,9 @@
 /**
  * Filterable select dialog — reusable pick-list for dialogs.
  *
- * Keyboard: up/down navigate, enter selects, typing filters.
+ * Keyboard: list.* (↑↓/PgUp/PgDn/Home/End navigate, Enter selects), typing
+ * filters. With `filterable: false`, Space also selects (the scrollbox has
+ * focus so the filter input never sees it).
  * Mouse: hover highlights, click selects.
  * Grouped by category with headers.
  */
@@ -11,6 +13,8 @@ import type { ReactNode } from "react"
 import { useKeyboard } from "@opentui/react"
 import type { ParsedKey, ScrollBoxRenderable } from "@opentui/core"
 import { useTheme } from "../theme"
+import { useKeys } from "../keys/context"
+import { handleListKey } from "../keys/list"
 
 export type SelectOption = {
   readonly title: string
@@ -70,11 +74,7 @@ export const DialogSelect = (props: Props) => {
 
   const rowId = (i: number) => `ds-row-${i}`
 
-  const move = (n: number) => setCursor(c => {
-    const next = Math.max(0, Math.min(filtered.length - 1, c + n))
-    sb.current?.scrollChildIntoView(rowId(next))
-    return next
-  })
+  const scrollTo = (i: number) => sb.current?.scrollChildIntoView(rowId(i))
 
   // Notify on move
   useEffect(() => {
@@ -82,18 +82,24 @@ export const DialogSelect = (props: Props) => {
     if (item && props.onMove) props.onMove(item)
   }, [cursor, filtered, props.onMove])
 
+  const keys = useKeys()
+
   useKeyboard((key) => {
-    if (key.name === "up") return move(-1)
-    if (key.name === "down") return move(1)
-    if (key.name === "pageup") return move(-10)
-    if (key.name === "pagedown") return move(10)
-    // Space selects too when there's no filter input to type into.
-    const isSpace = key.name === "space" || key.name === " "
-    if (key.name === "return" || (!filterable && isSpace)) {
-      const item = filtered[cursor]
-      if (item) props.onSelect(item)
-      return
-    }
+    // Space only selects in non-filterable mode (otherwise it's a literal
+    // space for the filter input). Drive through list.toggle so a rebind
+    // of space takes effect here too.
+    const onToggle = !filterable
+      ? () => { const item = filtered[cursor]; if (item) props.onSelect(item) }
+      : undefined
+    const consumed = handleListKey(keys, key, {
+      count: filtered.length,
+      setSel: setCursor,
+      scrollTo,
+      page: Math.max(1, (sb.current?.viewport.height ?? 10) - 1),
+      onActivate: () => { const item = filtered[cursor]; if (item) props.onSelect(item) },
+      onToggle,
+    })
+    if (consumed) return
     if (props.onKey?.(key)) return
   })
 

--- a/src/ui/hint.tsx
+++ b/src/ui/hint.tsx
@@ -5,20 +5,23 @@ import { useTheme } from "../theme"
 // One row, rendered below all panes and above the composer. Muted
 // text, clips instead of wraps.
 //
-// Two input shapes during migration:
+// Input shapes:
 //   - `pairs`: structured [key, verb] list, rendered as `[key] verb`
-//     separated by 2 spaces. Preferred going forward; sibling card
-//     t_2b0d31ac rebuilds tabs around this.
-//   - `raw`: free-form string (previous TabShell.hint text). Relocated
-//     verbatim so the footer move is layout-only; each tab migrates to
-//     `pairs` when its nav is fully catalog-resolved.
+//     separated by 2 spaces. The canonical shape.
+//   - `suffix`: optional trailing status fragment appended after pairs
+//     with a `  ·  ` separator — for live indicators like "● 3 unsaved"
+//     or "● active" that sit alongside key hints but aren't bindings
+//     themselves.
+//   - `raw`: free-form passthrough. Used where the hint is pure status
+//     text (breadcrumb, managed-by label) with no key bindings.
 
 type Pair = readonly [string, string]
 
-export const HintBar = memo((props: { pairs?: readonly Pair[]; raw?: string }) => {
+export const HintBar = memo((props: { pairs?: readonly Pair[]; suffix?: string; raw?: string }) => {
   const theme = useTheme().theme
   const text = props.pairs
     ? props.pairs.map(p => `[${p[0]}] ${p[1]}`).join("  ")
+      + (props.suffix ? `  ·  ${props.suffix}` : "")
     : props.raw ?? ""
   return (
     <box height={1} flexShrink={0} paddingX={1} overflow="hidden">

--- a/src/ui/hint.tsx
+++ b/src/ui/hint.tsx
@@ -1,0 +1,28 @@
+import { memo } from "react"
+import { useTheme } from "../theme"
+
+// Tab-footer hint line (docs/nav_and_ui_standards.md § Hint Line).
+// One row, rendered below all panes and above the composer. Muted
+// text, clips instead of wraps.
+//
+// Two input shapes during migration:
+//   - `pairs`: structured [key, verb] list, rendered as `[key] verb`
+//     separated by 2 spaces. Preferred going forward; sibling card
+//     t_2b0d31ac rebuilds tabs around this.
+//   - `raw`: free-form string (previous TabShell.hint text). Relocated
+//     verbatim so the footer move is layout-only; each tab migrates to
+//     `pairs` when its nav is fully catalog-resolved.
+
+type Pair = readonly [string, string]
+
+export const HintBar = memo((props: { pairs?: readonly Pair[]; raw?: string }) => {
+  const theme = useTheme().theme
+  const text = props.pairs
+    ? props.pairs.map(p => `[${p[0]}] ${p[1]}`).join("  ")
+    : props.raw ?? ""
+  return (
+    <box height={1} flexShrink={0} paddingX={1} overflow="hidden">
+      <text fg={theme.textMuted} wrapMode="none">{text}</text>
+    </box>
+  )
+})

--- a/src/ui/shell.tsx
+++ b/src/ui/shell.tsx
@@ -1,11 +1,15 @@
 import type { ReactNode } from "react"
 import { useTheme } from "../theme"
 
-// Bordered panel chrome shared by every tab: title + keybinding hint
-// on one header line, optional error line, a one-row gap, then the
-// body. Body is wrapped in a flexGrow column with minWidth=0 so
-// children can truncate instead of forcing the panel wider than the
-// terminal.
+// Bordered panel chrome shared by every tab: bare title line, optional
+// error line, a one-row gap, then the body. Body is wrapped in a
+// flexGrow column with minWidth=0 so children can truncate instead of
+// forcing the panel wider than the terminal.
+//
+// Keybind hints do NOT live here — each tab owns a single <HintBar>
+// footer rendered below all its panes (docs/nav_and_ui_standards.md §
+// Hint Line). Multi-pane tabs otherwise rendered two competing header
+// hints with no room for either.
 //
 // `focus` switches the border to theme.primary — used when a tab
 // hosts multiple panels and wants to show which has keyboard focus.
@@ -14,7 +18,6 @@ import { useTheme } from "../theme"
 
 export const TabShell = (props: {
   title: string
-  hint: string
   error?: string | null
   focus?: boolean
   grow?: number
@@ -25,13 +28,8 @@ export const TabShell = (props: {
     <box flexDirection="column" flexGrow={props.grow ?? 1} flexBasis={0} minWidth={0}
          border borderColor={props.focus ? theme.primary : theme.border}
          backgroundColor={theme.backgroundPanel} padding={1}>
-      <box height={1} flexDirection="row" overflow="hidden">
-        <box flexShrink={0}>
-          <text fg={theme.primary}><strong>{props.title}</strong></text>
-        </box>
-        <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
-          <text fg={theme.textMuted}>{`  ${props.hint}`}</text>
-        </box>
+      <box height={1} overflow="hidden">
+        <text fg={theme.primary} wrapMode="none"><strong>{props.title}</strong></text>
       </box>
       {props.error
         ? <box height={1}><text fg={theme.error}>{`⚠ ${props.error}`}</text></box>

--- a/src/utils/hermes-kanban.ts
+++ b/src/utils/hermes-kanban.ts
@@ -75,6 +75,121 @@ export type Detail = Task & {
 
 export type Board = { slug: string; name: string }
 
+// ── Diagnostics ────────────────────────────────────────────────────
+// Fetched by shelling `hermes kanban --board <slug> diagnostics --json`.
+// Parsed here so Kanban.tsx holds only the UI shape. The Python rule
+// engine (hermes_cli/kanban_diagnostics.py, ~650 LOC) owns all rule
+// logic — thresholds, phantom-id regex, severity escalation, action
+// suggestions. Herm does not port any of it.
+
+export type Severity = "warning" | "error" | "critical"
+
+export type DiagAction = {
+  kind: string
+  label: string
+  payload: Record<string, unknown>
+  suggested: boolean
+}
+
+export type Diag = {
+  kind: string
+  severity: Severity
+  title: string
+  detail: string
+  actions: DiagAction[]
+  first_seen_at: number
+  last_seen_at: number
+  count: number
+  run_id: number | null
+  data: Record<string, unknown>
+}
+
+export type TaskDiags = {
+  task_id: string
+  title?: string
+  status?: string
+  assignee?: string | null
+  diagnostics: Diag[]
+}
+
+const SEV = new Set<Severity>(["warning", "error", "critical"])
+
+/** Parse the CLI's `diagnostics --json` stdout into typed rows. Rejects
+ *  malformed payloads silently so a CLI regression doesn't blank the
+ *  tab — we'd rather show tasks without badges than crash the board. */
+export function parseDiagnostics(stdout: string): TaskDiags[] {
+  const trimmed = stdout.trim()
+  if (!trimmed) return []
+  let raw: unknown
+  try { raw = JSON.parse(trimmed) } catch { return [] }
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap(r => {
+    if (!r || typeof r !== "object") return []
+    const rec = r as Record<string, unknown>
+    const id = rec.task_id
+    if (typeof id !== "string" || !id) return []
+    const diags = Array.isArray(rec.diagnostics) ? rec.diagnostics : []
+    return [{
+      task_id: id,
+      title: typeof rec.title === "string" ? rec.title : undefined,
+      status: typeof rec.status === "string" ? rec.status : undefined,
+      assignee: typeof rec.assignee === "string" ? rec.assignee : null,
+      diagnostics: diags.flatMap(toDiag),
+    }]
+  })
+}
+
+const toDiag = (raw: unknown): Diag[] => {
+  if (!raw || typeof raw !== "object") return []
+  const r = raw as Record<string, unknown>
+  const sev = r.severity
+  if (typeof sev !== "string" || !SEV.has(sev as Severity)) return []
+  const actions = Array.isArray(r.actions) ? r.actions.flatMap(toAction) : []
+  return [{
+    kind: String(r.kind ?? ""),
+    severity: sev as Severity,
+    title: String(r.title ?? ""),
+    detail: String(r.detail ?? ""),
+    actions,
+    first_seen_at: Number(r.first_seen_at) || 0,
+    last_seen_at: Number(r.last_seen_at) || 0,
+    count: Number(r.count) || 1,
+    run_id: typeof r.run_id === "number" ? r.run_id : null,
+    data: (r.data && typeof r.data === "object")
+      ? (r.data as Record<string, unknown>) : {},
+  }]
+}
+
+const toAction = (raw: unknown): DiagAction[] => {
+  if (!raw || typeof raw !== "object") return []
+  const r = raw as Record<string, unknown>
+  const kind = r.kind, label = r.label
+  if (typeof kind !== "string" || typeof label !== "string") return []
+  return [{
+    kind, label,
+    payload: (r.payload && typeof r.payload === "object")
+      ? (r.payload as Record<string, unknown>) : {},
+    suggested: r.suggested === true,
+  }]
+}
+
+/** Severity order: critical > error > warning. Sorted worst-first.
+ *  Kind is the tiebreaker so UI snapshots stay stable. */
+const SEV_RANK: Record<Severity, number> = { critical: 3, error: 2, warning: 1 }
+
+export const maxSeverity = (ds: Diag[]): Severity | null => {
+  let best: Severity | null = null
+  for (const d of ds) {
+    if (!best || SEV_RANK[d.severity] > SEV_RANK[best]) best = d.severity
+  }
+  return best
+}
+
+export const sortDiags = (ds: Diag[]): Diag[] =>
+  [...ds].sort((a, b) =>
+    SEV_RANK[b.severity] - SEV_RANK[a.severity]
+    || a.kind.localeCompare(b.kind))
+
 const DEFAULT = "default"
 const SLUG = /^[a-z0-9][a-z0-9_-]{0,63}$/
 

--- a/src/utils/sessions-db.ts
+++ b/src/utils/sessions-db.ts
@@ -406,11 +406,35 @@ export const systemPrompt = (): { id: string; text: string } | null =>
 // 'goal:<sid>'. status: active | paused | done | cleared. Only the
 // fields herm consumes are surfaced.
 
+export type ChecklistItem = {
+  text: string
+  status: "pending" | "completed" | "impossible"
+  addedBy?: "judge" | "user"
+}
+
 export type GoalState = {
   goal: string
   status: "active" | "paused" | "done" | "cleared"
   turn_count?: number
   max_turns?: number | null
+  checklist?: ChecklistItem[]
+  decomposed?: boolean
+}
+
+const VALID_ITEM: ReadonlySet<ChecklistItem["status"]> =
+  new Set<ChecklistItem["status"]>(["pending", "completed", "impossible"])
+
+const parseItem = (raw: unknown): ChecklistItem | null => {
+  if (!raw || typeof raw !== "object") return null
+  const o = raw as Record<string, unknown>
+  const text = typeof o.text === "string" ? o.text : ""
+  if (!text.trim()) return null
+  const s = typeof o.status === "string" ? o.status : "pending"
+  const status = (VALID_ITEM.has(s as ChecklistItem["status"])
+    ? s : "pending") as ChecklistItem["status"]
+  const by = typeof o.added_by === "string" ? o.added_by : undefined
+  const addedBy = by === "judge" || by === "user" ? by : undefined
+  return { text, status, addedBy }
 }
 
 export function goalState(sid: string): GoalState | null {
@@ -419,11 +443,15 @@ export function goalState(sid: string): GoalState | null {
   if (!row) return null
   try {
     const j = JSON.parse(row.value) as Record<string, unknown>
+    const rawList = Array.isArray(j.checklist) ? j.checklist : []
+    const checklist = rawList.map(parseItem).filter((x): x is ChecklistItem => x !== null)
     return {
       goal: String(j.goal ?? ""),
       status: (j.status as GoalState["status"]) ?? "active",
       turn_count: typeof j.turn_count === "number" ? j.turn_count : undefined,
       max_turns: (j.max_turns as number | null | undefined) ?? null,
+      checklist: checklist.length > 0 ? checklist : undefined,
+      decomposed: j.decomposed === true ? true : undefined,
     }
   } catch { return null }
 }

--- a/test/agents.test.tsx
+++ b/test/agents.test.tsx
@@ -566,8 +566,8 @@ describe("Agents tab", () => {
     expect(f).toContain("CHROME_API_KEY")   // required env listed
     expect(f).toContain("1 optional")
 
-    // Confirm
-    await act(async () => { await t.keys.typeText("y") })
+    // Confirm (Enter submits the form; nav spec § Dialogs)
+    act(() => t.keys.pressEnter())
     await t.settle()
 
     const installCmd = cmds.find(c => c.startsWith("hermes profile install"))
@@ -604,21 +604,23 @@ describe("Agents tab", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("coderv2"))
 
-    // Toggle alias on.
+    // Tab walks fields: name → alias. Space toggles on alias.
     act(() => t.keys.pressTab())
+    await until(t, () => t.frame().includes("[ ] create shell wrapper"))
+    act(() => t.keys.pressKey(" "))
     await until(t, () => t.frame().includes("[x] create shell wrapper"))
 
-    // Override name → press 'n' to enter edit, type, press Enter to exit.
-    await act(async () => { await t.keys.typeText("n") })
+    // Shift+Tab back to name field, then type the override.
+    act(() => t.keys.pressTab({ shift: true }))
     await t.settle()
     for (const c of "coder-local") {
       await act(async () => { await t.keys.typeText(c) })
     }
-    act(() => t.keys.pressEnter())
     await t.settle()
 
-    // Confirm — 'y' is consumed by dialog.confirm when not in the name field.
-    await act(async () => { await t.keys.typeText("y") })
+    // Enter submits from the name field (<input> onSubmit fires the same
+    // path as the global dialog.accept).
+    act(() => t.keys.pressEnter())
     await t.settle()
 
     const installCmd = cmds.find(c => c.startsWith("hermes profile install"))

--- a/test/agents.test.tsx
+++ b/test/agents.test.tsx
@@ -751,8 +751,12 @@ describe("Agents tab", () => {
     expect(t.frame()).toContain("[ ] --force-config")
     expect(t.frame()).not.toContain("active profile")
 
+    // Tab is a no-op on single-checkbox confirm dialogs.
+    act(() => t.keys.pressTab()); await t.settle()
+    expect(t.frame()).toContain("[ ] --force-config")
+
     // Toggle force, confirm.
-    act(() => t.keys.pressTab())
+    act(() => t.keys.pressKey(" "))
     await until(t, () => t.frame().includes("[x] --force-config"))
     await act(async () => { await t.keys.typeText("y") })
     await until(t, () => cmds.length > 0)

--- a/test/agents.test.tsx
+++ b/test/agents.test.tsx
@@ -340,7 +340,7 @@ describe("Agents tab", () => {
     await until(t, () => t.frame().includes("New Profile"))
     expect(t.frame()).toContain("(fresh)")
     expect(t.frame()).toContain("type a name")
-    expect(t.frame()).toContain("shell alias: yes")
+    expect(t.frame()).toContain("[x] shell alias")
 
     for (const c of "coder") await act(async () => { await t.keys.typeText(c) })
     await until(t, () => t.frame().includes("already exists"))
@@ -350,9 +350,13 @@ describe("Agents tab", () => {
 
     for (const c of "-v2") await act(async () => { await t.keys.typeText(c) })
     await until(t, () => t.frame().includes("Enter create"))
-    act(() => t.keys.pressArrow("down")) // clone: (fresh) → default
-    act(() => t.keys.pressTab())         // alias: yes → no
-    await until(t, () => t.frame().includes("shell alias: no"))
+    // Tab to clone field, ↓ to pick 'default'.
+    act(() => t.keys.pressTab())
+    act(() => t.keys.pressArrow("down"))
+    // Tab to alias field, Space to toggle off.
+    act(() => t.keys.pressTab())
+    act(() => t.keys.pressKey(" "))
+    await until(t, () => t.frame().includes("[ ] shell alias"))
 
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Profiles (3)"))

--- a/test/agents.test.tsx
+++ b/test/agents.test.tsx
@@ -424,22 +424,22 @@ describe("Agents tab", () => {
     const t = await mountNode(<Agents focused sessionId="test-sid" />, { gw, width: 80 })
     await until(t, () => t.frame().includes("Profiles (2)"))
     expect(t.frame()).not.toContain("Delegation (")
-    expect(t.frame()).toContain("Tab ↔ delegation")
-    expect(t.frame()).toContain("Enter detail")
+    expect(t.frame()).toContain("[Tab] ↔ delegation")
+    expect(t.frame()).toContain("[Enter] detail")
     // Detail column (path/model) hidden at 80 cols.
     expect(t.frame()).not.toContain("test-model")
 
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("test-model"))
-    expect(t.frame()).toContain("Enter actions")
-    expect(t.frame()).toContain("Esc back")
+    expect(t.frame()).toContain("[Enter] actions")
+    expect(t.frame()).toContain("[Esc] back")
     // Second Enter from detail opens the action menu.
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Profile · default"))
     act(() => t.keys.pressEscape())
     await until(t, () => !t.frame().includes("Profile · default"))
     act(() => t.keys.pressEscape())
-    await until(t, () => t.frame().includes("Enter detail"))
+    await until(t, () => t.frame().includes("[Enter] detail"))
 
     act(() => t.keys.pressTab())
     await until(t, () => t.frame().includes("Delegation (3)"))
@@ -462,7 +462,7 @@ describe("Agents tab", () => {
       { gw },
     )
     await until(t, () => t.frame().includes("Profiles (2)"))
-    expect(t.frame()).toContain("s switch")
+    expect(t.frame()).toContain("[s] switch")
 
     // Row 0 is active — `s` should not open the confirm.
     await act(async () => { await t.keys.typeText("s") })

--- a/test/config-models.test.tsx
+++ b/test/config-models.test.tsx
@@ -92,7 +92,7 @@ describe("Config → models category", () => {
     expect(f).toContain("Vision")
     expect(f).toContain("google · gemini-2.5-flash")
     expect(f).toContain("auto  (use main model)")
-    expect(f).toContain("Enter pick  x reset  X reset-all")
+    expect(f).toContain("[Enter] pick  [x] reset  [X] reset-all")
 
     // ↓ to vision, Enter → picker titled for the slot
     act(() => t.keys.pressArrow("down"))

--- a/test/config-models.test.tsx
+++ b/test/config-models.test.tsx
@@ -83,7 +83,7 @@ describe("Config → models category", () => {
 
     // ↓ to 'models', → into slots
     act(() => t.keys.pressArrow("down"))
-    act(() => t.keys.pressArrow("right"))
+    act(() => t.keys.pressTab())
     await t.settle()
     const f = t.frame()
     expect(f).toContain("★")
@@ -126,7 +126,7 @@ describe("Config → models category", () => {
     const t = await mountNode(<Config focused />, { gw, width: 160, height: 40 })
     await until(t, () => t.frame().includes("models (10)"))
     act(() => t.keys.pressArrow("down"))
-    act(() => t.keys.pressArrow("right"))
+    act(() => t.keys.pressTab())
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Set main model"))
     expect(t.frame()).not.toContain("Scope:")   // scope toggle hidden when onApply set

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -226,12 +226,14 @@ describe("Config tab", () => {
 
     // Boot: two panes visible, left pane focused — form mode, not YAML.
     expect(t.frame()).not.toContain("Config · YAML")
-    // Right-pane hint advertises the new chords.
-    expect(t.frame()).toContain("Tab categories")
+    // Footer hint reflects focused pane: boot = categories → advertises Tab→fields.
+    expect(t.frame()).toContain("[Tab] fields")
 
     // Tab → focus moves to fields pane. The right pane's focus border
     // is a visual signal; the hint is a stable string to assert on.
     act(() => t.keys.pressTab()); await t.settle()
+    // Footer flips to advertise Tab→categories once fields are focused.
+    expect(t.frame()).toContain("[Tab] categories")
     // Field rows are active now; arrow-down moves cursor, not category.
     // Easiest observable: a FieldRow carries a ▸ caret when focus=fields.
     const f = t.frame()

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -16,7 +16,7 @@ const navTo = async (t: H, cfg: Record<string, unknown>, key: string) => {
   const ri = rows.findIndex(f => f.key === key)
   if (gi < 0 || ri < 0) throw new Error(`navTo: ${key} not found (group=${g})`)
   act(() => { for (let i = 0; i < gi; i++) t.keys.pressArrow("down") })
-  act(() => t.keys.pressArrow("right"))
+  act(() => t.keys.pressTab())
   act(() => { for (let i = 0; i < ri; i++) t.keys.pressArrow("down") })
   await t.settle()
 }
@@ -214,6 +214,54 @@ describe("Config tab", () => {
     }
     await t.settle(); await t.settle()
     expect(t.frame()).toContain(last)
+    t.destroy()
+  })
+
+  // 11237112: Tab walks focus categories↔fields; mode-swap moved off Tab
+  // to mnemonic `m`. Old pane-swap on ←→ is removed.
+  test("Tab walks focus categories↔fields; m toggles form↔yaml mode", async () => {
+    const gw = new MockGateway({ "config.get": () => ({ config: {} }) })
+    const t = await mountNode(<Config focused />, { gw, width: 160, height: 40 })
+    await until(t, () => t.frame().includes("general"))
+
+    // Boot: two panes visible, left pane focused — form mode, not YAML.
+    expect(t.frame()).not.toContain("Config · YAML")
+    // Right-pane hint advertises the new chords.
+    expect(t.frame()).toContain("Tab categories")
+
+    // Tab → focus moves to fields pane. The right pane's focus border
+    // is a visual signal; the hint is a stable string to assert on.
+    act(() => t.keys.pressTab()); await t.settle()
+    // Field rows are active now; arrow-down moves cursor, not category.
+    // Easiest observable: a FieldRow carries a ▸ caret when focus=fields.
+    const f = t.frame()
+    // First field of `general` is selected; the row has the caret glyph.
+    expect(f.split("\n").some(l => /▸.*\w/.test(l) && !l.includes("general"))).toBe(true)
+
+    // Shift+Tab → back to categories.
+    act(() => t.keys.pressTab({ shift: true })); await t.settle()
+    // Category row now carries the caret.
+    expect(t.frame().split("\n").some(l => l.includes("▸") && l.includes("general"))).toBe(true)
+
+    // m toggles mode — enters YAML.
+    await act(async () => { await t.keys.typeText("m") })
+    await until(t, () => t.frame().includes("Config · YAML"))
+    // m again → back to form.
+    await act(async () => { await t.keys.typeText("m") })
+    await until(t, () => !t.frame().includes("Config · YAML"))
+    expect(t.frame()).toContain("general")
+    t.destroy()
+  })
+
+  test("←→ no longer swaps panes (dropped in favor of Tab)", async () => {
+    const gw = new MockGateway({ "config.get": () => ({ config: {} }) })
+    const t = await mountNode(<Config focused />, { gw, width: 160, height: 40 })
+    await until(t, () => t.frame().includes("general"))
+    // Boot: categories pane focused (caret on 'general').
+    expect(t.frame().split("\n").some(l => l.includes("▸") && l.includes("general"))).toBe(true)
+    // → should be a no-op now; caret stays on 'general' in categories.
+    act(() => t.keys.pressArrow("right")); await t.settle()
+    expect(t.frame().split("\n").some(l => l.includes("▸") && l.includes("general"))).toBe(true)
     t.destroy()
   })
 })

--- a/test/dialog-select.test.tsx
+++ b/test/dialog-select.test.tsx
@@ -36,4 +36,56 @@ describe("DialogSelect", () => {
     expect(/[▲▼║│┃█▐]/.test(row)).toBe(true)
     t.destroy()
   })
+
+  test("End jumps to last item, Home back to first", async () => {
+    const moves: string[] = []
+    const t = await mountNode(
+      <DialogSelect title="Pick" options={opts} onSelect={() => {}}
+        onMove={o => moves.push(o.value)} />,
+      { width: 80, height: 30 },
+    )
+    await until(t, () => t.frame().includes("Item 00"))
+    act(() => t.keys.pressKey("END"))
+    await t.settle()
+    expect(moves.at(-1)).toBe(`v${opts.length - 1}`)
+    expect(t.frame()).toContain("Item 29")
+    act(() => t.keys.pressKey("HOME"))
+    await t.settle()
+    expect(moves.at(-1)).toBe("v0")
+    expect(t.frame()).toContain("Item 00")
+    t.destroy()
+  })
+
+  test("PgDn advances by one viewport, Enter selects", async () => {
+    const picked: string[] = []
+    const t = await mountNode(
+      <DialogSelect title="Pick" options={opts} onSelect={o => picked.push(o.value)} />,
+      { width: 80, height: 30 },
+    )
+    await until(t, () => t.frame().includes("Item 00"))
+    // Viewport height is 16 → PgDn stride ≈ 15 → cursor lands on a mid-list item.
+    act(() => t.keys.pressKey("\x1B[57355u")) // kitty pagedown
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(picked.length).toBe(1)
+    expect(picked[0]).not.toBe("v0")
+    t.destroy()
+  })
+
+  test("non-filterable: Space selects", async () => {
+    const picked: string[] = []
+    const t = await mountNode(
+      <DialogSelect title="Pick" options={opts.slice(0, 5)}
+        filterable={false} onSelect={o => picked.push(o.value)} />,
+      { width: 80, height: 30 },
+    )
+    await until(t, () => t.frame().includes("Item 00"))
+    act(() => t.keys.pressArrow("down"))
+    await t.settle()
+    act(() => t.keys.pressKey(" "))
+    await t.settle()
+    expect(picked).toEqual(["v1"])
+    t.destroy()
+  })
 })

--- a/test/goal.test.tsx
+++ b/test/goal.test.tsx
@@ -20,7 +20,17 @@ describe("sessions-db.goalState", () => {
     db.run("CREATE TABLE IF NOT EXISTS state_meta (key TEXT PRIMARY KEY, value TEXT)")
     db.run("INSERT OR REPLACE INTO state_meta VALUES (?, ?)", [
       "goal:sid-done",
-      JSON.stringify({ goal: "ship it", status: "done", turn_count: 3, max_turns: null }),
+      JSON.stringify({
+        goal: "ship it", status: "done", turn_count: 3, max_turns: null,
+        decomposed: true,
+        checklist: [
+          { text: "write it", status: "completed", added_by: "judge" },
+          { text: "ship it",  status: "completed", added_by: "judge" },
+          { text: "extra",    status: "impossible", added_by: "user" },
+          { text: "", status: "pending" },           // dropped (empty text)
+          { text: "weird", status: "bogus" },         // status coerced to pending
+        ],
+      }),
     ])
     db.run("INSERT OR REPLACE INTO state_meta VALUES (?, ?)", [
       "goal:sid-active", JSON.stringify({ goal: "wip", status: "active" }),
@@ -45,6 +55,22 @@ describe("sessions-db.goalState", () => {
     expect(d?.turn_count).toBe(3)
     expect(goalState("sid-active")?.status).toBe("active")
     expect(goalState("nope")).toBeNull()
+  })
+
+  test("checklist + decomposed parsed; empty text dropped; bad status coerced; added_by→addedBy", () => {
+    const d = goalState("sid-done")
+    expect(d?.decomposed).toBe(true)
+    expect(d?.checklist?.length).toBe(4) // empty-text dropped
+    expect(d?.checklist?.[0]).toEqual({ text: "write it", status: "completed", addedBy: "judge" })
+    expect(d?.checklist?.[2]).toEqual({ text: "extra", status: "impossible", addedBy: "user" })
+    // bogus status coerced to pending; added_by missing → addedBy undefined
+    expect(d?.checklist?.[3]).toEqual({ text: "weird", status: "pending", addedBy: undefined })
+  })
+
+  test("active goal with no checklist: checklist/decomposed are undefined", () => {
+    const a = goalState("sid-active")
+    expect(a?.checklist).toBeUndefined()
+    expect(a?.decomposed).toBeUndefined()
   })
 })
 

--- a/test/hint.test.tsx
+++ b/test/hint.test.tsx
@@ -38,6 +38,22 @@ describe("HintBar", () => {
     t.destroy()
   })
 
+  test("suffix appends after pairs with ' · ' separator", async () => {
+    const t = await mountNode(
+      <HintBar pairs={[["↑↓", "select"], ["Space", "activate"]]}
+               suffix="● 3 unsaved" />,
+      { width: 80, height: 3 },
+    )
+    expect(t.frame()).toContain("[↑↓] select  [Space] activate  ·  ● 3 unsaved")
+    t.destroy()
+  })
+
+  test("suffix without pairs is ignored (use raw for pure-status lines)", async () => {
+    const t = await mountNode(<HintBar suffix="lonely" />, { width: 40, height: 3 })
+    expect(t.frame()).not.toContain("lonely")
+    t.destroy()
+  })
+
   test("oversized content clips to one row, does not wrap", async () => {
     const long = "↑↓ nav  Enter open  n new  d delete  / search  r refresh  Tab pane"
     const t = await mountNode(<HintBar raw={long} />, { width: 30, height: 3 })

--- a/test/hint.test.tsx
+++ b/test/hint.test.tsx
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "bun:test"
+import { mountNode } from "./harness"
+import { HintBar } from "../src/ui/hint"
+
+// HintBar is rendered as a one-row footer below tab panes (docs/
+// nav_and_ui_standards.md § Hint Line). It should not wrap; pairs
+// render as `[key] verb` joined by two spaces; raw text passes through
+// unchanged so in-flight migrations can relocate hints verbatim.
+
+describe("HintBar", () => {
+  test("raw text renders verbatim in a single row", async () => {
+    const t = await mountNode(<HintBar raw="↑↓ nav  Enter open" />, { width: 60, height: 3 })
+    const f = t.frame()
+    expect(f).toContain("↑↓ nav  Enter open")
+    // Single-row footer — no second content line.
+    const nonEmpty = f.split("\n").filter(l => l.trim()).length
+    expect(nonEmpty).toBe(1)
+    t.destroy()
+  })
+
+  test("pairs format as [key] verb joined by 2 spaces", async () => {
+    const t = await mountNode(
+      <HintBar pairs={[["↑↓", "select"], ["Enter", "open"], ["n", "new"]]} />,
+      { width: 60, height: 3 },
+    )
+    expect(t.frame()).toContain("[↑↓] select  [Enter] open  [n] new")
+    t.destroy()
+  })
+
+  test("pairs take precedence over raw when both supplied", async () => {
+    const t = await mountNode(
+      <HintBar pairs={[["Esc", "cancel"]]} raw="ignored" />,
+      { width: 40, height: 3 },
+    )
+    const f = t.frame()
+    expect(f).toContain("[Esc] cancel")
+    expect(f).not.toContain("ignored")
+    t.destroy()
+  })
+
+  test("oversized content clips to one row, does not wrap", async () => {
+    const long = "↑↓ nav  Enter open  n new  d delete  / search  r refresh  Tab pane"
+    const t = await mountNode(<HintBar raw={long} />, { width: 30, height: 3 })
+    const f = t.frame()
+    // At w=30 the tail words won't fit — the line is clipped, not
+    // reflowed onto a second row.
+    const nonEmpty = f.split("\n").filter(l => l.trim()).length
+    expect(nonEmpty).toBe(1)
+    t.destroy()
+  })
+})

--- a/test/install-distribution.test.tsx
+++ b/test/install-distribution.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mountNode, until } from "./harness"
+import { ConfirmStep, type InstallResult } from "../src/dialogs/install-distribution"
+import type { DistributionManifest } from "../src/utils/hermes-profiles"
+
+const manifest: DistributionManifest = {
+  name: "my-dist",
+  version: "1.0.0",
+  description: "A test distribution",
+  hermes_requires: "",
+  author: "",
+  license: "",
+  env_requires: [],
+  distribution_owned: [],
+  source: "",
+  installed_at: "",
+}
+
+async function open() {
+  let result: InstallResult | null | undefined
+  let cancelled = false
+  const t = await mountNode(
+    <ConfirmStep
+      source="github.com/owner/repo"
+      manifest={manifest}
+      onConfirm={(r) => { result = r }}
+      onCancel={() => { cancelled = true }}
+    />,
+    { width: 120, height: 40 },
+  )
+  await until(t, () => t.frame().includes("Install Distribution"))
+  return {
+    t,
+    get result() { return result },
+    get cancelled() { return cancelled },
+  }
+}
+
+describe("install-distribution Confirm step", () => {
+  test("Tab cycles fields (name → alias → name); Space toggles alias only when focused", async () => {
+    const h = await open()
+    const t = h.t
+
+    // Starts on 'name' field — alias shows [ ].
+    expect(t.frame()).toContain("[ ] create shell wrapper")
+
+    // Space while 'name' is focused must NOT toggle alias.
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[ ] create shell wrapper")
+
+    // Tab → alias. Space now toggles.
+    act(() => t.keys.pressTab()); await t.settle()
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[x] create shell wrapper")
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[ ] create shell wrapper")
+
+    // Tab wraps back to name. Space is inert again.
+    act(() => t.keys.pressTab()); await t.settle()
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[ ] create shell wrapper")
+
+    // Shift+Tab goes back to alias.
+    act(() => t.keys.pressTab({ shift: true })); await t.settle()
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[x] create shell wrapper")
+
+    t.destroy()
+  })
+
+  test("Enter submits from alias field with current values", async () => {
+    const h = await open()
+    const t = h.t
+    act(() => t.keys.pressTab()); await t.settle()  // → alias
+    act(() => t.keys.pressKey(" ")); await t.settle()  // alias = true
+    expect(t.frame()).toContain("[x] create shell wrapper")
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => h.result !== undefined)
+    expect(h.result).toEqual({
+      source: "github.com/owner/repo",
+      manifest,
+      name: null,
+      alias: true,
+    })
+    t.destroy()
+  })
+
+  test("Esc cancels", async () => {
+    const h = await open()
+    act(() => h.t.keys.pressEscape()); await h.t.settle()
+    await until(h.t, () => h.cancelled)
+    expect(h.cancelled).toBe(true)
+    h.t.destroy()
+  })
+})

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -6,7 +6,7 @@ import { mountNode, MockGateway, until } from "./harness"
 import { hermesPath } from "../src/utils/hermes-home"
 import {
   board, boardOf, detail, assignees, tailLog, q, resetKanban,
-  currentBoard, listBoards,
+  currentBoard, listBoards, parseDiagnostics, maxSeverity, sortDiags,
 } from "../src/utils/hermes-kanban"
 import { Kanban } from "../src/tabs/Kanban"
 
@@ -207,7 +207,7 @@ describe("Kanban tab", () => {
   test("Tab walks boards; verbs pin --board to active section", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("▾ Default"))
@@ -268,7 +268,7 @@ describe("Kanban tab", () => {
   test("a → DialogSelect → shell.exec assign", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -287,7 +287,7 @@ describe("Kanban tab", () => {
   test("u on blocked → comment then unblock", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -306,7 +306,7 @@ describe("Kanban tab", () => {
   test("d → confirm → archive", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -323,7 +323,7 @@ describe("Kanban tab", () => {
     const cmds: string[] = []
     const gw = new MockGateway({
       "shell.exec": p => {
-        cmds.push(p.command as string)
+        if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string)
         return { stdout: `{"task_id":"t0","ok":true,"reason":null,"new_title":"Expanded idea"}\n`, stderr: "", code: 0 }
       },
     })
@@ -340,7 +340,7 @@ describe("Kanban tab", () => {
   test("s on non-triage is a no-op (info toast, no command)", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -357,7 +357,7 @@ describe("Kanban tab", () => {
     const cmds: string[] = []
     const gw = new MockGateway({
       "shell.exec": p => {
-        cmds.push(p.command as string)
+        if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string)
         return {
           stdout:
             `{"task_id":"t0","ok":true,"reason":null,"new_title":"First spec"}\n`
@@ -380,7 +380,7 @@ describe("Kanban tab", () => {
   test("n → create dialog → shell.exec create on active board", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t6", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "t6", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -397,7 +397,7 @@ describe("Kanban tab", () => {
   test("create form: empty title blocks submit; footer nags", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "x", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "x", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -416,7 +416,7 @@ describe("Kanban tab", () => {
   test("create form: ↓ walks fields; Space toggles triage; Ctrl+Enter submits", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t7", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "t7", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -441,7 +441,7 @@ describe("Kanban tab", () => {
   test("create form: Space on Assignee opens picker; selection feeds --assignee", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t8", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "t8", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -467,7 +467,7 @@ describe("Kanban tab", () => {
   test("create form: body textarea — ↓ enters, Enter newlines, Tab leaves; body feeds --body", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t9", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "t9", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -495,7 +495,7 @@ describe("Kanban tab", () => {
   test("create form: ↑/↓ in a multi-line body move the cursor, only escape at the edges", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "tb", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "tb", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -540,7 +540,7 @@ describe("Kanban tab", () => {
   test("create form: More section hidden until expanded; Workspace dir: → --workspace dir:<path>", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "t10", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "t10", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -578,7 +578,7 @@ describe("Kanban tab", () => {
   test("create form: Esc cancels — no command", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "x", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "x", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -643,7 +643,7 @@ describe("Kanban tab", () => {
   test("create form: Priority picker is filter-free; Space selects", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "tp", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "tp", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -674,7 +674,7 @@ describe("Kanban tab", () => {
   test("D → confirm → dispatch", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { cmds.push(p.command as string); return { stdout: "[]", stderr: "", code: 0 } },
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "[]", stderr: "", code: 0 } },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -1032,6 +1032,167 @@ describe("max_retries parity", () => {
       act(() => t.keys.pressArrow("down")); await t.settle()
       await until(t, () => /Title\s+retries default/.test(t.frame()))
       expect(t.frame()).not.toMatch(/Retries\s+\d/)
+    } finally {
+      t.destroy()
+    }
+  })
+})
+
+describe("diagnostics parser", () => {
+  test("parseDiagnostics() accepts CLI shape and filters malformed rows", () => {
+    const out = parseDiagnostics(JSON.stringify([
+      {
+        task_id: "t1", title: "a", status: "running", assignee: "worker",
+        diagnostics: [
+          {
+            kind: "spawn_loop", severity: "critical", title: "10 failures",
+            detail: "spawn failed 10x", actions: [
+              { kind: "reassign", label: "Reassign elsewhere", payload: {}, suggested: true },
+              { kind: "cli_hint", label: "hermes profile doctor", payload: {} },
+            ],
+            first_seen_at: 100, last_seen_at: 200, count: 10, run_id: 7,
+            data: { count: 10 },
+          },
+          // Bad severity → dropped.
+          { kind: "bad", severity: "info", title: "x", detail: "", actions: [] },
+        ],
+      },
+      // Missing task_id → row dropped.
+      { title: "orphan", diagnostics: [] },
+    ]))
+    expect(out).toHaveLength(1)
+    expect(out[0].task_id).toBe("t1")
+    expect(out[0].diagnostics).toHaveLength(1)
+    const d = out[0].diagnostics[0]
+    expect(d.severity).toBe("critical")
+    expect(d.count).toBe(10)
+    expect(d.actions).toHaveLength(2)
+    expect(d.actions[0].suggested).toBe(true)
+    expect(d.actions[1].suggested).toBe(false)
+  })
+
+  test("parseDiagnostics() returns [] on empty/invalid/bad-JSON input", () => {
+    expect(parseDiagnostics("")).toEqual([])
+    expect(parseDiagnostics("[]")).toEqual([])
+    expect(parseDiagnostics("not json")).toEqual([])
+    expect(parseDiagnostics("{}")).toEqual([])
+  })
+
+  test("maxSeverity() picks worst; sortDiags() orders critical→warning", () => {
+    const ds = [
+      { kind: "a", severity: "warning" as const, title: "", detail: "", actions: [], first_seen_at: 0, last_seen_at: 0, count: 1, run_id: null, data: {} },
+      { kind: "b", severity: "critical" as const, title: "", detail: "", actions: [], first_seen_at: 0, last_seen_at: 0, count: 1, run_id: null, data: {} },
+      { kind: "c", severity: "error" as const, title: "", detail: "", actions: [], first_seen_at: 0, last_seen_at: 0, count: 1, run_id: null, data: {} },
+    ]
+    expect(maxSeverity(ds)).toBe("critical")
+    expect(maxSeverity([])).toBeNull()
+    expect(sortDiags(ds).map(d => d.kind)).toEqual(["b", "c", "a"])
+  })
+})
+
+describe("Kanban diagnostics UI", () => {
+  // Emit a diagnostics payload keyed by board slug. Every `shell.exec`
+  // that contains the `diagnostics` verb matches the slug in `--board
+  // <slug>` against the fixture and returns that board's rows.
+  const diagFixture = (cmd: string, byBoard: Record<string, unknown[]>): string => {
+    const m = /--board\s+(\S+)\s+diagnostics/.exec(cmd)
+    const slug = m?.[1] ?? "default"
+    return JSON.stringify(byBoard[slug] ?? [])
+  }
+
+  test("Card prefixes severity glyph; SidePane renders Diagnostics block + suggested action", async () => {
+    const fixture = {
+      default: [{
+        task_id: "t5", title: "need decision", status: "blocked", assignee: "researcher",
+        diagnostics: [{
+          kind: "stuck_blocked", severity: "error",
+          title: "Blocked for 7 days",
+          detail: "Awaiting operator input on rate-limit keying.",
+          actions: [
+            { kind: "comment", label: "Add an unblock comment", payload: {}, suggested: true },
+            { kind: "unblock", label: "Mark ready", payload: {} },
+          ],
+          first_seen_at: now - 86400 * 7, last_seen_at: now, count: 1, run_id: null, data: {},
+        }],
+      }],
+    }
+    const gw = new MockGateway({
+      "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
+        ? ({ stdout: diagFixture(p.command as string, fixture), stderr: "", code: 0 })
+        : ({ stdout: "", stderr: "", code: 0 }),
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 48 })
+    try {
+      // Card badge: the `!!` glyph sits on the same line as "need decision"
+      // in the blocked column.
+      await until(t, () => {
+        const row = t.frame().split("\n").find(l => l.includes("need decision"))
+        return !!row && /!!/.test(row)
+      })
+
+      // Tab → grid; arrow over to the blocked column (index 4: triage, todo,
+      // ready, running, blocked). Row 0 is t5 by priority sort.
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => /Diagnostics\s+\(1\)/.test(t.frame()))
+      const f = t.frame()
+      expect(f).toMatch(/\[error\]\s+stuck_blocked/)
+      expect(f).toContain("Blocked for 7 days")
+      expect(f).toContain("Awaiting operator input")
+      // Suggested action leads with → arrow, non-suggested with ·.
+      expect(f).toMatch(/→\s+Add an unblock comment/)
+      expect(f).toMatch(/·\s+Mark ready/)
+    } finally {
+      t.destroy()
+    }
+  })
+
+  test("task without diagnostics shows no badge; other tasks still get theirs", async () => {
+    const fixture = {
+      default: [{
+        task_id: "t2", title: "", status: "running", assignee: "researcher",
+        diagnostics: [{
+          kind: "crash_loop", severity: "critical", title: "3 crashes",
+          detail: "", actions: [],
+          first_seen_at: now, last_seen_at: now, count: 3, run_id: 7, data: {},
+        }],
+      }],
+    }
+    const gw = new MockGateway({
+      "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
+        ? ({ stdout: diagFixture(p.command as string, fixture), stderr: "", code: 0 })
+        : ({ stdout: "", stderr: "", code: 0 }),
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 48 })
+    try {
+      // Badge must attach to its own task — `‼` appears adjacent to
+      // "research perf" in the per-column cell, never to "research
+      // cost" in an adjacent column. Use cell-scoped regexes (no "."
+      // in between) so "same row, different column" doesn't alias.
+      await until(t, () => /‼\s*research perf/.test(t.frame()))
+      expect(t.frame()).not.toMatch(/[‼⚠]\s*research cost/)
+      expect(t.frame()).not.toMatch(/!!\s*research cost/)
+    } finally {
+      t.destroy()
+    }
+  })
+
+  test("diagnostics CLI failure → board still renders, no badges", async () => {
+    const gw = new MockGateway({
+      "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
+        ? ({ stdout: "", stderr: "hermes: command not found", code: 127 })
+        : ({ stdout: "", stderr: "", code: 0 }),
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    try {
+      // Don't depend on board count — other describes may seed extra
+      // boards by the time this one runs. Gate on a task title instead.
+      await until(t, () => t.frame().includes("research cost"))
+      // No badge glyphs leaked into any row.
+      expect(t.frame()).not.toMatch(/[‼⚠]|!!/)
     } finally {
       t.destroy()
     }

--- a/test/list-keys.test.tsx
+++ b/test/list-keys.test.tsx
@@ -94,8 +94,8 @@ describe("useListKeys / handleListKey", () => {
     await until(t, () => t.frame().includes("Cron Jobs (2)"))
 
     // Hint reflects rebind + suppressed refresh.
-    expect(t.frame()).toContain("X delete")
-    expect(t.frame()).not.toMatch(/R refresh/)
+    expect(t.frame()).toContain("[X] delete")
+    expect(t.frame()).not.toMatch(/\[R\] refresh/)
 
     // 'd' no longer deletes.
     await act(async () => { await t.keys.typeText("d") })

--- a/test/new-profile.test.tsx
+++ b/test/new-profile.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mountNode, until } from "./harness"
+import { openCreateProfile } from "../src/dialogs/new-profile"
+import { useDialog, type DialogContext } from "../src/ui/dialog"
+import { useEffect, useRef } from "react"
+
+// Harness component — opens the dialog on mount and stashes the result
+// promise so tests can assert on it without racing the dialog's resolve.
+function Host(p: { existing: string[]; onResult: (r: unknown) => void }) {
+  const dialog = useDialog()
+  const started = useRef(false)
+  useEffect(() => {
+    if (started.current) return
+    started.current = true
+    openCreateProfile(dialog as DialogContext, { existing: p.existing }).then(p.onResult)
+  }, [dialog, p])
+  return null
+}
+
+async function open(existing: string[] = []) {
+  let result: unknown = undefined
+  const t = await mountNode(
+    <Host existing={existing} onResult={(r) => { result = r }} />,
+    { width: 120, height: 40 },
+  )
+  await until(t, () => t.frame().includes("New Profile"))
+  return { t, get result() { return result } }
+}
+
+describe("new-profile dialog", () => {
+  test("Tab cycles fields (name → clone → alias); Space toggles alias only when focused", async () => {
+    const { t } = await open([])
+    // Type a name while 'name' is focused — printable char should land.
+    await act(async () => { await t.keys.typeText("a") })
+    await t.settle()
+    expect(t.frame()).toContain("Name")
+    expect(t.frame()).toMatch(/Name\s+a/)
+
+    // Alias starts true (default). Space should NOT toggle it while 'name'
+    // is focused — Space is a printable and must not reach the checkbox.
+    expect(t.frame()).toContain("[x] shell alias")
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[x] shell alias")
+
+    // Tab once → clone. Tab again → alias. Now Space toggles.
+    act(() => t.keys.pressTab()); await t.settle()  // → clone
+    act(() => t.keys.pressKey(" ")); await t.settle()  // must NOT toggle
+    expect(t.frame()).toContain("[x] shell alias")
+
+    act(() => t.keys.pressTab()); await t.settle()  // → alias
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[ ] shell alias")
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[x] shell alias")
+
+    // Tab wraps back to name. Shift+Tab reverses.
+    act(() => t.keys.pressTab()); await t.settle()  // alias → name
+    await act(async () => { await t.keys.typeText("b") })
+    await t.settle()
+    expect(t.frame()).toMatch(/Name\s+ab/)
+
+    act(() => t.keys.pressTab({ shift: true })); await t.settle()  // name → alias
+    act(() => t.keys.pressKey(" ")); await t.settle()
+    expect(t.frame()).toContain("[ ] shell alias")
+    t.destroy()
+  })
+
+  test("arrows move clone-from selection only while 'clone' is focused", async () => {
+    const { t } = await open(["profile-a", "profile-b"])
+    // Focus starts on name; ↓ should be inert here.
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    const frame1 = t.frame()
+    // caret still on '(fresh)'
+    expect(frame1).toMatch(/▸ \(fresh\)/)
+
+    // Tab → clone; now ↓ moves the caret.
+    act(() => t.keys.pressTab()); await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    expect(t.frame()).toMatch(/▸ profile-a/)
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    expect(t.frame()).toMatch(/▸ profile-b/)
+    t.destroy()
+  })
+
+  test("Enter submits with current field values; Esc cancels", async () => {
+    const host = await open([])
+    const { t } = host
+    await act(async () => { await t.keys.typeText("myprofile") })
+    await t.settle()
+    // Enter from any field should submit when valid.
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => host.result !== undefined)
+    expect(host.result).toEqual({ name: "myprofile", cloneFrom: null, alias: true })
+    t.destroy()
+  })
+
+  test("Esc cancels and resolves null", async () => {
+    const host = await open([])
+    act(() => host.t.keys.pressEscape()); await host.t.settle()
+    await until(host.t, () => host.result !== undefined)
+    expect(host.result).toBeNull()
+    host.t.destroy()
+  })
+})

--- a/test/new-task-skills.test.tsx
+++ b/test/new-task-skills.test.tsx
@@ -1,0 +1,138 @@
+import { describe, test, expect } from "bun:test"
+import { act, useEffect } from "react"
+import { mountNode, MockGateway, until } from "./harness"
+import { useDialog } from "../src/ui/dialog"
+import { openCreateTask, type Draft } from "../src/dialogs/new-task"
+
+let resolved: Draft | null | undefined
+
+const Opener = () => {
+  const dialog = useDialog()
+  useEffect(() => {
+    resolved = undefined
+    void openCreateTask(dialog, { assignees: ["builder", "reviewer"] })
+      .then(v => { resolved = v })
+  }, [])
+  return null
+}
+
+// Walk the form from "title" down into the Skills field (under More).
+// Form opens focused on Title; Tab walks visible fields in order. Settle
+// between presses — without it multiple pressTab() in one microtask
+// coalesce and only one field advance lands per frame.
+async function walkToSkills(t: Awaited<ReturnType<typeof mountNode>>) {
+  // Make sure the form is fully mounted and focused on Title before we
+  // start tab-walking. Without this gate the first few Tab presses can
+  // land before the dialog's useKeyboard hook has registered.
+  await until(t, () => /▸ Title/.test(t.frame()))
+  // Type a title so submit() passes validation later. Skills focus
+  // doesn't route printables outside the form, so we type it here.
+  for (const c of "hi") await act(async () => { await t.keys.typeText(c) })
+  const tab = async () => { await act(async () => { t.keys.pressTab() }); await t.settle() }
+  await tab(); await until(t, () => /▸ Body/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Assignee/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Priority/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Triage/.test(t.frame()))
+  await tab(); await until(t, () => /▸ More/.test(t.frame()))
+  // pressKey(" ") emits key.name === " " under kitty, but the form
+  // handler checks key.name === "space" (how real terminals / typeText
+  // deliver it). Use typeText to route through the "space" name.
+  await act(async () => { await t.keys.typeText(" ") })
+  await until(t, () => /More ▾/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Tenant/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Workspace/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Runtime/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Skills/.test(t.frame()))
+}
+
+describe("new-task Skills field", () => {
+  test("typing filters → Tab commits highlighted match as a chip", async () => {
+    const gw = new MockGateway({
+      "skills.manage": p => p.action === "list"
+        ? { skills: { devops: ["kanban-worker", "hermes-agent-skill-authoring"], software: ["plan"] } }
+        : {},
+    })
+    const t = await mountNode(<Opener />, { gw, width: 120, height: 60 })
+    await until(t, () => t.frame().includes("New Task"))
+    await walkToSkills(t)
+    await until(t, () => /▸ Skills/.test(t.frame()))
+    // Type "plan" → one match; Tab commits.
+    for (const c of "plan") await act(async () => { await t.keys.typeText(c) })
+    // Match row shows: "  ▸          plan  software" — ▸ is in the 13-wide label column.
+    await until(t, () => /plan\s+software/.test(t.frame()))
+    await act(async () => { await t.keys.pressTab() })
+    // After commit, filter clears and the match row disappears; only the chip remains.
+    await until(t, () => !/plan\s+software/.test(t.frame()))
+    // Commit: Ctrl+Enter from the Skills field submits.
+    await act(async () => { t.keys.pressEnter({ ctrl: true }) })
+    await until(t, () => resolved !== undefined)
+    expect(resolved).not.toBeNull()
+    expect(resolved!.skills).toEqual(["plan"])
+    t.destroy()
+  })
+
+  test("Backspace on empty filter removes the last chip", async () => {
+    const gw = new MockGateway({
+      "skills.manage": () => ({ skills: { devops: ["kanban-worker"], software: ["plan"] } }),
+    })
+    const t = await mountNode(<Opener />, { gw, width: 120, height: 60 })
+    await until(t, () => t.frame().includes("New Task"))
+    await walkToSkills(t)
+    await until(t, () => /▸ Skills/.test(t.frame()))
+    // Add "plan" chip via filter + Tab.
+    for (const c of "plan") await act(async () => { await t.keys.typeText(c) })
+    await act(async () => { await t.keys.pressTab() })
+    // Add "kanban" chip.
+    for (const c of "kanban") await act(async () => { await t.keys.typeText(c) })
+    await act(async () => { await t.keys.pressTab() })
+    await t.settle()
+    // Filter is empty now. Backspace should pop the last chip (kanban-worker).
+    await act(async () => { await t.keys.pressBackspace() })
+    await t.settle()
+    // Submit and inspect the draft — more robust than regex on the frame,
+    // since chip label collides with the "Title" placeholder glyph.
+    await act(async () => { t.keys.pressEnter({ ctrl: true }) })
+    await until(t, () => resolved !== undefined)
+    expect(resolved!.skills).toEqual(["plan"])
+    t.destroy()
+  })
+
+  test("filter buffer eats Backspace before popping chips", async () => {
+    const gw = new MockGateway({
+      "skills.manage": () => ({ skills: { s: ["plan"] } }),
+    })
+    const t = await mountNode(<Opener />, { gw, width: 120, height: 60 })
+    await until(t, () => t.frame().includes("New Task"))
+    await walkToSkills(t)
+    await until(t, () => /▸ Skills/.test(t.frame()))
+    // Add one chip.
+    for (const c of "plan") await act(async () => { await t.keys.typeText(c) })
+    await act(async () => { await t.keys.pressTab() })
+    await t.settle()
+    // Type "xyz" into the filter (no matches, but buffer grows).
+    for (const c of "xyz") await act(async () => { await t.keys.typeText(c) })
+    // Bksp erases filter char — chip must survive.
+    await act(async () => { await t.keys.pressBackspace() })
+    await act(async () => { await t.keys.pressBackspace() })
+    await act(async () => { await t.keys.pressBackspace() })
+    await t.settle()
+    await act(async () => { t.keys.pressEnter({ ctrl: true }) })
+    await until(t, () => resolved !== undefined)
+    expect(resolved!.skills).toEqual(["plan"])
+    t.destroy()
+  })
+
+  test("Tab with empty filter moves to next field (no match to commit)", async () => {
+    const gw = new MockGateway({
+      "skills.manage": () => ({ skills: { s: ["plan"] } }),
+    })
+    const t = await mountNode(<Opener />, { gw, width: 120, height: 60 })
+    await until(t, () => t.frame().includes("New Task"))
+    await walkToSkills(t)
+    await until(t, () => /▸ Skills/.test(t.frame()))
+    // Tab from empty Skills field should wrap to first field (title).
+    await act(async () => { await t.keys.pressTab() })
+    await until(t, () => /▸ Title/.test(t.frame()))
+    t.destroy()
+  })
+})

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -440,9 +440,11 @@ describe("Sessions tab", () => {
     // Transcript section doesn't fit at h=12 with the metadata block
     // above it; it's clipped rather than painted past the border.
     expect(f).not.toContain("Transcript")
-    // Bottom border intact (no content bleeding through it).
-    const last = f.split("\n").filter(l => l.trim()).at(-1)!
-    expect(last).toMatch(/└─+┘└─+┘$/)
+    // Bottom border intact (no content bleeding through it). The
+    // HintBar footer renders below the pane row, so find the border row
+    // (the last non-empty line that contains box-drawing corners).
+    const borderRow = f.split("\n").filter(l => /└─+┘└─+┘/.test(l)).at(-1)
+    expect(borderRow).toMatch(/└─+┘└─+┘$/)
     t.destroy()
   })
 })

--- a/test/toolsets.test.tsx
+++ b/test/toolsets.test.tsx
@@ -32,7 +32,7 @@ describe("Toolsets tab", () => {
     const f = strip(t.frame())
     expect(f).toContain("● file")
     expect(f).toContain("○ web")
-    expect(f).toContain("Space toggle")
+    expect(f).toContain("[Space] toggle")
     // no expand affordance now that detail pane is the single surface
     expect(f).not.toMatch(/\bexpand\b/)
     t.destroy()


### PR DESCRIPTION
## Summary

Navigation/UI standards conformance across tabs and dialogs, plus three features: kanban diagnostics surface, skills-chip input in the new-task form, and goal checklist progress in the done toast. 35 files, +1516/-204.

## Nav & UI standards

| Surface | Change |
|---|---|
| `src/ui/hint.tsx` (new) + `src/ui/shell.tsx` | `<HintBar>` footer component. `TabShell.hint` prop removed. Every tab renders one footer below its panes. Format `[key] verb`, two-space separated, ≤6 pairs. |
| All `src/tabs/*.tsx` | Hints relocated header → footer. Mnemonic keys rendered via `keys.print(id)` so rebinds show correctly. |
| `src/tabs/Config.tsx` + `src/keys/catalog.ts` | `m` toggles form↔yaml (new `config.mode` catalog entry). `Tab`/`Shift+Tab` moves categories↔fields. `←/→` pane-swap removed. |
| `src/dialogs/new-profile.tsx` | `Tab`/`Shift+Tab` cycles name → clone-source → alias. `Space` toggles alias when focused. `Tab` no longer toggles. |
| `src/dialogs/install-distribution.tsx` | Same Tab/Space fix as new-profile. |
| `src/dialogs/profile.tsx` ForceConfirm | `Space` toggles `force`. `Tab` is a no-op. `y`/`Enter` confirms. |
| `src/tabs/Skills.tsx` HistoryPanel | Routes through `handleListKey`. Adds `PgUp`/`PgDn`/`Home`/`End` and honors `list.*` rebinds. |
| `src/ui/dialog-select.tsx` | Routes through `handleListKey`. Adds `Home`/`End`. Keeps filterable `Space`-as-literal. |

## Features

| Surface | Change |
|---|---|
| `src/tabs/Kanban.tsx` + `src/utils/hermes-kanban.ts` | Per-task diagnostics via `hermes kanban diagnostics --json`. Severity glyph on cards; Diagnostics block + suggested actions in SidePane. Cached with board data; refetched on `r`. |
| `src/dialogs/new-task.tsx` | Skills field under More. Type-to-filter, `Tab` commits highlighted match as a chip, `Backspace` on empty input peels last chip. Feeds repeatable `--skill <name>` on create. |
| `src/utils/sessions-db.ts` + `src/app/goalHook.ts` | `GoalState` carries `checklist: ChecklistItem[]` and `decomposed: boolean` (defensive parse; snake→camel on `added_by`). Goal-done toast shows M/N item count when checklist is present. |

## Tests

805 pass / 0 fail (`dev` baseline 775). New: `hint.test.tsx`, `new-profile.test.tsx`, `new-task-skills.test.tsx`, `install-distribution.test.tsx`, `dialog-select.test.tsx`, `goal.test.tsx`, `list-keys.test.tsx`; extended `kanban.test.tsx`, `config.test.tsx`, `agents.test.tsx`, others.

`bunx tsc --noEmit`: only pre-existing `test/context.test.tsx:136`.
