### PR TITLE
fix(kanban): drop readonly sqlite opens; reset handles after shell writes

### DIFF
--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -704,6 +704,10 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     gw.request<Sh>("shell.exec", { command: `hermes kanban --board ${q(at)} ${argv}` }).then(r => {
       if (r.code !== 0) throw new Error((r.stderr || r.stdout || `exit ${r.code}`).trim())
       if (ok) toast.show({ variant: "success", message: ok })
+      // Drop cached handles before re-read — the shell-backed write
+      // came from another process; a handle opened before the board
+      // existed (or under a since-rotated path) stays null/stale (gh#29).
+      resetKanban()
       load()
       return r.stdout
     }).catch((e: Error) => void toast.show({ variant: "error", message: trunc(e.message, 120) })),

--- a/src/utils/hermes-home.ts
+++ b/src/utils/hermes-home.ts
@@ -691,7 +691,7 @@ export async function readToolsFromLatestSession(): Promise<ToolsInfo | null> {
 /** Read system prompt from the most recent state.db session that has a full one */
 export function readSystemPromptInfo(): SystemPromptInfo | null {
   try {
-    const db = new Database(hermesPath("state.db"), { readonly: true });
+    const db = new Database(hermesPath("state.db"), { readwrite: true, create: false });
     // Short prompts (~700 chars) are the generic fallback without SOUL/memory/skills.
     const row = db
       .query(

--- a/src/utils/hermes-kanban.ts
+++ b/src/utils/hermes-kanban.ts
@@ -208,9 +208,9 @@ const resolve = (): string => {
 let slug = resolve()
 
 /** Two cached handles per board slug: [ro, rw]. `null` = open attempted
- *  and failed (no DB yet); `undefined` = not yet attempted. Separate
- *  handles because bun:sqlite's readonly flag is per-connection and we
- *  want reads to never block on a write handle taking the lock. */
+ *  and failed (no DB yet); `undefined` = not yet attempted. `ro` is
+ *  opened RW-no-create (gh#29) and used only for SELECTs; `rw` runs
+ *  the WAL/foreign_keys pragmas and serves patches. */
 type Handles = { ro: Database | null; rw: Database | null }
 const handles = new Map<string, Handles>()
 
@@ -233,8 +233,12 @@ const pair = (s: string): Handles => {
 
 const dbOf = (s: string): Database | null => {
   const h = pair(s)
-  if (h.ro !== null) return h.ro
-  try { h.ro = new Database(dbPath(s), { readonly: true }) } catch { h.ro = null }
+  if (h.ro) return h.ro
+  // Not { readonly: true } — Bun 1.3.x readonly mode can fail with
+  // "unable to open database file" on WAL DBs whose sidecars don't
+  // exist yet (gh#29). RW-no-create is safe: we only SELECT on this
+  // handle, and create:false still throws when the file is absent.
+  try { h.ro = new Database(dbPath(s), { readwrite: true, create: false }) } catch { h.ro = null }
   return h.ro
 }
 

--- a/src/utils/hermes-profiles.ts
+++ b/src/utils/hermes-profiles.ts
@@ -296,7 +296,7 @@ export async function profileStats(dir: string): Promise<ProfileStats> {
   const dbPath = join(dir, "state.db")
   if (existsSync(dbPath)) {
     try {
-      const db = new Database(dbPath, { readonly: true })
+      const db = new Database(dbPath, { readwrite: true, create: false })
       const r = db.query("SELECT COUNT(*) AS s FROM sessions WHERE message_count > 0")
         .get() as { s: number }
       const m = db.query("SELECT COALESCE(SUM(message_count), 0) AS m FROM sessions")

--- a/src/utils/sessions-db.ts
+++ b/src/utils/sessions-db.ts
@@ -55,10 +55,12 @@ export const setHome = (h: string) => {
   resetDb()
 }
 
-/** Shared readonly handle. Null when state.db doesn't exist yet. */
+/** Shared read handle. Null when state.db doesn't exist yet.
+ *  RW-no-create, not readonly — Bun 1.3.x readonly mode can fail on
+ *  WAL DBs before sidecars exist (gh#29). We only SELECT on it. */
 export const stateDb = (): Database | null => {
   if (conn.ro) return conn.ro
-  try { return (conn.ro = new Database(conn.path, { readonly: true })) }
+  try { return (conn.ro = new Database(conn.path, { readwrite: true, create: false })) }
   catch { return null }
 }
 


### PR DESCRIPTION
Closes #29.

## Problem
- Bun 1.3.x `new Database(path, { readonly: true })` can fail `unable to open database file` on WAL DBs whose `-wal`/`-shm` sidecars don't exist yet. The kanban reader and two `state.db` readers all hit this, so board names rendered but task rows stayed empty.
- `dbOf()` cached `h.ro = null` forever (`if (h.ro !== null) return h.ro`), so a board that failed once never reopened.
- Shell-backed writes (`hermes kanban --board ... create/assign/...`) come from another process; the cached handle opened before that write stays stale/null and `load()` reads nothing new.

## Fix
- `{ readonly: true }` -> `{ readwrite: true, create: false }` in `hermes-kanban.ts` / `sessions-db.ts` / `hermes-home.ts` / `hermes-profiles.ts`. Still refuses to create a missing file; opens existing ones reliably. These handles only SELECT.
- `dbOf()`: `if (h.ro)` so a later retry can succeed.
- `Kanban.tsx` `sh()` now calls `resetKanban()` before `load()` on success, same pattern the board-create path already used.

## Out of scope
- #28 profile-path collapse (separate PR).

## Verify
- `bunx tsc --noEmit`: 0 new (1 pre-existing `test/context.test.tsx:136`).
- `bun test`: 810/810.
- `rg 'readonly:\s*true' src/`: none.