### PR TITLE
fix(kanban): collapse profiles/<name> to shared Hermes root

### DIFF
--- a/src/utils/hermes-kanban.ts
+++ b/src/utils/hermes-kanban.ts
@@ -1,8 +1,10 @@
 // Window onto the kanban board(s) under ~/.hermes/.
 //
 // Kanban is deliberately profile-agnostic (the board IS the
-// coordination primitive between profiles), so this reads the
-// HERMES_HOME-relative paths and shows every tenant's tasks.
+// coordination primitive between profiles). Paths anchor on the
+// shared Hermes root — NOT the active profile's HERMES_HOME — so
+// herm sees the same boards `hermes kanban` does even when running
+// under ~/.hermes/profiles/<name>. See kanbanRoot() below (gh#28).
 //
 // Upstream 5ec6baa40 introduced multi-project boards. Resolution
 // chain for the *default-active* board mirrors
@@ -193,13 +195,26 @@ export const sortDiags = (ds: Diag[]): Diag[] =>
 const DEFAULT = "default"
 const SLUG = /^[a-z0-9][a-z0-9_-]{0,63}$/
 
+/** Shared Hermes root for kanban paths — mirrors upstream
+ *  hermes_cli/kanban_db.py::kanban_home(). HERMES_KANBAN_HOME wins
+ *  when set; otherwise collapse …/profiles/<name> to the parent root
+ *  so the TUI reads the same boards the CLI does (gh#28). Exported
+ *  for tests. */
+export const kanbanRoot = (): string => {
+  const pin = (process.env.HERMES_KANBAN_HOME ?? "").trim()
+  if (pin) return pin.replace(/[\\/]+$/, "")
+  return hermesPath("").replace(/[\\/]+$/, "").replace(/[\\/]profiles[\\/][^\\/]+$/, "")
+}
+
+const kp = (rel: string) => `${kanbanRoot()}/${rel}`
+
 /** Active board slug per the CLI's resolution chain. Herm shows every
  *  board; this only picks which section is focused on mount. */
 const resolve = (): string => {
   const env = (process.env.HERMES_KANBAN_BOARD ?? "").trim().toLowerCase()
   if (SLUG.test(env)) return env
   try {
-    const txt = readFileSync(hermesPath("kanban/current"), "utf-8").trim().toLowerCase()
+    const txt = readFileSync(kp("kanban/current"), "utf-8").trim().toLowerCase()
     if (SLUG.test(txt)) return txt
   } catch {}
   return DEFAULT
@@ -218,10 +233,10 @@ export const currentBoard = () => slug
 
 /** default keeps legacy <root>/kanban.db; others live under boards/<slug>/. */
 const dbPath = (s: string) =>
-  hermesPath(s === DEFAULT ? "kanban.db" : `kanban/boards/${s}/kanban.db`)
+  kp(s === DEFAULT ? "kanban.db" : `kanban/boards/${s}/kanban.db`)
 
 const logsDir = (s: string) =>
-  hermesPath(s === DEFAULT ? "kanban/logs" : `kanban/boards/${s}/logs`)
+  kp(s === DEFAULT ? "kanban/logs" : `kanban/boards/${s}/logs`)
 
 const pair = (s: string): Handles => {
   const cached = handles.get(s)
@@ -267,7 +282,7 @@ export const resetKanban = () => {
 /** Enumerate boards on disk. 'default' always first; others sorted. */
 export function listBoards(): Board[] {
   const out = new Map<string, string>([[DEFAULT, "Default"]])
-  const dir = hermesPath("kanban/boards")
+  const dir = kp("kanban/boards")
   if (existsSync(dir))
     for (const e of readdirSync(dir, { withFileTypes: true })) {
       if (!e.isDirectory() || !SLUG.test(e.name)) continue
@@ -495,7 +510,7 @@ export function tailLogOf(s: string, id: string, bytes = 16_384): string | null 
  *  no longer exists; show it so the operator can reassign *away*). */
 export function assignees(s: string = slug): string[] {
   const seen = new Set<string>()
-  const dir = hermesPath("profiles")
+  const dir = kp("profiles")
   if (existsSync(dir))
     for (const e of readdirSync(dir, { withFileTypes: true }))
       if (e.isDirectory()) seen.add(e.name)

--- a/test/kanban-root.test.ts
+++ b/test/kanban-root.test.ts
@@ -1,0 +1,47 @@
+// gh#28 — kanban paths must collapse …/profiles/<name> to the shared
+// Hermes root so the TUI sees the same boards `hermes kanban` does.
+// Mirrors upstream hermes_cli/kanban_db.py::kanban_home() resolution.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { setHome } from "../src/utils/hermes-home"
+import { kanbanRoot, resetKanban } from "../src/utils/hermes-kanban"
+
+const HH = process.env.HERMES_HOME!   // preload.ts sandboxes this
+
+describe("kanbanRoot (gh#28)", () => {
+  let pin: string | undefined
+  beforeEach(() => { pin = process.env.HERMES_KANBAN_HOME; delete process.env.HERMES_KANBAN_HOME })
+  afterEach(() => {
+    if (pin === undefined) delete process.env.HERMES_KANBAN_HOME
+    else process.env.HERMES_KANBAN_HOME = pin
+    setHome(HH); resetKanban()
+  })
+
+  test("HERMES_HOME at root → root", () => {
+    setHome("/h/.hermes")
+    expect(kanbanRoot()).toBe("/h/.hermes")
+  })
+
+  test("HERMES_HOME inside profiles/<name> collapses to parent root", () => {
+    setHome("/h/.hermes/profiles/ops-manager")
+    expect(kanbanRoot()).toBe("/h/.hermes")
+  })
+
+  test("trailing slashes trimmed before collapse", () => {
+    setHome("/h/.hermes/profiles/home-assistant///")
+    expect(kanbanRoot()).toBe("/h/.hermes")
+  })
+
+  test("HERMES_KANBAN_HOME override wins over profile collapse", () => {
+    setHome("/h/.hermes/profiles/ops-manager")
+    process.env.HERMES_KANBAN_HOME = "/pinned/kanban/"
+    expect(kanbanRoot()).toBe("/pinned/kanban")
+  })
+
+  test("non-'profiles' penultimate segment is left alone", () => {
+    setHome("/srv/profiles-data/hermes")
+    expect(kanbanRoot()).toBe("/srv/profiles-data/hermes")
+    setHome("/h/.hermes/profiles")   // 'profiles' is the leaf, not the parent
+    expect(kanbanRoot()).toBe("/h/.hermes/profiles")
+  })
+})


### PR DESCRIPTION
Closes #28.

## Problem
Kanban reader resolved paths via `hermesPath()`, i.e. the literal active `HERMES_HOME`. When that's `~/.hermes/profiles/<name>`, native Hermes still reads the shared `~/.hermes` root (`hermes_cli/kanban_db.py::kanban_home()`), so the TUI looked at a nonexistent profile-local `kanban.db` / `kanban/boards` and rendered empty.

## Fix
`kanbanRoot()` in `src/utils/hermes-kanban.ts`, mirroring upstream:
1. `HERMES_KANBAN_HOME` when set.
2. Else active home with trailing `/profiles/<name>` stripped.

Routed through `hermesPath("")` so post-rehome profile switches follow without a module reload. `kanban.db`, `kanban/current`, `kanban/boards`, `kanban/logs`, and assignee `profiles/` discovery all go through it.

## Out of scope
- #29 stale-handle reset (separate PR).
- Non-kanban rehome logic.

## Verify
- `bunx tsc --noEmit`: 0 new (1 pre-existing `test/context.test.tsx:136`).
- `bun test`: 815/815 (+5 in `test/kanban-root.test.ts`).