### PR TITLE
fix: add missing streaming property in context test

### DIFF
--- a/test/context.test.tsx
+++ b/test/context.test.tsx
@@ -133,7 +133,7 @@ describe("Context tab", () => {
   describe("keyboard nav", () => {
     const msgs: Message[] = [{
       id: "m1", role: "user", timestamp: 0,
-      parts: [{ type: "text", content: "hello world ".repeat(50) }],
+      parts: [{ type: "text", content: "hello world ".repeat(50), streaming: false }],
       usage: { input: 200, output: 0, total: 200 },
     }]
     const info: SessionInfo = { model: "test", context_max: 10_000 }


### PR DESCRIPTION
The TextPart type requires a `streaming` property, but the test was creating a TextPart without it. This causes a TypeScript compilation error (`tsc --noEmit` fails).

```
test/context.test.tsx(136,15): error TS2322: Type '{ type: "text"; content: string; }' is not assignable to type 'Part'.
  Property 'streaming' is missing in type '{ type: "text"; content: string; }' but required in type 'TextPart'.
```

Adding `streaming: false` fixes the type error.