### PR TITLE
fix: handle TOCTOU race in fs.watch path detection

### DIFF
--- a/src/home/store.ts
+++ b/src/home/store.ts
@@ -270,7 +270,9 @@ export class HomeStore {
           name = null
         }
       } catch {
-        continue
+        // TOCTOU: file may have been deleted between existsSync and
+        // statSync. Fall through — dir/name already default to the
+        // parent directory, which the watch logic below handles.
       }
       if (!existsSync(dir)) continue
       try {


### PR DESCRIPTION
In `startWatch()`, if a file is deleted between `existsSync(p)` returning true and `statSync(p)` being called, the catch block would `continue` and skip setting up the watcher entirely. Since `dir` and `name` already default to the parent directory + basename before the try block, the fix is to let the code fall through — the existing parent-directory watching logic below handles this case correctly.