### PR TITLE
fix(build): shim react/jsx-dev-runtime so prod bundle paints

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -37,10 +37,9 @@ const noopDevtools: import("bun").BunPlugin = {
   },
 }
 
-// See the define-block comment below for the upstream bug this papers over.
-// Shim `react/jsx-dev-runtime` → the production runtime, re-exporting `jsx`
-// under the name `jsxDEV`. Anything importing from the dev runtime (only
-// @opentui/react today) gets a working function instead of `undefined`.
+// @opentui/react's bundle calls jsxDEV from react/jsx-dev-runtime, which
+// is `undefined` under NODE_ENV=production. Alias it to prod `jsx`
+// (jsx === jsxs in React 19 prod, so isStaticChildren is moot).
 const jsxDevShim: import("bun").BunPlugin = {
   name: "jsx-dev-shim",
   setup(b) {
@@ -79,12 +78,6 @@ const result = await Bun.build({
   sourcemap: "none",
   external,
   plugins: [noopDevtools, jsxDevShim],
-  // @opentui/react@0.2.2 ships one bundle that imports `jsxDEV` from
-  // `react/jsx-dev-runtime`. In React's production build that export is
-  // `undefined`, so under NODE_ENV=production the first BoundSlot render
-  // throws `jsxDEV is not a function` and the shell never paints. Redirect
-  // the dev runtime to the stable one; `jsxDEV(type, props, key)` is call-
-  // compatible with `jsx(type, props, key)` (extra debug args are ignored).
   define: {
     "process.env.NODE_ENV": '"production"',
     "process.env.DEV": '"false"',

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -30,8 +30,28 @@ const noopDevtools: import("bun").BunPlugin = {
   setup(b) {
     b.onResolve({ filter: /^react-devtools-core$/ }, () =>
       ({ path: "rdc-stub", namespace: "stub" }))
-    b.onLoad({ filter: /.*/, namespace: "stub" }, () => ({
+    b.onLoad({ filter: /^rdc-stub$/, namespace: "stub" }, () => ({
       contents: "export default { initialize() {}, connectToDevTools() {} }",
+      loader: "js",
+    }))
+  },
+}
+
+// See the define-block comment below for the upstream bug this papers over.
+// Shim `react/jsx-dev-runtime` → the production runtime, re-exporting `jsx`
+// under the name `jsxDEV`. Anything importing from the dev runtime (only
+// @opentui/react today) gets a working function instead of `undefined`.
+const jsxDevShim: import("bun").BunPlugin = {
+  name: "jsx-dev-shim",
+  setup(b) {
+    b.onResolve({ filter: /^react\/jsx-dev-runtime$/ }, () =>
+      ({ path: "jsx-dev-shim", namespace: "stub" }))
+    b.onLoad({ filter: /^jsx-dev-shim$/, namespace: "stub" }, () => ({
+      contents: `
+        import { jsx, jsxs, Fragment } from "react/jsx-runtime"
+        export { jsx, jsxs, Fragment }
+        export var jsxDEV = jsx
+      `,
       loader: "js",
     }))
   },
@@ -58,7 +78,13 @@ const result = await Bun.build({
   minify: { whitespace: true, syntax: true, identifiers: false },
   sourcemap: "none",
   external,
-  plugins: [noopDevtools],
+  plugins: [noopDevtools, jsxDevShim],
+  // @opentui/react@0.2.2 ships one bundle that imports `jsxDEV` from
+  // `react/jsx-dev-runtime`. In React's production build that export is
+  // `undefined`, so under NODE_ENV=production the first BoundSlot render
+  // throws `jsxDEV is not a function` and the shell never paints. Redirect
+  // the dev runtime to the stable one; `jsxDEV(type, props, key)` is call-
+  // compatible with `jsx(type, props, key)` (extra debug args are ignored).
   define: {
     "process.env.NODE_ENV": '"production"',
     "process.env.DEV": '"false"',

--- a/src/plugins/runtime.tsx
+++ b/src/plugins/runtime.tsx
@@ -91,15 +91,10 @@ function scoped(base: HermPluginApi, reg: ReturnType<typeof createReactSlotRegis
   }
 }
 
-// createSlotRegistry is keyed per-renderer under the fixed
-// "react:slot-registry" key and throws if a second call supplies a
-// different `context` object — by design (see opentui react/tests/
-// slot.test.tsx "reuses one registry per renderer and rejects different
-// context"). PluginProvider can remount (ErrorBoundary retry, fast
-// refresh, test renderer reuse) while the renderer lives on, so the
-// SlotCtx cannot be constructed inside the component. Upstream's React
-// example holds its context at module scope; we do the same but keep a
-// mutable themeRef cell so the current mount's theme is always read.
+// createSlotRegistry stores one registry per renderer and throws if a
+// second call passes a different context object. Intern the SlotCtx at
+// module scope so PluginProvider remounts reuse it; swap the themeRef
+// cell each call so the getter reads the live theme.
 type Cell = { ctx: SlotCtx; themeRef: { current: { theme: Theme } } }
 const CELLS = new WeakMap<object, Cell>()
 function ctxFor(renderer: object, themeRef: Cell["themeRef"]): SlotCtx {

--- a/src/plugins/runtime.tsx
+++ b/src/plugins/runtime.tsx
@@ -91,6 +91,22 @@ function scoped(base: HermPluginApi, reg: ReturnType<typeof createReactSlotRegis
   }
 }
 
+// The underlying SlotRegistry store is keyed per-renderer under the fixed
+// "react:slot-registry" key and throws if a second call supplies a
+// different `context` object. PluginProvider can unmount/remount (fast
+// refresh, ErrorBoundary retry, test renderer reuse) while the renderer
+// lives on — each fresh mount would construct a new SlotCtx and crash.
+// Intern one SlotCtx per renderer at module scope so every mount reuses it.
+const CTXS = new WeakMap<object, SlotCtx>()
+function ctxFor(renderer: object, themeRef: { current: { theme: unknown } }): SlotCtx {
+  const hit = CTXS.get(renderer)
+  if (hit) return hit
+  const made = Object.defineProperty({} as SlotCtx, "theme",
+    { get: () => themeRef.current.theme, enumerable: true })
+  CTXS.set(renderer, made)
+  return made
+}
+
 export function PluginProvider(props: { children: ReactNode; plugins?: ReadonlyArray<HermPlugin> }) {
   const list = props.plugins ?? INTERNAL
   const renderer = useRenderer()
@@ -115,8 +131,7 @@ export function PluginProvider(props: { children: ReactNode; plugins?: ReadonlyA
   const reg = useMemo(
     () => createReactSlotRegistry<Slots, SlotCtx>(
       renderer,
-      // Stable object; `theme` is a getter so slot renderers retint live.
-      Object.defineProperty({} as SlotCtx, "theme", { get: () => themeRef.current.theme, enumerable: true }),
+      ctxFor(renderer, themeRef),
       { onPluginError: e => fail(`[plugin:${e.pluginId}] ${e.phase} error in slot "${e.slot}"`, e.error) },
     ),
     [renderer],

--- a/src/plugins/runtime.tsx
+++ b/src/plugins/runtime.tsx
@@ -7,7 +7,7 @@
 import { createContext, useEffect, useMemo, useReducer, useRef, type ReactNode } from "react"
 import { createReactSlotRegistry, createSlot, useRenderer, type ReactSlotComponent } from "@opentui/react"
 import { makeUse } from "../context/helper"
-import { useTheme } from "../theme"
+import { useTheme, type Theme } from "../theme"
 import { useKeys } from "../keys"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
@@ -91,20 +91,25 @@ function scoped(base: HermPluginApi, reg: ReturnType<typeof createReactSlotRegis
   }
 }
 
-// The underlying SlotRegistry store is keyed per-renderer under the fixed
+// createSlotRegistry is keyed per-renderer under the fixed
 // "react:slot-registry" key and throws if a second call supplies a
-// different `context` object. PluginProvider can unmount/remount (fast
-// refresh, ErrorBoundary retry, test renderer reuse) while the renderer
-// lives on — each fresh mount would construct a new SlotCtx and crash.
-// Intern one SlotCtx per renderer at module scope so every mount reuses it.
-const CTXS = new WeakMap<object, SlotCtx>()
-function ctxFor(renderer: object, themeRef: { current: { theme: unknown } }): SlotCtx {
-  const hit = CTXS.get(renderer)
-  if (hit) return hit
-  const made = Object.defineProperty({} as SlotCtx, "theme",
-    { get: () => themeRef.current.theme, enumerable: true })
-  CTXS.set(renderer, made)
-  return made
+// different `context` object — by design (see opentui react/tests/
+// slot.test.tsx "reuses one registry per renderer and rejects different
+// context"). PluginProvider can remount (ErrorBoundary retry, fast
+// refresh, test renderer reuse) while the renderer lives on, so the
+// SlotCtx cannot be constructed inside the component. Upstream's React
+// example holds its context at module scope; we do the same but keep a
+// mutable themeRef cell so the current mount's theme is always read.
+type Cell = { ctx: SlotCtx; themeRef: { current: { theme: Theme } } }
+const CELLS = new WeakMap<object, Cell>()
+function ctxFor(renderer: object, themeRef: Cell["themeRef"]): SlotCtx {
+  const hit = CELLS.get(renderer)
+  if (hit) { hit.themeRef = themeRef; return hit.ctx }
+  const cell: Cell = { themeRef, ctx: {} as SlotCtx }
+  Object.defineProperty(cell.ctx, "theme",
+    { get: () => cell.themeRef.current.theme, enumerable: true })
+  CELLS.set(renderer, cell)
+  return cell.ctx
 }
 
 export function PluginProvider(props: { children: ReactNode; plugins?: ReadonlyArray<HermPlugin> }) {


### PR DESCRIPTION
## Symptom

`bun run build && bun dist/index.js` boots, paints one whitespace frame, and sits forever on a blank screen. `bun src/index.tsx` (dev) works. `NODE_ENV=production bun src/index.tsx` reproduces without the bundler.

## Cause

`@opentui/react` (0.2.2, still present in 0.2.10) ships a bundle whose internal JSX was emitted with `jsxDEV` from `react/jsx-dev-runtime`. React 19 exports `jsxDEV = undefined` in its production build, so the first `<Slot>` render throws `jsxDEV is not a function`, the root ErrorBoundary swallows it, and the subtree unmounts. Surfaced now because PR #38 put `<PluginProvider>` (which mounts `BoundSlot`) on the render path.

The retry render then hit a second, latent bug: `PluginProvider` built a fresh `SlotCtx` object inside `useMemo`, but `createSlotRegistry` keys one registry per renderer under `"react:slot-registry"` and throws if called again with a different context identity. Any remount against a live renderer (ErrorBoundary retry, fast refresh, test renderer reuse) would crash here regardless of the jsxDEV bug.

## Fix

- `scripts/build.ts`: add a `jsxDevShim` Bun plugin that intercepts `react/jsx-dev-runtime` and re-exports `jsx` as `jsxDEV`. In React 19 prod `jsx === jsxs === jsxProd`, so the 4th `isStaticChildren` arg is moot. Narrow the existing `noopDevtools` onLoad filter from `/.*/` to `/^rdc-stub$/` so it stops capturing every stub-namespace load (it was eating the shim).
- `src/plugins/runtime.tsx`: intern the SlotCtx per renderer at module scope (`WeakMap<renderer, {ctx, themeRef}>`). `ctxFor()` swaps the `themeRef` cell on every call so remounts read the current theme, but `ctx` identity is stable for the lifetime of the renderer. Matches the pattern in opentui's own React example, which holds `hostContext` at module scope.

## Verified

- `bun run build` then `dist/index.js` paints the splash.
- `NODE_ENV=production bun src/index.tsx` paints.
- `bun test`: 865 pass / 0 fail.
- `bunx tsc --noEmit` clean.

## Not done here

- `@opentui/react` bump. 0.2.10 still has the jsxDEV emission; fixing it there needs `"jsx": "react-jsx"` in their `tsconfig.build.json`. Upstream issue to follow.
- Dropping `NODE_ENV=production` from the define block. React dev mode runs element validation per createElement; not worth the per-frame cost when the shim is 7 lines.
