### PR TITLE
feat(keys): Ctrl+V image attach, empty-paste probe, double-tap quit

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -569,6 +569,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     queued: queue.length,
     onFlushQueue: stream.doInterrupt,
     onQuit: () => quit(renderer, sid, title, gw),
+    onQuitArm: (label) =>
+      toast.show({ variant: "info", message: `${label} again to quit` }),
     onInterruptNotice: () => {
       setEscHint(true)
       setTimeout(() => setEscHint(false), 5000)
@@ -692,6 +694,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 cmds={cmds}
                 onSend={onSend} onSlash={slash} onShell={onShell}
                 onAttach={onAttach}
+                onAttachClipboard={attachClipboard}
                 onEnqueue={onEnqueue}
                 onDequeue={dequeue}
                 onDirty={setComposing}

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -52,7 +52,6 @@ type Opts = {
   queued: number
   onFlushQueue: () => void
   onQuit: () => void
-  /** First Ctrl+C on an empty buffer — caller shows a transient hint. */
   onQuitArm: (label: string) => void
   onCopyLast: () => void
   onAttachClipboard: () => void
@@ -117,11 +116,8 @@ export function useAppKeys(o: Opts) {
       key.stopPropagation()
       return
     }
-    // Double-tap to quit. Legacy terminals can't report Shift on
-    // Ctrl+letter, so Ctrl+Shift+C (the user's intended copy chord)
-    // arrives as plain ^C; on a non-kitty emulator with no selection
-    // and an empty buffer that used to be a one-shot exit. First press
-    // arms + hints; second within QUIT_MS quits.
+    // Legacy terminals send Ctrl+Shift+C as plain ^C — guard with a
+    // double-tap so a reflexive copy chord doesn't one-shot exit.
     if (keys.match("app.exit", key)) {
       const now = Date.now()
       if (now - lastQuit.current < QUIT_MS) return o.onQuit()

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -24,6 +24,7 @@ import type { ComposerHandle } from "../components/chat/Composer"
 
 const INTERRUPT_MS = 5000
 export const DOUBLE_TAB_MS = 400
+export const QUIT_MS = 2000
 
 type Region = "input" | "content"
 
@@ -51,6 +52,8 @@ type Opts = {
   queued: number
   onFlushQueue: () => void
   onQuit: () => void
+  /** First Ctrl+C on an empty buffer — caller shows a transient hint. */
+  onQuitArm: (label: string) => void
   onCopyLast: () => void
   onAttachClipboard: () => void
   /** Remove the last pending attachment (backspace on empty composer). */
@@ -65,6 +68,7 @@ export function useAppKeys(o: Opts) {
   const keys = useKeys()
   const lastEsc = useRef(0)
   const lastTab = useRef(0)
+  const lastQuit = useRef(0)
 
   // Tabs with their own keyboard surface own focus on entry; Chat keeps
   // the composer since its content region has no keybinds.
@@ -104,6 +108,7 @@ export function useAppKeys(o: Opts) {
       const v = c.value().trim()
       if (v.length >= 20) c.remember(v)
       c.set("")
+      lastQuit.current = 0
       key.stopPropagation()
       return
     }
@@ -112,7 +117,19 @@ export function useAppKeys(o: Opts) {
       key.stopPropagation()
       return
     }
-    if (keys.match("app.exit", key)) return o.onQuit()
+    // Double-tap to quit. Legacy terminals can't report Shift on
+    // Ctrl+letter, so Ctrl+Shift+C (the user's intended copy chord)
+    // arrives as plain ^C; on a non-kitty emulator with no selection
+    // and an empty buffer that used to be a one-shot exit. First press
+    // arms + hints; second within QUIT_MS quits.
+    if (keys.match("app.exit", key)) {
+      const now = Date.now()
+      if (now - lastQuit.current < QUIT_MS) return o.onQuit()
+      lastQuit.current = now
+      o.onQuitArm(keys.print("app.exit"))
+      key.stopPropagation()
+      return
+    }
 
     if (keys.match("app.suspend", key)) {
       renderer.suspend()

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -61,6 +61,10 @@ type Props = {
    *  to shell.exec and rendered as a transcript $ cmd / stdout pair. */
   onShell?: (command: string) => void
   onAttach?: (r: ImageAttachResponse) => void
+  /** Probe the OS clipboard for an image (same path as the Ctrl+V chord).
+   *  Called on an empty bracketed-paste, which is how Windows Terminal
+   *  surfaces image-only clipboard content. */
+  onAttachClipboard?: () => void
   onEnqueue?: (text: string) => void
   onDequeue?: (i: number) => void
   /** Enter pressed with an empty buffer. Return true to consume. */
@@ -149,6 +153,9 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   }
 
   // Paste routing, in priority order:
+  //  0. Empty bracketed paste → probe the OS clipboard for an image.
+  //     Windows Terminal surfaces an image-only clipboard as ESC[200~
+  //     ESC[201~ with no payload; the image has to be read out-of-band.
   //  1. Single-line paste that *looks* like a local path → ask the gateway.
   //     input.detect_drop is authoritative (stats the file, handles file://,
   //     quoting, escaped spaces, ~/ expansion, WSL drive rewriting). Image
@@ -169,6 +176,10 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     e.preventDefault()
     const raw = decodePasteBytes(e.bytes).replace(/\r\n?/g, "\n")
     const text = /[^\n]/.test(raw) ? raw.replace(/\n+$/, "") : raw
+    if (!text) {
+      live.current.props.onAttachClipboard?.()
+      return
+    }
     const verbatim = () => ta.current?.insertText(text)
     if (looksLikePath(text)) {
       gw.request<DropDetectResponse>("input.detect_drop", { text })

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -61,9 +61,7 @@ type Props = {
    *  to shell.exec and rendered as a transcript $ cmd / stdout pair. */
   onShell?: (command: string) => void
   onAttach?: (r: ImageAttachResponse) => void
-  /** Probe the OS clipboard for an image (same path as the Ctrl+V chord).
-   *  Called on an empty bracketed-paste, which is how Windows Terminal
-   *  surfaces image-only clipboard content. */
+  /** Fired on an empty bracketed paste (Windows Terminal image-only clipboard). */
   onAttachClipboard?: () => void
   onEnqueue?: (text: string) => void
   onDequeue?: (i: number) => void
@@ -153,9 +151,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   }
 
   // Paste routing, in priority order:
-  //  0. Empty bracketed paste → probe the OS clipboard for an image.
-  //     Windows Terminal surfaces an image-only clipboard as ESC[200~
-  //     ESC[201~ with no payload; the image has to be read out-of-band.
+  //  0. Empty payload → probe the OS clipboard for an image. Windows
+  //     Terminal sends a zero-byte bracketed paste for image-only content.
   //  1. Single-line paste that *looks* like a local path → ask the gateway.
   //     input.detect_drop is authoritative (stats the file, handles file://,
   //     quoting, escaped spaces, ~/ expansion, WSL drive rewriting). Image

--- a/src/keys/catalog.ts
+++ b/src/keys/catalog.ts
@@ -14,11 +14,6 @@
 // `leader` entry). Existing Ctrl-chords are kept as secondary alternates
 // so nothing breaks while the leader pattern settles; print() shows the
 // first alternate, so Help advertises the leader form.
-//
-// Trailing markers cross-reference opencode's config/keybinds.ts:
-//   (blank)  oc has the same action on substantively the same chord
-//   ø        oc has an analogue but herm binds it differently
-//   ☨        no oc equivalent (herm-specific surface or concept)
 
 export type Scope =
   | "global" | "list" | "dialog" | "composer"
@@ -31,21 +26,20 @@ const def = (chord: string, desc: string, scope: Scope): Def => ({ chord, desc, 
 export const DEFAULTS = {
   "leader":            def("ctrl+x",               "Leader prefix",                      "global"),
   "app.exit":          def("ctrl+c",               "Quit",                               "global"),
-  // Same chord as app.exit, disjoint on buffer-empty. oc parity:
-  // input_clear + app_exit both bind ctrl+c and dispatch sequentially.
+  // Same chord as app.exit, disjoint on buffer-empty — see useAppKeys.
   "input.clear":       def("ctrl+c",               "Clear input",                        "global"),
   "app.suspend":       def("ctrl+z",               "Suspend to shell",                   "global"),
-  "app.redraw":        def("ctrl+l",               "Clear & force-repaint terminal",     "global"), // ☨
+  "app.redraw":        def("ctrl+l",               "Clear & force-repaint terminal",     "global"),
   "app.sidebar":       def("<leader>b",            "Toggle sidebar",                     "global"),
-  "palette.open":      def("ctrl+k",               "Command palette",                    "global"), // ø command_list=ctrl+p
-  "help.open":         def("f1",                   "Keyboard shortcuts",                 "global"), // ☨
-  "tab.next":          def("alt+right",            "Next tab",                           "global"), // ☨
-  "tab.prev":          def("alt+left",             "Previous tab",                       "global"), // ☨
-  "focus.cycle":       def("tab",                  "Cycle focus (double-tap → composer)","global"), // ☨
+  "palette.open":      def("ctrl+k",               "Command palette",                    "global"),
+  "help.open":         def("f1",                   "Keyboard shortcuts",                 "global"),
+  "tab.next":          def("alt+right",            "Next tab",                           "global"),
+  "tab.prev":          def("alt+left",             "Previous tab",                       "global"),
+  "focus.cycle":       def("tab",                  "Cycle focus (double-tap → composer)","global"),
   "editor.open":       def("<leader>e,ctrl+g",     "Open $EDITOR on prompt",             "global"),
   "reply.copy":        def("<leader>y,ctrl+y",     "Copy last assistant reply",          "global"),
   "clipboard.attach":  def("ctrl+v",               "Attach clipboard image",             "global"),
-  "queue.flush":       def("<leader>u",            "Interrupt and send queued now",      "global"), // ☨
+  "queue.flush":       def("<leader>u",            "Interrupt and send queued now",      "global"),
   "session.interrupt": def("escape",               "Interrupt (double-tap while streaming)", "global"),
   "session.new":       def("<leader>n",            "New session",                        "global"),
   "session.redo":      def("<leader>r",            "Redo last undo",                     "global"),
@@ -55,8 +49,6 @@ export const DEFAULTS = {
   "theme.pick":        def("<leader>t",            "Switch theme",                       "global"),
   "model.pick":        def("<leader>m",            "Switch model",                       "global"),
   "status.open":       def("<leader>s",            "Show status",                        "global"),
-  // ☨ — oc has no generic list surface; nearest are per-dialog
-  //     session_*/stash_* bindings and messages_* scroll.
   "list.up":           def("up",                   "Move selection up",                  "list"),
   "list.down":         def("down",                 "Move selection down",                "list"),
   "list.pageUp":       def("pageup",               "Page up",                            "list"),
@@ -69,7 +61,6 @@ export const DEFAULTS = {
   "list.new":          def("n",                    "Create",                             "list"),
   "list.search":       def("/",                    "Filter",                             "list"),
   "list.toggle":       def("space",                "Toggle item",                        "list"),
-  // ☨ — oc dialogs hardcode return/escape/y/n per-component.
   "dialog.accept":     def("return",               "Accept",                             "dialog"),
   "dialog.cancel":     def("escape",               "Cancel / close",                     "dialog"),
   "dialog.confirm":    def("y",                    "Yes",                                "dialog"),
@@ -77,17 +68,14 @@ export const DEFAULTS = {
   "dialog.copy":       def("c",                    "Copy body",                          "dialog"),
   "input.submit":      def("return",               "Send",                               "composer"),
   "input.newline":     def("shift+return,ctrl+return,alt+return,ctrl+j", "Insert newline", "composer"),
-  // ☨ — herm admin tabs (Cron/Env/Skills/Agents/Config) have no oc
-  //     counterpart; sessions.rename diverges from oc's session-
-  //     dialog ctrl+r.
-  "sessions.rename":   def("ctrl+r",               "Retitle session",                    "sessions"), // match oc session_rename
+  "sessions.rename":   def("ctrl+r",               "Retitle session",                    "sessions"),
   "sessions.prev":     def("left",                 "Walk lineage back (continues from)", "sessions"),
   "sessions.next":     def("right",                "Walk lineage forward (compressed to)", "sessions"),
   "agents.kill":       def("k",                    "Kill subagent",                      "agents"),
   "agents.history":    def("h",                    "Spawn history",                      "agents"),
-  "agents.install":    def("i",                    "Install distribution",               "agents"), // ☨
+  "agents.install":    def("i",                    "Install distribution",               "agents"),
   "config.save":       def("ctrl+s",               "Write config",                       "config"),
-  "config.mode":       def("m",                    "Toggle form ↔ YAML",                 "config"), // ☨
+  "config.mode":       def("m",                    "Toggle form ↔ YAML",                 "config"),
 } satisfies Record<string, Def>
 
 export type ActionId = keyof typeof DEFAULTS

--- a/src/keys/catalog.ts
+++ b/src/keys/catalog.ts
@@ -44,7 +44,7 @@ export const DEFAULTS = {
   "focus.cycle":       def("tab",                  "Cycle focus (double-tap → composer)","global"), // ☨
   "editor.open":       def("<leader>e,ctrl+g",     "Open $EDITOR on prompt",             "global"),
   "reply.copy":        def("<leader>y,ctrl+y",     "Copy last assistant reply",          "global"),
-  "clipboard.attach":  def("alt+v",                "Attach clipboard image",             "global"), // ø input_paste=ctrl+v
+  "clipboard.attach":  def("ctrl+v",               "Attach clipboard image",             "global"), // oc input_paste=ctrl+v
   "queue.flush":       def("<leader>u",            "Interrupt and send queued now",      "global"), // ☨
   "session.interrupt": def("escape",               "Interrupt (double-tap while streaming)", "global"),
   "session.new":       def("<leader>n",            "New session",                        "global"),

--- a/src/keys/catalog.ts
+++ b/src/keys/catalog.ts
@@ -44,7 +44,7 @@ export const DEFAULTS = {
   "focus.cycle":       def("tab",                  "Cycle focus (double-tap → composer)","global"), // ☨
   "editor.open":       def("<leader>e,ctrl+g",     "Open $EDITOR on prompt",             "global"),
   "reply.copy":        def("<leader>y,ctrl+y",     "Copy last assistant reply",          "global"),
-  "clipboard.attach":  def("ctrl+v",               "Attach clipboard image",             "global"), // oc input_paste=ctrl+v
+  "clipboard.attach":  def("ctrl+v",               "Attach clipboard image",             "global"),
   "queue.flush":       def("<leader>u",            "Interrupt and send queued now",      "global"), // ☨
   "session.interrupt": def("escape",               "Interrupt (double-tap while streaming)", "global"),
   "session.new":       def("<leader>n",            "New session",                        "global"),
@@ -54,7 +54,6 @@ export const DEFAULTS = {
   "session.timeline":  def("<leader>g",            "Session timeline",                   "global"),
   "theme.pick":        def("<leader>t",            "Switch theme",                       "global"),
   "model.pick":        def("<leader>m",            "Switch model",                       "global"),
-  // "tool.details":      def("<leader>d",            "Cycle tool-trail detail",            "global"), // ø tool_details=none k: I need to see if it warrants a shortcut. defer
   "status.open":       def("<leader>s",            "Show status",                        "global"),
   // ☨ — oc has no generic list surface; nearest are per-dialog
   //     session_*/stash_* bindings and messages_* scroll.
@@ -66,8 +65,8 @@ export const DEFAULTS = {
   "list.end":          def("end",                  "Last item",                          "list"),
   "list.activate":     def("return",               "Activate / open",                    "list"),
   "list.delete":       def("d,delete",             "Delete item",                        "list"),
-  "list.refresh":      def("r",                    "Reload",                             "list"), // k: where is this used?  → 7 tabs; removal tracked in herm-0pg.15 (gated on bqo)
-  "list.new":          def("n",                    "Create",                             "list"), // k: keep
+  "list.refresh":      def("r",                    "Reload",                             "list"),
+  "list.new":          def("n",                    "Create",                             "list"),
   "list.search":       def("/",                    "Filter",                             "list"),
   "list.toggle":       def("space",                "Toggle item",                        "list"),
   // ☨ — oc dialogs hardcode return/escape/y/n per-component.
@@ -84,9 +83,9 @@ export const DEFAULTS = {
   "sessions.rename":   def("ctrl+r",               "Retitle session",                    "sessions"), // match oc session_rename
   "sessions.prev":     def("left",                 "Walk lineage back (continues from)", "sessions"),
   "sessions.next":     def("right",                "Walk lineage forward (compressed to)", "sessions"),
-  "agents.kill":       def("k",                    "Kill subagent",                      "agents"),	// k: I like this
-  "agents.history":    def("h",                    "Spawn history",                      "agents"),	// k: keep
-  "agents.install":    def("i",                    "Install distribution",               "agents"),	// ☨
+  "agents.kill":       def("k",                    "Kill subagent",                      "agents"),
+  "agents.history":    def("h",                    "Spawn history",                      "agents"),
+  "agents.install":    def("i",                    "Install distribution",               "agents"), // ☨
   "config.save":       def("ctrl+s",               "Write config",                       "config"),
   "config.mode":       def("m",                    "Toggle form ↔ YAML",                 "config"), // ☨
 } satisfies Record<string, Def>

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -3,7 +3,7 @@ import { act } from "react"
 import { mount, until, MockGateway } from "./harness"
 import * as prefs from "../src/context/preferences"
 import * as exit from "../src/app/exit"
-import { DOUBLE_TAB_MS } from "../src/app/useAppKeys"
+import { DOUBLE_TAB_MS, QUIT_MS } from "../src/app/useAppKeys"
 import type { GatewayEvent } from "../src/context/wire"
 
 describe("app", () => {
@@ -73,7 +73,7 @@ describe("app", () => {
     t.destroy()
   })
 
-  test("Ctrl+C: non-empty buffer clears; empty buffer quits (oc parity)", async () => {
+  test("Ctrl+C: non-empty clears; empty arms then quits on double-tap", async () => {
     const q = spyOn(exit, "quit").mockImplementation((() => {}) as never)
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
@@ -88,12 +88,47 @@ describe("app", () => {
     expect(t.frame()).toContain("Message Hermes")
     expect(q).not.toHaveBeenCalled()
 
+    // First ^C on empty → arm + hint, no quit.
+    act(() => t.keys.pressKey("c", { ctrl: true }))
+    await until(t, () => t.frame().includes("again to quit"))
+    expect(q).not.toHaveBeenCalled()
+
+    // Second within window → quit.
     act(() => t.keys.pressKey("c", { ctrl: true }))
     await t.settle()
     expect(q).toHaveBeenCalledTimes(1)
     // sid arg threaded from session state.
     expect(q.mock.calls[0]?.[1]).toBe("test-sid")
 
+    q.mockRestore()
+    t.destroy()
+  })
+
+  test("Ctrl+C: arm expires after QUIT_MS", async () => {
+    const q = spyOn(exit, "quit").mockImplementation((() => {}) as never)
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    // until() uses Date.now() for its own timeout — mock only after
+    // boot settles, and use bare settle()/expect thereafter.
+    const t0 = 10_000
+    const now = spyOn(Date, "now").mockReturnValue(t0)
+    act(() => t.keys.pressKey("c", { ctrl: true }))
+    await t.settle()
+    expect(q).not.toHaveBeenCalled()
+
+    now.mockReturnValue(t0 + QUIT_MS + 1)
+    act(() => t.keys.pressKey("c", { ctrl: true }))
+    await t.settle()
+    // Window elapsed → re-arm, not quit.
+    expect(q).not.toHaveBeenCalled()
+
+    now.mockReturnValue(t0 + QUIT_MS + 2)
+    act(() => t.keys.pressKey("c", { ctrl: true }))
+    await t.settle()
+    expect(q).toHaveBeenCalledTimes(1)
+
+    now.mockRestore()
     q.mockRestore()
     t.destroy()
   })

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -109,8 +109,7 @@ describe("app", () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
 
-    // until() uses Date.now() for its own timeout — mock only after
-    // boot settles, and use bare settle()/expect thereafter.
+    // Mock after boot — until() uses Date.now() for its own timeout.
     const t0 = 10_000
     const now = spyOn(Date, "now").mockReturnValue(t0)
     act(() => t.keys.pressKey("c", { ctrl: true }))

--- a/test/attachments.test.tsx
+++ b/test/attachments.test.tsx
@@ -3,7 +3,7 @@ import { act } from "react"
 import { mount, until } from "./harness"
 
 describe("composer: image attachments (D4+D7)", () => {
-  test("Alt+V → clipboard.paste → chip renders; clears on send", async () => {
+  test("Ctrl+V → clipboard.paste → chip renders; clears on send", async () => {
     const t = await mount({
       handlers: {
         "clipboard.paste": () => ({
@@ -14,7 +14,7 @@ describe("composer: image attachments (D4+D7)", () => {
     })
     await until(t, () => t.frame().includes("Ready"))
 
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.gw.last("clipboard.paste") !== undefined)
     await until(t, () => t.frame().includes("clip_1.png"))
 
@@ -44,7 +44,7 @@ describe("composer: image attachments (D4+D7)", () => {
     t.destroy()
   })
 
-  test("Alt+V with no clipboard image → toast, no chip", async () => {
+  test("Ctrl+V with no clipboard image → toast, no chip", async () => {
     const t = await mount({
       handlers: {
         "clipboard.paste": () => ({ attached: false, message: "No image found in clipboard" }),
@@ -52,7 +52,7 @@ describe("composer: image attachments (D4+D7)", () => {
     })
     await until(t, () => t.frame().includes("Ready"))
 
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.gw.last("clipboard.paste") !== undefined)
     await until(t, () => t.frame().includes("No image found in clipboard"))
     expect(t.frame()).not.toContain(" img ")
@@ -71,9 +71,9 @@ describe("composer: image attachments (D4+D7)", () => {
     })
     await until(t, () => t.frame().includes("Ready"))
 
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.frame().includes("i1.png"))
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.frame().includes("i2.png"))
 
     expect(t.frame()).toContain("i1.png")
@@ -92,9 +92,9 @@ describe("composer: image attachments (D4+D7)", () => {
       },
     })
     await until(t, () => t.frame().includes("Ready"))
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.frame().includes("i1.png"))
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.frame().includes("i2.png"))
 
     // First backspace peels i2 (last attached).
@@ -119,7 +119,7 @@ describe("composer: image attachments (D4+D7)", () => {
       },
     })
     await until(t, () => t.frame().includes("Ready"))
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.frame().includes("clip_1.png"))
     await act(async () => { await t.keys.typeText("hi") })
     // Backspace with "hi" in buffer → textarea eats it (now "h").
@@ -140,7 +140,7 @@ describe("composer: image attachments (D4+D7)", () => {
       },
     })
     await until(t, () => t.frame().includes("Ready"))
-    act(() => t.keys.pressKey("v", { meta: true }))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
     await until(t, () => t.frame().includes("⌫ to detach"))
     // Enter with no typed text — should still submit (gateway has the image).
     act(() => t.keys.pressEnter())
@@ -149,6 +149,23 @@ describe("composer: image attachments (D4+D7)", () => {
     // Pre-send tray is gone (detach hint disappears; chip still appears in
     // the transcript MEDIA echo, which is expected).
     await until(t, () => !t.frame().includes("⌫ to detach"))
+    t.destroy()
+  })
+
+  test("empty bracketed paste → probes clipboard for image", async () => {
+    // Windows Terminal surfaces an image-only clipboard as ESC[200~ESC[201~.
+    const t = await mount({
+      handlers: {
+        "clipboard.paste": () => ({
+          attached: true, path: "/tmp/wt.png", name: "wt.png", count: 1,
+        }),
+      },
+    })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.pasteBracketedText("") })
+    await until(t, () => t.gw.last("clipboard.paste") !== undefined)
+    await until(t, () => t.frame().includes("wt.png"))
     t.destroy()
   })
 


### PR DESCRIPTION
Three clipboard/quit fixes reported by Windows/WSL users.

## Changes

**`clipboard.attach` bound to Ctrl+V** (was Alt+V). The gateway `clipboard.paste` RPC already reads images via `powershell.exe` under WSL; only the chord was wrong. Alt+V alternate dropped; users can rebind if wanted.

**Empty bracketed paste probes the clipboard for an image.** Windows Terminal surfaces an image-only clipboard as `ESC[200~ESC[201~` with zero payload. Previously that was a silent no-op; now it routes to the same `clipboard.paste` RPC as Ctrl+V and renders a chip. Newline-only pastes are unaffected (still insert verbatim).

**`app.exit` requires a double-tap.** Legacy terminals encode Ctrl+Shift+C identically to Ctrl+C, so a reflexive copy chord on an empty buffer was a one-shot quit. First press now arms and toasts `Ctrl+C again to quit`; second press within 2s exits. `input.clear` (Ctrl+C on a non-empty buffer) resets the arm.

## Gates

- `bunx tsc --noEmit`: clean (one pre-existing unrelated error in `test/context.test.tsx`)
- `bun test`: 867 pass / 0 fail

## Files

```
src/keys/catalog.ts              |  2 +-
src/app/useAppKeys.ts            | 19 ++++++++++++++++++-
src/app.tsx                      |  3 +++
src/components/chat/Composer.tsx | 11 +++++++++++
test/app.test.tsx                | 39 +++++++++++++++++++++++++++++++++++++--
test/attachments.test.tsx        | 37 +++++++++++++++++++++++++++----------
```