### PR TITLE
fix(bin): node launcher shim so npm .ps1 resolves on Windows

### DIFF
--- a/bin/herm.cjs
+++ b/bin/herm.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Launcher shim: locate a bun runtime and exec dist/index.js under it.
+// Node shebang so npm's cmd-shim generates a .ps1 that invokes node.exe,
+// which is always resolvable (npm itself is running under it). A bun
+// shebang produces a .ps1 that looks for a literal bun.exe in PATH and
+// fails when bun was installed via `npm i -g bun` (npm/cmd-shim#95).
+
+const cp = require("child_process")
+const fs = require("fs")
+const path = require("path")
+
+const win = process.platform === "win32"
+const exe = win ? "bun.exe" : "bun"
+const here = path.dirname(fs.realpathSync(__filename))
+const entry = [path.join(here, "..", "index.js"), path.join(here, "..", "dist", "index.js")]
+  .find(fs.existsSync) ?? path.join(here, "..", "src", "index.tsx")
+
+function walk(dir, rel) {
+  for (;;) {
+    const p = path.join(dir, "node_modules", ...rel)
+    if (fs.existsSync(p)) return p
+    const up = path.dirname(dir)
+    if (up === dir) return null
+    dir = up
+  }
+}
+
+// BUN_INSTALL (official installer) → node_modules/bun (npm -g bun sibling)
+// → node_modules/.bin (pm-local) → PATH.
+const bun = (() => {
+  if (process.env.HERM_BUN) return process.env.HERM_BUN
+  const inst = process.env.BUN_INSTALL
+  if (inst) {
+    const p = path.join(inst, "bin", exe)
+    if (fs.existsSync(p)) return p
+  }
+  return walk(here, ["bun", "bin", exe])
+    ?? walk(here, [".bin", win ? "bun.cmd" : "bun"])
+    ?? "bun"
+})()
+
+const child = cp.spawn(bun, [entry, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  shell: win && bun.endsWith(".cmd"),
+})
+child.on("error", (e) => {
+  if (e.code === "ENOENT") {
+    console.error("herm: bun runtime not found.")
+    console.error(win
+      ? '  install: powershell -c "irm bun.sh/install.ps1 | iex"'
+      : "  install: curl -fsSL https://bun.sh/install | bash")
+  } else {
+    console.error(e.message)
+  }
+  process.exit(1)
+})
+for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"])
+  process.on(sig, () => { try { child.kill(sig) } catch {} })
+child.on("exit", (code, sig) => {
+  if (sig) return process.kill(process.pid, sig)
+  process.exit(code ?? 0)
+})

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -100,6 +100,11 @@ for (const out of result.outputs.filter(o => o.kind === "entry-point")) {
 }
 chmodSync("dist/index.js", 0o755)
 
+// Node-shebang'd launcher lives beside dist/ so npm's cmd-shim emits a
+// node.exe-invoking .ps1; the launcher then finds bun itself.
+await $`mkdir -p dist/bin && cp bin/herm.cjs dist/bin/`
+chmodSync("dist/bin/herm.cjs", 0o755)
+
 // The published package is dist/ + this manifest. `dependencies` is
 // empty — everything is bundled. Platform libs are optionals (bun/npm
 // install the one that matches, skip the rest).
@@ -119,7 +124,7 @@ await Bun.write("dist/package.json", JSON.stringify({
   bugs: pkg.bugs,
   engines: pkg.engines,
   publishConfig: { access: "public", provenance: true },
-  bin: { herm: "index.js" },
+  bin: { herm: "bin/herm.cjs" },
   optionalDependencies: Object.fromEntries(
     platforms.map(p => [`@opentui/core-${p}`, ov]),
   ),


### PR DESCRIPTION
Fixes #45.

## Problem

Published `bin` was `index.js` with `#!/usr/bin/env bun`. npm `cmd-shim` reads that shebang and generates a `herm.ps1` that tries `$basedir/bun.exe` then `& "bun.exe"`. When bun was installed via `npm i -g bun`, neither resolves: PATH only has `bun.cmd`/`bun.ps1` wrappers, and the real exe lives under `node_modules/bun/bin/`. PowerShell fails with "bun not found"; CMD and git-bash work. See npm/cmd-shim#95, oven-sh/bun#10858.

## Fix

New `bin/herm.cjs` with `#!/usr/bin/env node`, so cmd-shim emits a node.exe-invoking `.ps1` (node is always resolvable since npm runs under it). The shim locates bun itself and spawns the bundle:

1. `$HERM_BUN` override
2. `$BUN_INSTALL/bin/bun{.exe}` (official installer)
3. `node_modules/bun/bin/bun{.exe}` walked upward (`npm i -g bun` sibling)
4. `node_modules/.bin/bun{.cmd}` walked upward (local dep)
5. bare `bun` via PATH

On ENOENT, prints the platform-appropriate install one-liner instead of a bare spawn error.

`scripts/build.ts` copies the shim into `dist/bin/` and points published `bin` at it. Entry probe tries `../index.js` (published) then `../dist/index.js` (repo build) then `../src/index.tsx` (dev checkout).

## Verified

- `bun scripts/build.ts` → `dist/bin/herm.cjs` present, `dist/package.json` `bin.herm = "bin/herm.cjs"`
- `node dist/bin/herm.cjs --version` → `1.0.0-dev.1` (resolves via `BUN_INSTALL`)
- `HERM_BUN=/nope node bin/herm.cjs` → friendly install hint, exit 1
- `bunx tsc --noEmit` clean, `bun test` 867/867

Not verified on native Windows PowerShell (no box); the cmd-shim behavior with a node shebang is well-trodden so risk is low. Would appreciate the reporter confirming.