### PR TITLE
fix(session): keep bare herm launch fresh

### DIFF
--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -108,16 +108,8 @@ export function useSession(): SessionOps {
       }
     }
 
-    // mode:"new" — bare launch is ALWAYS a fresh session (herm-1jd). The
-    // stored id exists only to reuse our own abandoned empty stub instead
-    // of creating another row every launch. It may point at an ended
-    // compression parent (the stub is its continuation), so chase the
-    // chain tip before checking emptiness.
-    const last = preferences.get("lastSessionId")
-    const tip = last ? sdb.chainTip(last) : null
-    if (tip && sdb.byId(tip)?.message_count === 0) {
-      try { return await resume(tip) } catch { /* fall through */ }
-    }
+    // mode:"new" — bare launch is ALWAYS a fresh session (herm-1jd).
+    // Resume is only for explicit -c/--continue/--resume launches.
     return fresh()
   }, [create, resume])
 

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -108,8 +108,15 @@ export function useSession(): SessionOps {
       }
     }
 
-    // mode:"new" — bare launch is ALWAYS a fresh session (herm-1jd).
-    // Resume is only for explicit -c/--continue/--resume launches.
+    // mode:"new" — bare launch is fresh unless we can reuse our own
+    // abandoned root stub. Do not chase compression tips here: a stored
+    // old continuation can point at a 0-msg child and silently keep bare
+    // `herm` attached to old lineage.
+    const last = preferences.get("lastSessionId")
+    const row = last ? sdb.byId(last) : null
+    if (row?.message_count === 0 && row.parent_session_id == null) {
+      try { return await resume(row.id) } catch { /* fall through */ }
+    }
     return fresh()
   }, [create, resume])
 

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -105,13 +105,13 @@ describe("useSession.boot", () => {
   })
   afterAll(wipe)
 
-  test("mode:new creates even when lastSessionId is an empty stub", async () => {
+  test("mode:new reuses standalone empty stub instead of creating", async () => {
     preferences.set("lastSessionId", "stub")
     const gw = new MockGateway()
     const r = await boot(gw, { mode: "new" })
-    expect(gw.calls.some(c => c.method === "session.create")).toBe(true)
-    expect(gw.calls.some(c => c.method === "session.resume")).toBe(false)
-    expect(r.messages).toEqual([])
+    expect(r.id).toBe("stub")
+    expect(gw.calls.some(c => c.method === "session.create")).toBe(false)
+    expect(gw.last("session.resume")?.params.session_id).toBe("stub")
   })
 
   test("mode:new creates instead of resuming empty compression-chain tip", async () => {
@@ -121,6 +121,19 @@ describe("useSession.boot", () => {
     db.close()
     resetDb()
     preferences.set("lastSessionId", "root")
+    const gw = new MockGateway()
+    await boot(gw, { mode: "new" })
+    expect(gw.calls.some(c => c.method === "session.create")).toBe(true)
+    expect(gw.calls.some(c => c.method === "session.resume")).toBe(false)
+  })
+
+  test("mode:new creates instead of reusing stored empty continuation", async () => {
+    const db = seed()
+    sess(db, "root", "tui", 1000, 296, { ended_at: 2000, end_reason: "compression" })
+    sess(db, "tip",  "tui", 2100,   0, { parent_session_id: "root" })
+    db.close()
+    resetDb()
+    preferences.set("lastSessionId", "tip")
     const gw = new MockGateway()
     await boot(gw, { mode: "new" })
     expect(gw.calls.some(c => c.method === "session.create")).toBe(true)

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -105,16 +105,16 @@ describe("useSession.boot", () => {
   })
   afterAll(wipe)
 
-  test("mode:new reuses own empty stub instead of creating", async () => {
+  test("mode:new creates even when lastSessionId is an empty stub", async () => {
     preferences.set("lastSessionId", "stub")
     const gw = new MockGateway()
     const r = await boot(gw, { mode: "new" })
-    expect(r.id).toBe("stub")
-    expect(gw.calls.some(c => c.method === "session.create")).toBe(false)
-    expect(gw.last("session.resume")?.params.session_id).toBe("stub")
+    expect(gw.calls.some(c => c.method === "session.create")).toBe(true)
+    expect(gw.calls.some(c => c.method === "session.resume")).toBe(false)
+    expect(r.messages).toEqual([])
   })
 
-  test("mode:new chases compression chain to reuse empty tip stub", async () => {
+  test("mode:new creates instead of resuming empty compression-chain tip", async () => {
     const db = seed()
     sess(db, "root", "tui", 1000, 296, { ended_at: 2000, end_reason: "compression" })
     sess(db, "tip",  "tui", 2100,   0, { parent_session_id: "root" })
@@ -123,8 +123,8 @@ describe("useSession.boot", () => {
     preferences.set("lastSessionId", "root")
     const gw = new MockGateway()
     await boot(gw, { mode: "new" })
-    expect(gw.calls.some(c => c.method === "session.create")).toBe(false)
-    expect(gw.last("session.resume")?.params.session_id).toBe("tip")
+    expect(gw.calls.some(c => c.method === "session.create")).toBe(true)
+    expect(gw.calls.some(c => c.method === "session.resume")).toBe(false)
   })
 
   test("mode:new creates when lastSessionId is non-empty session", async () => {


### PR DESCRIPTION
## Summary
- make bare `herm` (`mode: "new"`) always create a new session
- keep resume behavior limited to explicit `-c`, `--continue`, and `--resume`
- update launch tests for empty-stub and compression-chain-tip cases

## Why
`herm --help` documents bare `herm` as "start a fresh session", but `boot()` could silently resume `lastSessionId` when its chain tip had `message_count === 0`. If that empty tip was a continuation from an old compression chain, a supposedly fresh TUI launch could stay attached to old session lineage.

## Test plan
- `bun test test/launch.test.tsx`
- `bun run typecheck`
