### PR TITLE
fix(exit): route real SIGINT through quit() so banner always lands

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -104,6 +104,17 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [usage, setUsage] = useState<Usage | undefined>(undefined)
   const [info, setInfo] = useState<SessionInfo | null>(null)
   const [title, setTitle] = useState("")
+  const titleRef = useRef(title); titleRef.current = title
+  // Real SIGINT (terminal multiplexer, focus-stolen widget, kernel-delivered
+  // ctrl+c that bypasses the React keyboard tree) goes through the same
+  // quit() path as /quit so the resume banner always lands. Replaces the
+  // bare-exit handler installed by terminal-reset.installExitResetHooks();
+  // quit() ends in process.exit(0), which still fires the `exit` hook that
+  // emits the mode-reset blob. Mount-once: gw/renderer identity is stable.
+  useEffect(() => {
+    process.removeAllListeners("SIGINT")
+    process.on("SIGINT", () => quit(renderer, sidRef.current, titleRef.current, gw))
+  }, [renderer, gw])
   const [focusRegion, setFocusRegion] = useState<"input" | "content">("input")
   const goToTab = useCallback((t: number) => {
     setTab(t)

--- a/src/app/exit.ts
+++ b/src/app/exit.ts
@@ -30,9 +30,11 @@ export function quit(
   // setupGracefulExit cleanup.
   try { gw?.kill() } catch {}
   renderer.destroy()
-  if (process.stdout.isTTY && sid) {
-    const t = title ? `  —  ${title.slice(0, 60)}` : ""
-    writeSync(1, `\n  continue  herm --resume ${sid}${t}\n\n`)
+  if (process.stdout.isTTY) {
+    const banner = sid
+      ? `\n  continue  herm --resume ${sid}${title ? `  —  ${title.slice(0, 60)}` : ""}\n\n`
+      : `\n  bye\n\n`
+    writeSync(1, banner)
   }
   process.exit(0)
 }


### PR DESCRIPTION
## Problem

Three exit paths exist in herm and only two run `quit()`:

| Path | Calls `quit()` | Banner |
|------|------|------|
| `/quit` slash | yes | ✅ |
| ctrl+c ×2 in-tree (`useAppKeys`) | yes | ✅ |
| **real SIGINT** (`terminal-reset.ts` handler) | no | ❌ |

A real SIGINT hits when:
- A terminal multiplexer / ssh mux synthesizes `^C` as a kernel signal
- A focus-stolen widget (dialog, scrollbox, child pty cell) eats the key before the React keyboard tree sees it
- A screen recorder or pty wrapper interposes on input

In all three cases the user got a bare 130 exit with no resume banner. `/quit` advertises a copy-paste resume command and SIGINT silently does not.

## Fix

After mount, replace the SIGINT handler installed by `terminal-reset.installExitResetHooks()` with one that calls `quit(renderer, sid, title, gw)` — same code path `/quit` uses.

Safety:
- `quit()`'s `done` latch (`exit.ts:16,24`) prevents re-entry on a double-tap or signal racing the keyboard handler.
- `quit()` ends in `process.exit(0)` which still fires the `exit` hook in `terminal-reset.ts:98` → mode-reset blob still flushes.
- OpenTUI's own SIGINT handler (per the comment at `terminal-reset.ts:101-104`) only does `destroy()`, which `quit()` already calls.

Also: when `sid` is unset (SIGINT before session creation), emit a generic `bye` banner instead of silently exiting.

## Files

- `src/app.tsx` — add `titleRef` (mirroring existing `sidRef`) + mount-once effect that overrides SIGINT
- `src/app/exit.ts` — fall back to `bye` banner when `sid` empty

## Verification

- `bunx tsc --noEmit` clean
- `bun test src/utils/terminal-reset.test.ts` passes (the standalone SIGINT-exits-130 assertion still holds at the `terminal-reset` module boundary; the app overrides it post-mount, so the unit-level contract is unchanged)
- Manual: ctrl+c ×2 inside a tmux pane that intercepts the chord now prints the `continue herm --resume <sid>` banner