### PR TITLE
triage sweep: control /tab, video_generate preview, GoalState.subgoals, thoughtcloud border

### DIFF
--- a/src/app/control.ts
+++ b/src/app/control.ts
@@ -249,7 +249,9 @@ async function handle(req: Request): Promise<Response> {
     })
   }
 
-  // GET /tab/:n — switch tab by injecting Ctrl+Right/Left key events
+  // GET /tab/:n — switch tab via the real key path (tab.next/prev is
+  // alt+arrow → meta:true per chord.ts). Falls back to setTab() when
+  // the renderer isn't ready yet.
   const tabMatch = path.match(/^\/tab\/(\d+)$/)
   if (tabMatch) {
     const n = Number(tabMatch[1])
@@ -257,18 +259,11 @@ async function handle(req: Request): Promise<Response> {
 
     const renderer = bridge.renderer()
     if (renderer) {
-      // Inject Ctrl+Left/Right keys to navigate to target tab
       const cur = bridge.tab()
       const diff = n - cur
-      if (diff !== 0) {
-        const keyName = diff > 0 ? "right" : "left"
-        const steps = Math.abs(diff)
-        for (let i = 0; i < steps; i++) {
-          injectKey(renderer, makeKey({ name: keyName, ctrl: true }))
-        }
-      }
+      const key = makeKey({ name: diff > 0 ? "right" : "left", meta: true })
+      for (let i = Math.abs(diff); i > 0; i--) injectKey(renderer, key)
     } else {
-      // Fallback to direct setState (may not work reliably)
       bridge.setTab(n)
     }
     pendingTab = n

--- a/src/components/chat/ThoughtCloud.tsx
+++ b/src/components/chat/ThoughtCloud.tsx
@@ -14,12 +14,11 @@ import { useTheme } from "../../theme"
 export const CLOUD_MIN = 12
 const CLOUD_MAX = 24
 
-// Heavy triple-dash — reads as thick + noncontinuous. Corners stay
-// heavy-solid so the box parses as a bubble, not a grid.
+// Light triple-dash with rounded corners — reads as a bubble, not a grid.
 const CLOUD: BorderCharacters = {
-  topLeft: "┏", topRight: "┓", bottomLeft: "┗", bottomRight: "┛",
-  horizontal: "┅", vertical: "┇",
-  topT: "┅", bottomT: "┅", leftT: "┇", rightT: "┇", cross: "╋",
+  topLeft: "╭", topRight: "╮", bottomLeft: "╰", bottomRight: "╯",
+  horizontal: "┄", vertical: "┆",
+  topT: "┄", bottomT: "┄", leftT: "┆", rightT: "┆", cross: "┼",
 }
 
 // Stepped bubbles bridging the cloud to the avatar's upper-left. Three
@@ -27,9 +26,9 @@ const CLOUD: BorderCharacters = {
 // frame and travels bottom→top (away from the head, into the cloud);
 // the trailing empty frame reads as the bubble entering the cloud.
 const SLOTS = [
-  ["┏┅┅┓   ", "┗┅┅┛   "],
-  ["   ┏┓  ", "   ┗┛  "],
-  ["     ╸ ", "       "],
+  ["╭┄┄╮   ", "╰┄┄╯   "],
+  ["   ╭╮  ", "   ╰╯  "],
+  ["     ╶ ", "       "],
 ]
 const BLANK = "       "
 const ORDER = [2, 1, 0, -1]
@@ -147,7 +146,7 @@ export const ThoughtCloud = memo((props: {
 
   return (
     <box
-      height={props.height} flexDirection="column" position="relative"
+      height={props.height} flexDirection="column" position="relative" marginLeft={1}
       border borderColor={theme.hermAvatar} customBorderChars={CLOUD}
       backgroundColor={theme.backgroundPanel} paddingX={1}
     >

--- a/src/components/chat/tool/preview.ts
+++ b/src/components/chat/tool/preview.ts
@@ -45,6 +45,7 @@ const SPEC: Record<string, Spec> = {
   cronjob:          { icon: "◷", verb: "Cron",     pending: "Managing cron…" },
   text_to_speech:   { icon: "♪", verb: "TTS",      pending: "Synthesizing…" },
   image_generate:   { icon: "✦", verb: "Image",    pending: "Generating image…" },
+  video_generate:   { icon: "✦", verb: "Video",    pending: "Generating video…" },
 }
 
 const GENERIC: Spec = { icon: "⚙", verb: "", pending: "Running…" }

--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -414,6 +414,7 @@ export type GoalState = {
   turn_count?: number
   max_turns?: number | null
   checklist?: ChecklistItem[]
+  subgoals?: string[]
   decomposed?: boolean
 }
 
@@ -441,12 +442,16 @@ export function goalState(sid: string): GoalState | null {
     const j = JSON.parse(row.value) as Record<string, unknown>
     const rawList = Array.isArray(j.checklist) ? j.checklist : []
     const checklist = rawList.map(parseItem).filter((x): x is ChecklistItem => x !== null)
+    const subgoals = (Array.isArray(j.subgoals) ? j.subgoals : [])
+      .map(s => typeof s === "string" ? s.trim() : "")
+      .filter((s): s is string => s.length > 0)
     return {
       goal: String(j.goal ?? ""),
       status: (j.status as GoalState["status"]) ?? "active",
       turn_count: typeof j.turn_count === "number" ? j.turn_count : undefined,
       max_turns: (j.max_turns as number | null | undefined) ?? null,
       checklist: checklist.length > 0 ? checklist : undefined,
+      subgoals: subgoals.length > 0 ? subgoals : undefined,
       decomposed: j.decomposed === true ? true : undefined,
     }
   } catch { return null }

--- a/test/fixtures/state-db.ts
+++ b/test/fixtures/state-db.ts
@@ -56,5 +56,8 @@ export const openStateDb = (): Database => {
     AFTER DELETE ON messages BEGIN
       DELETE FROM messages_fts WHERE rowid = old.id;
     END`)
+  db.run(`CREATE TABLE IF NOT EXISTS state_meta (
+    key TEXT PRIMARY KEY, value TEXT NOT NULL
+  )`)
   return db
 }

--- a/test/goal-state.test.ts
+++ b/test/goal-state.test.ts
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { openStateDb } from "./fixtures/state-db"
+import { goalState, resetDb } from "../src/service/sessions-db"
+
+describe("sessions-db/goalState", () => {
+  beforeAll(() => {
+    const db = openStateDb()
+    const put = (sid: string, j: unknown) =>
+      db.run("INSERT OR REPLACE INTO state_meta (key, value) VALUES (?, ?)",
+        [`goal:${sid}`, JSON.stringify(j)])
+    put("g-none", { goal: "ship it", status: "active", turn_count: 2 })
+    put("g-subs", {
+      goal: "ship it", status: "active",
+      subgoals: ["  add tests  ", "", 42, null, "update docs"],
+    })
+    put("g-empty", { goal: "x", status: "paused", subgoals: [] })
+    db.run("INSERT OR REPLACE INTO state_meta (key, value) VALUES (?, ?)",
+      ["goal:g-bad", "{not json"])
+    db.close()
+    resetDb()
+  })
+
+  test("absent subgoals field → undefined (back-compat)", () => {
+    const g = goalState("g-none")
+    expect(g?.goal).toBe("ship it")
+    expect(g?.turn_count).toBe(2)
+    expect(g?.subgoals).toBeUndefined()
+  })
+
+  test("subgoals: trims, drops non-string and empty", () => {
+    const g = goalState("g-subs")
+    expect(g?.subgoals).toEqual(["add tests", "update docs"])
+  })
+
+  test("empty subgoals array → undefined", () => {
+    expect(goalState("g-empty")?.subgoals).toBeUndefined()
+  })
+
+  test("malformed JSON → null", () => {
+    expect(goalState("g-bad")).toBeNull()
+  })
+
+  test("missing row → null", () => {
+    expect(goalState("nope")).toBeNull()
+  })
+})

--- a/test/thoughtcloud.test.tsx
+++ b/test/thoughtcloud.test.tsx
@@ -20,20 +20,20 @@ describe("ThoughtCloud/Tail (ref-mutation animation)", () => {
     }
     const t = await mountNode(<Fix />, { width: 20, height: 10 })
     await t.settle()
-    expect(t.frame()).toContain("┏┅┅┓")
-    expect(t.frame()).toContain("╸")
+    expect(t.frame()).toContain("╭┄┄╮")
+    expect(t.frame()).toContain("╶")
 
     act(() => setRun(true))
     await t.settle()
     await act(async () => { await Bun.sleep(400) })
     await t.settle()
-    const lit = t.frame().split("\n").filter(l => /[┏┓┗┛╸]/.test(l)).length
+    const lit = t.frame().split("\n").filter(l => /[╭╮╰╯╶]/.test(l)).length
     expect(lit).toBeLessThan(6)
 
     act(() => setRun(false))
     await t.settle()
-    expect(t.frame()).toContain("┏┅┅┓")
-    expect(t.frame()).toContain("╸")
+    expect(t.frame()).toContain("╭┄┄╮")
+    expect(t.frame()).toContain("╶")
     t.destroy()
   })
 })


### PR DESCRIPTION
Four small triage items batched.

- **fix(control):** `/tab/:n` injects `meta:true` (alt+arrow) to match `tab.next`/`tab.prev` binding in `keys/catalog.ts`. Was injecting `ctrl:true`, dead path since the binding moved.
- **feat(chat):** `video_generate` entry in tool preview spec, mirrors `image_generate`.
- **feat(goal):** `GoalState.subgoals?: string[]` + defensive parse in `goalState()`. Data-layer only; no sidebar goal surface exists yet. Adds `state_meta` to test fixture + 5 tests.
- **style(thoughtcloud):** rounded corners `╭╮╰╯` + light triple-dash `┄┆`, `marginLeft={1}`. Tail bubbles reglyphed to match.

`bunx tsc --noEmit` clean, `bun test` 873 pass.