### PR TITLE
fix(eikon): studio panes clip + scroll instead of bleeding past slot

### DIFF
--- a/src/tabs/Automation.tsx
+++ b/src/tabs/Automation.tsx
@@ -45,4 +45,4 @@ export const Automation = memo((props: Props) => {
 })
 
 const Pane = ({ visible, children }: { visible: boolean; children: ReactNode }) =>
-  visible ? <box flexGrow={1} minWidth={0} flexDirection="column">{children}</box> : null
+  visible ? <box flexGrow={1} minWidth={0} minHeight={0} flexDirection="column">{children}</box> : null

--- a/src/tabs/ConfigGroup.tsx
+++ b/src/tabs/ConfigGroup.tsx
@@ -49,4 +49,4 @@ export const ConfigGroup = memo((props: Props) => {
 })
 
 const Pane = ({ visible, children }: { visible: boolean; children: ReactNode }) =>
-  visible ? <box flexGrow={1} minWidth={0} flexDirection="column">{children}</box> : null
+  visible ? <box flexGrow={1} minWidth={0} minHeight={0} flexDirection="column">{children}</box> : null

--- a/src/tabs/EikonGroup.tsx
+++ b/src/tabs/EikonGroup.tsx
@@ -22,9 +22,9 @@ export const EikonGroup = memo((props: Props) => {
   const edit = useCallback((name: string) => { setTarget(name); props.setSub(0) }, [props])
   const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
   return (
-    <box flexDirection="column" flexGrow={1} minWidth={0}>
+    <box flexDirection="column" flexGrow={1} minWidth={0} minHeight={0}>
       <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />
-      <box flexGrow={1} minWidth={0} flexDirection="column">
+      <box flexGrow={1} minWidth={0} minHeight={0} flexDirection="column">
         <Pane visible={props.sub === 0}>
           <EikonStudio focused={!!props.focused && props.sub === 0} name={target} />
         </Pane>
@@ -37,4 +37,4 @@ export const EikonGroup = memo((props: Props) => {
 })
 
 const Pane = ({ visible, children }: { visible: boolean; children: ReactNode }) =>
-  visible ? <box flexGrow={1} minWidth={0} flexDirection="column">{children}</box> : null
+  visible ? <box flexGrow={1} minWidth={0} minHeight={0} flexDirection="column">{children}</box> : null

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -13,7 +13,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import { extend, useKeyboard, useTerminalDimensions } from "@opentui/react"
 import { SliderRenderable } from "@opentui/core"
-import type { ParsedKey } from "@opentui/core"
+import type { ParsedKey, ScrollBoxRenderable } from "@opentui/core"
 import { readFileSync } from "node:fs"
 import { basename } from "node:path"
 import { useTheme } from "../theme"
@@ -43,6 +43,8 @@ declare module "@opentui/react" {
 
 type Pane = "knobs" | "preview" | "strip"
 const PANES: readonly Pane[] = ["knobs", "preview", "strip"]
+// Stable contentOptions — inline `{}` would re-set on every reconcile.
+const COL = { flexDirection: "column" } as const
 
 type RowKind = "select" | "prompt" | "action" | "divider" | "knob"
 type Row = {
@@ -332,6 +334,8 @@ export const EikonStudio = memo((props: {
   const toast = useToast()
   const dims = useTerminalDimensions()
   const wide = dims.width >= 120
+  const ksb = useRef<ScrollBoxRenderable | null>(null)
+  const outer = useRef<ScrollBoxRenderable | null>(null)
 
   useSyncExternalStore(eikon.onRegistry, () => eikon.rasterizers().length)
 
@@ -417,6 +421,12 @@ export const EikonStudio = memo((props: {
 
   const rows = useMemo(() => (s ? buildRows(r, s, live, url) : []), [r, s, live, url])
   const navRows = useMemo(() => rows.map((x, i) => ({ ...x, i })).filter(x => x.kind !== "divider"), [rows])
+  // Knobs pane: ↑↓ keeps the selected row in view. Rows already carry
+  // `id="knob-<row.id>"` (reconciler-id rule) — resolve via that.
+  const kScroll = (ni: number) => {
+    const row = navRows[ni]
+    if (row) ksb.current?.scrollChildIntoView(`knob-${row.id}`)
+  }
 
   // Render the current state's full clip. Sourceless falls through
   // to the baked .eikon's frames for the current state — Studio's
@@ -631,7 +641,10 @@ export const EikonStudio = memo((props: {
     if (key.name === "escape") return void discard()
     if (key.name === "tab") {
       const i = PANES.indexOf(pane)
-      return setPane(PANES[(i + (key.shift ? PANES.length - 1 : 1)) % PANES.length]!)
+      const next = PANES[(i + (key.shift ? PANES.length - 1 : 1)) % PANES.length]!
+      setPane(next)
+      outer.current?.scrollChildIntoView(`studio-${next}`)
+      return
     }
     if (!s) {
       if (key.name === "return") return void doPrompt("source")
@@ -639,7 +652,8 @@ export const EikonStudio = memo((props: {
     }
     if (pane === "knobs") {
       if (handleListKey(keys, key, {
-        count: navRows.length, setSel,
+        count: navRows.length, setSel, scrollTo: kScroll,
+        page: Math.max(1, (ksb.current?.viewport.height ?? 10) - 1),
         onActivate: activate,
         onToggle: toggle,
         onNew: () => void doPrompt("source"),
@@ -740,20 +754,22 @@ export const EikonStudio = memo((props: {
         ? <box flexGrow={1} alignItems="center" justifyContent="center">
             <text fg={theme.textMuted}>No eikon open. Enter to create one.</text>
           </box>
-        : rows.map((row, i) => {
-            const ni = navRows.findIndex(x => x.i === i)
-            const on = pane === "knobs" && ni === sel
-            const dim = row.kind === "knob" && !src
-            return (
-              <KnobRow key={`${r.name}:${row.id}`} id={`knob-${row.id}`} row={row} s={s} r={r} src={src}
-                       on={on} dim={dim} peek={peek} busy={row.id === "fetch" && fetching}
-                       onHover={() => { if (ni >= 0) { setPane("knobs"); setSel(ni) } }}
-                       onClick={() => { if (ni >= 0) { setSel(ni); setPane("knobs"); act(row, "click") } }}
-                       onSlide={row.knob?.kind === "slider"
-                         ? v => mutate(p => knobs.edit(p, k => knobs.setSlider(k, row.id, row.knob!, v)))
-                         : undefined} />
-            )
-          })}
+        : <scrollbox ref={ksb} scrollY flexGrow={1} contentOptions={COL}>
+            {rows.map((row, i) => {
+              const ni = navRows.findIndex(x => x.i === i)
+              const on = pane === "knobs" && ni === sel
+              const dim = row.kind === "knob" && !src
+              return (
+                <KnobRow key={`${r.name}:${row.id}`} id={`knob-${row.id}`} row={row} s={s} r={r} src={src}
+                         on={on} dim={dim} peek={peek} busy={row.id === "fetch" && fetching}
+                         onHover={() => { if (ni >= 0) { setPane("knobs"); setSel(ni) } }}
+                         onClick={() => { if (ni >= 0) { setSel(ni); setPane("knobs"); act(row, "click") } }}
+                         onSlide={row.knob?.kind === "slider"
+                           ? v => mutate(p => knobs.edit(p, k => knobs.setSlider(k, row.id, row.knob!, v)))
+                           : undefined} />
+              )
+            })}
+          </scrollbox>}
     </TabShell>
   )
 
@@ -762,7 +778,7 @@ export const EikonStudio = memo((props: {
   // would collapse it in a column, so pin the wrapper height.
   const STRIP_H = 17
   const strip = s ? (
-    <box flexShrink={0} height={STRIP_H}>
+    <box id="studio-strip" flexShrink={0} height={STRIP_H}>
       <TabShell title="States" focus={pane === "strip"}>
         <Strip s={s} frames={thumbs} focused={pane === "strip"}
                onPick={st => { setPane("strip"); mutate(p => knobs.setState(p, st)) }} />
@@ -770,24 +786,28 @@ export const EikonStudio = memo((props: {
     </box>
   ) : null
 
+  // Full stack is ~PREVIEW_H + STRIP_H rows — taller than most
+  // terminals — so it always sits inside a scrollbox. `wide` only
+  // decides whether preview+knobs are row-adjacent or stacked. Tab
+  // scrolls the focused pane into view; knobs has its own inner
+  // scrollbox so ↑↓ follows without moving the outer viewport.
+  const top = wide ? (
+    <box flexDirection="row" flexShrink={0} height={PREVIEW_H}>
+      <box id="studio-preview" flexShrink={0} width={PREVIEW_W}>{preview}</box>
+      <box id="studio-knobs" flexGrow={1} flexBasis={0} minWidth={0}>{panel}</box>
+    </box>
+  ) : (
+    <>
+      <box id="studio-preview" flexShrink={0} height={PREVIEW_H}>{preview}</box>
+      <box id="studio-knobs" flexShrink={0} height={Math.max(rows.length, 1) + 6}>{panel}</box>
+    </>
+  )
   return (
-    <box flexDirection="column" flexGrow={1} minWidth={0}>
-      {wide ? (
-        <>
-          <box flexDirection="row" flexShrink={0} height={PREVIEW_H}>
-            <box flexShrink={0} width={PREVIEW_W}>{preview}</box>
-            <box flexGrow={1} flexBasis={0} minWidth={0}>{panel}</box>
-          </box>
-          {strip}
-          <box flexGrow={1} />
-        </>
-      ) : (
-        <scrollbox scrollY flexGrow={1} contentOptions={{ flexDirection: "column" }}>
-          <box flexShrink={0} height={PREVIEW_H}>{preview}</box>
-          <box flexShrink={0} height={rows.length + 6}>{panel}</box>
-          {strip}
-        </scrollbox>
-      )}
+    <box flexDirection="column" flexGrow={1} minWidth={0} minHeight={0}>
+      <scrollbox ref={outer} scrollY flexGrow={1} contentOptions={COL}>
+        {top}
+        {strip}
+      </scrollbox>
       <HintBar pairs={hint} suffix={s?.dirty ? "● unsaved" : undefined} />
     </box>
   )

--- a/src/tabs/SessionsGroup.tsx
+++ b/src/tabs/SessionsGroup.tsx
@@ -58,4 +58,4 @@ export const SessionsGroup = memo((props: Props) => {
 })
 
 const Pane = ({ visible, children }: { visible: boolean; children: ReactNode }) =>
-  visible ? <box flexGrow={1} minWidth={0} flexDirection="column">{children}</box> : null
+  visible ? <box flexGrow={1} minWidth={0} minHeight={0} flexDirection="column">{children}</box> : null

--- a/src/ui/shell.tsx
+++ b/src/ui/shell.tsx
@@ -15,6 +15,9 @@ import { useTheme } from "../theme"
 // hosts multiple panels and wants to show which has keyboard focus.
 // `grow` lets side-by-side panels set their flex ratio directly;
 // flexBasis=0 makes the ratio authoritative regardless of content.
+// minHeight=0 on both wrapper and body defeats Yoga's
+// `min-height: auto` so a panel never inflates past the slot its
+// parent assigned — body clips at the border instead of bleeding.
 
 export const TabShell = (props: {
   title: string
@@ -25,7 +28,7 @@ export const TabShell = (props: {
 }) => {
   const theme = useTheme().theme
   return (
-    <box flexDirection="column" flexGrow={props.grow ?? 1} flexBasis={0} minWidth={0}
+    <box flexDirection="column" flexGrow={props.grow ?? 1} flexBasis={0} minWidth={0} minHeight={0}
          border borderColor={props.focus ? theme.primary : theme.border}
          backgroundColor={theme.backgroundPanel} padding={1}>
       <box height={1} overflow="hidden">
@@ -35,7 +38,7 @@ export const TabShell = (props: {
         ? <box height={1}><text fg={theme.error}>{`⚠ ${props.error}`}</text></box>
         : null}
       <box height={1} />
-      <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <box flexDirection="column" flexGrow={1} minWidth={0} minHeight={0} overflow="hidden">
         {props.children}
       </box>
     </box>

--- a/test/eikon-layout.test.tsx
+++ b/test/eikon-layout.test.tsx
@@ -133,3 +133,68 @@ run("layout probe (narrow)", async () => {
   expect(f).toContain("rasterizer")
   un()
 })
+
+run("wide: clips to slot at short height; Tab scrolls strip into view", async () => {
+  const un = eikon.register(stub); seed("short")
+  const prefs = await import("../src/context/preferences")
+  prefs.set("eikon", "short")
+  await using t = await mountNode(<EikonGroup focused sub={0} setSub={() => {}} />, { width: 180, height: 30 })
+  await until(t, () => t.frame().includes("#·········#"))
+  const lines = () => t.frame().split("\n")
+  const hint = () => lines().findIndex(l => l.includes("[Tab] pane"))
+  // Hint bar is the last non-blank line; nothing studio-owned renders below it.
+  const h = hint()
+  expect(h).toBeGreaterThan(0)
+  expect(h).toBe(lines().findLastIndex(l => l.trim() !== ""))
+  // Strip doesn't fit at 30 rows — scrolled off, not painted.
+  expect(t.frame()).not.toContain("States")
+  // Knobs panel height matches Preview, so top rows are visible.
+  expect(t.frame()).toContain("rasterizer")
+  // Tab→Tab focuses strip → outer scrollbox brings it into view.
+  act(() => t.keys.pressTab()); await t.settle()
+  act(() => t.keys.pressTab()); await t.settle()
+  await until(t, () => t.frame().includes("States"))
+  // Hint bar stays pinned and last.
+  expect(hint()).toBe(lines().findLastIndex(l => l.trim() !== ""))
+  if (process.env.DUMP) console.log(t.frame())
+  un()
+})
+
+// Tall rasterizer (more knobs than fit in the preview-height panel):
+// knobs scrollbox clips inside its TabShell; ↑↓ scrolls selection
+// into view without moving the outer viewport (preview stays put).
+const tall: Rasterizer = {
+  name: "tall", available: () => true,
+  knobs: Object.fromEntries(Array.from({ length: 40 }, (_, i) =>
+    [`k${i}`, { kind: "slider", min: 0, max: 1, step: 0.1, default: 0.5 }])),
+  render: stub.render,
+}
+
+run("wide: knobs overflow scrolls inside its panel", async () => {
+  const un = eikon.register(tall); seed("tall")
+  eikon.writeStudio("tall", { rasterizer: "tall", spatial: { zoom: 1, ox: 0.5, oy: 0.5 },
+    fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+  const prefs = await import("../src/context/preferences")
+  prefs.set("eikon", "tall")
+  await using t = await mountNode(<EikonGroup focused sub={0} setSub={() => {}} />, { width: 180, height: 60 })
+  await until(t, () => t.frame().includes("rasterizer") && t.frame().includes("#·········#"))
+  const lines = () => t.frame().split("\n")
+  const iStrip = () => lines().findIndex(l => l.includes("States"))
+  // k39 doesn't fit in a PREVIEW_H panel; k0 does.
+  expect(t.frame()).toContain("k0")
+  expect(t.frame()).not.toContain("k39")
+  // Nothing between the knobs panel bottom and the States border —
+  // the panel clipped inside its own TabShell, not spilling over it.
+  const iPrev = lines().findIndex(l => l.includes("Preview"))
+  expect(iStrip() - iPrev).toBeLessThanOrEqual(38)
+  // End jumps to k39; scrollTo brings it into view, Preview stays.
+  act(() => t.keys.pressKey("END")); await t.settle()
+  await until(t, () => t.frame().includes("k39"))
+  expect(t.frame()).toContain("Preview")
+  expect(t.frame()).not.toContain("k0")
+  // Still nothing below hint bar.
+  const h = lines().findIndex(l => l.includes("[Tab] pane"))
+  expect(lines().slice(h + 1).every(l => l.trim() === "")).toBe(true)
+  if (process.env.DUMP) console.log(t.frame())
+  un()
+})


### PR DESCRIPTION
Studio's three panes were painting past the tab slot and over the composer on short terminals.

**Cause**: Yoga `min-height: auto` on the TabShell body and group `Pane` wrappers. No `minHeight=0` in the flex-column chain meant every ancestor sized to content; nothing clipped.

**Fix**:
- `TabShell`: `minHeight=0` on wrapper+body, `overflow=hidden` on body. All tabs now clip at their panel border.
- Group `Pane` wrappers (`Eikon/Automation/Sessions/Config`): `minHeight=0`.
- `EikonStudio`: whole stack sits in a scrollbox in both wide and narrow (full height ~55 rows). `wide` only toggles preview+knobs row-vs-stacked. Tab scrolls the focused pane into view. Knobs list has its own inner scrollbox with `scrollTo` wired into `handleListKey` so arrow/End keep the selected row visible without moving the outer viewport.

**Tests**: short-height containment (hint bar is last non-blank row, States scrolls in on Tab×2); 40-knob rasterizer inner-scroll (End brings k39 into view, Preview unchanged). 926 pass, tsc clean.