### PR TITLE
fix(plugins): demo files/clock ship disabled by default

### DIFF
--- a/src/plugins/bundled/clock.tsx
+++ b/src/plugins/bundled/clock.tsx
@@ -17,6 +17,7 @@ function Clock(props: { api: HermPluginApi }) {
 
 const plugin: HermPlugin = {
   id: "demo.clock",
+  enabled: false,
   tui(api) {
     api.slots.register({
       order: 100,

--- a/src/plugins/bundled/files.tsx
+++ b/src/plugins/bundled/files.tsx
@@ -110,6 +110,7 @@ function Files(props: { api: HermPluginApi }) {
 
 const plugin: HermPlugin = {
   id: "demo.files",
+  enabled: false,
   tui(api) {
     api.route.register([{
       name: "Files",


### PR DESCRIPTION
Both bundled plugins are tutorial/docs material — there's no reason they should put a Files route in the nav and a clock in the app footer on first launch.

The runtime already honours `enabled: false` ([runtime.tsx:199](https://github.com/liftaris/herm/blob/dev/src/plugins/runtime.tsx#L199): `on[p.id] ?? p.enabled ?? true`); the demos just needed to set it. Users who want them can flip them on from the Plugins tab and the choice persists in `~/.hermes/herm/tui.json` under `plugin.enabled`.

No test changes needed — nothing depended on these being auto-active. 926 pass, tsc clean.