### PR TITLE
feat(eikon): studio UX pass — picker, source menu, gen, save/discard, polish

### DIFF
--- a/src/dialogs/confirm.tsx
+++ b/src/dialogs/confirm.tsx
@@ -1,5 +1,9 @@
 // Generic y/n confirm dialog. `openConfirm(dialog, {...})` resolves to
 // true on [y], false on [n]/Esc.
+//
+// `openSaveDiscard(dialog, {...})` is the three-way variant for dirty-
+// editor exits: resolves to "save" on [s], "discard" on [d], null on Esc.
+// Enter triggers the highlighted choice (default: "save").
 
 import { useKeyboard } from "@opentui/react"
 import { useKeys } from "../keys"
@@ -51,6 +55,52 @@ export function openConfirm(
     dialog.replace(
       <Confirm {...opts} onConfirm={() => done(true)} onCancel={() => done(false)} />,
       () => resolve(false),
+    )
+  })
+}
+
+type Choice = "save" | "discard"
+
+type SDProps = {
+  title: string
+  body: string
+  onPick: (v: Choice) => void
+  onCancel: () => void
+}
+
+const SaveDiscard = (props: SDProps) => {
+  const theme = useTheme().theme
+  useKeyboard((key) => {
+    if (key.name === "s") return props.onPick("save")
+    if (key.name === "d") return props.onPick("discard")
+    if (key.name === "return") return props.onPick("save")
+  })
+  return (
+    <box flexDirection="column" width={54}>
+      <box height={1}>
+        <text fg={theme.warning}><strong>{props.title}</strong></text>
+      </box>
+      <box height={1} />
+      <box minHeight={1}><text wrapMode="word">{props.body}</text></box>
+      <box height={1} />
+      <box height={1}>
+        <text fg={theme.textMuted}>
+          {"[S/Enter] save   [D] discard   [Esc] keep editing"}
+        </text>
+      </box>
+    </box>
+  )
+}
+
+export function openSaveDiscard(
+  dialog: DialogContext,
+  opts: { title: string; body: string },
+): Promise<Choice | null> {
+  return new Promise((resolve) => {
+    const done = (v: Choice | null) => { resolve(v); dialog.clear() }
+    dialog.replace(
+      <SaveDiscard {...opts} onPick={done} onCancel={() => done(null)} />,
+      () => resolve(null),
     )
   })
 }

--- a/src/dialogs/eikon-generate.tsx
+++ b/src/dialogs/eikon-generate.tsx
@@ -7,7 +7,7 @@
 // installed hermes-agent venv's python and calls the image/video
 // tool functions directly — no gateway RPC round-trip.
 
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import type { TextareaRenderable } from "@opentui/core"
 import { useTheme } from "../theme"
@@ -35,15 +35,29 @@ type Props = Opts & {
 
 type Field = "prompt" | "seed" | "seconds" | "submit"
 
+// Style hints that make a generated image rasterize well as a mono
+// text avatar. Pre-filled on a blank first-open so new users start
+// from something usable; leading newline leaves line 1 for their
+// own subject description with the cursor parked there.
+const BASE_PROMPT = {
+  image: "\nhigh contrast, light subject on solid black background, centered, strong rim lighting, monochrome",
+  video: "\nhigh contrast, light subject on solid black background, centered, seamless loop, monochrome",
+} as const
+
 const Generate = (props: Props) => {
   const theme = useTheme().theme
   const ta = useRef<TextareaRenderable | null>(null)
-  const [prompt, setPrompt] = useState(props.lastPrompt ?? "")
+  const [prompt, setPrompt] = useState(props.lastPrompt ?? BASE_PROMPT[props.kind])
   const [useSeed, setUseSeed] = useState(!!props.seed)
   const [secs, setSecs] = useState(2)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const [field, setField] = useState<Field>("prompt")
+
+  // Park the caret at (0,0) so the user types their subject on the
+  // blank first line above the pre-filled style hints. initialValue
+  // lands the cursor at end-of-buffer by default.
+  useEffect(() => { ta.current?.setCursor(0, 0) }, [])
 
   const fields: readonly Field[] = props.kind === "video"
     ? (props.seed ? ["prompt", "seed", "seconds", "submit"] : ["prompt", "seconds", "submit"])
@@ -51,7 +65,13 @@ const Generate = (props: Props) => {
 
   const submit = () => {
     const p = prompt.trim()
-    if (!p || busy) return
+    // Blank line 1 with only the pre-filled style hints below = no
+    // subject described yet. Don't submit.
+    const bare = !props.lastPrompt && p === BASE_PROMPT[props.kind].trim()
+    if (!p || bare || busy) {
+      if (bare) setErr("describe the subject on line 1")
+      return
+    }
     setBusy(true); setErr(null)
     void props.run(props.kind, p, {
       seed: props.seed && useSeed ? props.seed : undefined,

--- a/src/dialogs/eikon-generate.tsx
+++ b/src/dialogs/eikon-generate.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useRef, useState } from "react"
 import { useKeyboard } from "@opentui/react"
-import type { TextareaRenderable } from "@opentui/core"
+import type { TextareaRenderable, KeyBinding } from "@opentui/core"
 import { useTheme } from "../theme"
 import { Spinner } from "../ui/spinner"
 import type { DialogContext } from "../ui/dialog"
@@ -39,15 +39,21 @@ type Field = "prompt" | "seed" | "seconds" | "submit"
 // text avatar. Pre-filled on a blank first-open so new users start
 // from something usable; leading newline leaves line 1 for their
 // own subject description with the cursor parked there.
-const BASE_PROMPT = {
-  image: "\nhigh contrast, light subject on solid black background, centered, strong rim lighting, monochrome",
-  video: "\nhigh contrast, light subject on solid black background, centered, seamless loop, monochrome",
-} as const
+const BASE = "\nhigh contrast, light subject on dark, black background"
+
+// Bare Enter in the prompt textarea confirms the field and advances
+// focus (like a single-line input); Shift+Enter inserts a newline.
+// mergeKeyBindings keys on (name, ctrl, shift, meta, super), so
+// `return` overrides the default `return → newline` entry exactly.
+const BINDS: KeyBinding[] = [
+  { name: "return",              action: "submit"  },
+  { name: "return", shift: true, action: "newline" },
+]
 
 const Generate = (props: Props) => {
   const theme = useTheme().theme
   const ta = useRef<TextareaRenderable | null>(null)
-  const [prompt, setPrompt] = useState(props.lastPrompt ?? BASE_PROMPT[props.kind])
+  const [prompt, setPrompt] = useState(props.lastPrompt ?? BASE)
   const [useSeed, setUseSeed] = useState(!!props.seed)
   const [secs, setSecs] = useState(2)
   const [busy, setBusy] = useState(false)
@@ -63,11 +69,13 @@ const Generate = (props: Props) => {
     ? (props.seed ? ["prompt", "seed", "seconds", "submit"] : ["prompt", "seconds", "submit"])
     : (props.seed ? ["prompt", "seed", "submit"] : ["prompt", "submit"])
 
+  const advance = () => setField(f => fields[(fields.indexOf(f) + 1) % fields.length]!)
+
   const submit = () => {
     const p = prompt.trim()
     // Blank line 1 with only the pre-filled style hints below = no
     // subject described yet. Don't submit.
-    const bare = !props.lastPrompt && p === BASE_PROMPT[props.kind].trim()
+    const bare = !props.lastPrompt && p === BASE.trim()
     if (!p || bare || busy) {
       if (bare) setErr("describe the subject on line 1")
       return
@@ -93,6 +101,7 @@ const Generate = (props: Props) => {
       return
     }
     if (field === "prompt") return
+    if (key.name === "return") return field === "submit" ? submit() : advance()
     if (field === "seed" && (key.name === "space" || key.name === "left" || key.name === "right")) {
       setUseSeed(v => !v)
       return
@@ -101,7 +110,7 @@ const Generate = (props: Props) => {
       if (key.name === "left") return setSecs(v => Math.max(1, v - 1))
       if (key.name === "right") return setSecs(v => Math.min(4, v + 1))
     }
-    if (field === "submit" && (key.name === "return" || key.name === "space")) {
+    if (field === "submit" && key.name === "space") {
       submit()
     }
   })
@@ -126,6 +135,8 @@ const Generate = (props: Props) => {
           <textarea
             ref={ta}
             initialValue={prompt}
+            keyBindings={BINDS}
+            onSubmit={advance}
             onContentChange={() => { if (ta.current) setPrompt(ta.current.plainText) }}
             focused={field === "prompt"}
             placeholder={props.kind === "image" ? "describe the image…" : "describe the motion…"}
@@ -182,7 +193,7 @@ const Generate = (props: Props) => {
 
       <box height={1} marginTop={1}>
         <text fg={theme.textMuted}>
-          {"Tab field  ·  Enter submit  ·  Esc cancel"}
+          {"Enter next  ·  Shift+Enter newline  ·  Tab field  ·  Esc cancel"}
         </text>
       </box>
     </box>

--- a/src/dialogs/eikon-generate.tsx
+++ b/src/dialogs/eikon-generate.tsx
@@ -145,16 +145,18 @@ const Generate = (props: Props) => {
         </box>
       ) : null}
 
-      <box height={1} marginTop={1} flexDirection="row">
+      <box marginTop={1} flexDirection="row">
         {lbl("submit", "")}
-        <box flexGrow={1} minWidth={0} height={1}>
+        <box flexGrow={1} minWidth={0}>
           {busy
-            ? <Spinner color={theme.accent} label="generating…" />
+            ? <box height={1}><Spinner color={theme.accent} label="generating…" /></box>
             : err
-              ? <text fg={theme.warning}>{err}</text>
-              : <text fg={field === "submit" ? theme.accent : theme.textMuted}>
-                  {"[Enter] generate"}
-                </text>}
+              ? <text fg={theme.warning} wrapMode="word">{err}</text>
+              : <box height={1}>
+                  <text fg={field === "submit" ? theme.accent : theme.textMuted}>
+                    {"[Enter] generate"}
+                  </text>
+                </box>}
         </box>
       </box>
 

--- a/src/dialogs/eikon-generate.tsx
+++ b/src/dialogs/eikon-generate.tsx
@@ -3,9 +3,9 @@
 // the caller passes a seed path); optional seconds slider 1-4 for
 // kind="video". Enter submits → spinner → resolves with {path} or null.
 //
-// The RPC `eikon.generate` is NOT yet declared in stock hermes-agent.
-// Tests stub it via MockGateway; production calls will reject until a
-// follow-up adds the server method. See task t_b182c1b3 metadata.
+// Generation runs via `service/eikon-gen.ts`, which spawns the
+// installed hermes-agent venv's python and calls the image/video
+// tool functions directly — no gateway RPC round-trip.
 
 import { useRef, useState } from "react"
 import { useKeyboard } from "@opentui/react"
@@ -13,10 +13,10 @@ import type { TextareaRenderable } from "@opentui/core"
 import { useTheme } from "../theme"
 import { Spinner } from "../ui/spinner"
 import type { DialogContext } from "../ui/dialog"
-import type { Gateway } from "../context/gateway"
 import type { AvatarState } from "../components/avatar/states"
+import type { GenerateFn, GenerateKind } from "../service/eikon-gen"
 
-export type GenerateKind = "image" | "video"
+export type { GenerateKind }
 
 type Opts = {
   state: AvatarState
@@ -29,7 +29,7 @@ type Opts = {
 }
 
 type Props = Opts & {
-  gw: Gateway
+  run: GenerateFn
   onDone: (path: string | null, prompt: string) => void
 }
 
@@ -53,16 +53,14 @@ const Generate = (props: Props) => {
     const p = prompt.trim()
     if (!p || busy) return
     setBusy(true); setErr(null)
-    const params: Record<string, unknown> = { kind: props.kind, prompt: p }
-    if (props.seed && useSeed) params.seed = props.seed
-    if (props.kind === "video") params.seconds = secs
-    props.gw.request<{ path?: string; err?: string }>("eikon.generate", params)
-      .then(r => {
-        if (r.err) { setErr(r.err); setBusy(false); return }
-        if (r.path) return props.onDone(r.path, p)
-        setErr("no path returned"); setBusy(false)
-      })
-      .catch(e => { setErr(e instanceof Error ? e.message : String(e)); setBusy(false) })
+    void props.run(props.kind, p, {
+      seed: props.seed && useSeed ? props.seed : undefined,
+      seconds: props.kind === "video" ? secs : undefined,
+      aspect: props.kind === "video" ? "1:1" : "square",
+    }).then(r => {
+      if ("err" in r) { setErr(r.err); setBusy(false); return }
+      props.onDone(r.path, p)
+    })
   }
 
   useKeyboard(key => {
@@ -169,13 +167,13 @@ const Generate = (props: Props) => {
 
 export function openGenerate(
   dialog: DialogContext,
-  gw: Gateway,
+  run: GenerateFn,
   opts: Opts,
 ): Promise<{ path: string; prompt: string } | null> {
   return new Promise(resolve => {
     dialog.replace(
       <Generate
-        {...opts} gw={gw}
+        {...opts} run={run}
         onDone={(p, txt) => { resolve(p ? { path: p, prompt: txt } : null); dialog.clear() }}
       />,
       () => resolve(null),

--- a/src/dialogs/eikon-generate.tsx
+++ b/src/dialogs/eikon-generate.tsx
@@ -146,13 +146,15 @@ const Generate = (props: Props) => {
       ) : null}
 
       <box height={1} marginTop={1} flexDirection="row">
-        {lbl("submit", busy ? "" : "▸ Generate")}
+        {lbl("submit", "")}
         <box flexGrow={1} minWidth={0} height={1}>
           {busy
             ? <Spinner color={theme.accent} label="generating…" />
             : err
               ? <text fg={theme.warning}>{err}</text>
-              : <text fg={theme.textMuted}>Enter on Generate to submit</text>}
+              : <text fg={field === "submit" ? theme.accent : theme.textMuted}>
+                  {"[Enter] generate"}
+                </text>}
         </box>
       </box>
 

--- a/src/dialogs/eikon-generate.tsx
+++ b/src/dialogs/eikon-generate.tsx
@@ -1,0 +1,184 @@
+// Image/video generation dialog for the Eikon Studio source menu.
+// Multi-line textarea for the prompt; optional seed toggle (only when
+// the caller passes a seed path); optional seconds slider 1-4 for
+// kind="video". Enter submits → spinner → resolves with {path} or null.
+//
+// The RPC `eikon.generate` is NOT yet declared in stock hermes-agent.
+// Tests stub it via MockGateway; production calls will reject until a
+// follow-up adds the server method. See task t_b182c1b3 metadata.
+
+import { useRef, useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import type { TextareaRenderable } from "@opentui/core"
+import { useTheme } from "../theme"
+import { Spinner } from "../ui/spinner"
+import type { DialogContext } from "../ui/dialog"
+import type { Gateway } from "../context/gateway"
+import type { AvatarState } from "../components/avatar/states"
+
+export type GenerateKind = "image" | "video"
+
+type Opts = {
+  state: AvatarState
+  kind: GenerateKind
+  /** Absolute path to a seed image (e.g. base.png). When provided the
+   *  toggle row is shown so users can pick `base.png` vs `none`. */
+  seed?: string
+  /** Pre-fill the prompt input. */
+  lastPrompt?: string
+}
+
+type Props = Opts & {
+  gw: Gateway
+  onDone: (path: string | null, prompt: string) => void
+}
+
+type Field = "prompt" | "seed" | "seconds" | "submit"
+
+const Generate = (props: Props) => {
+  const theme = useTheme().theme
+  const ta = useRef<TextareaRenderable | null>(null)
+  const [prompt, setPrompt] = useState(props.lastPrompt ?? "")
+  const [useSeed, setUseSeed] = useState(!!props.seed)
+  const [secs, setSecs] = useState(2)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [field, setField] = useState<Field>("prompt")
+
+  const fields: readonly Field[] = props.kind === "video"
+    ? (props.seed ? ["prompt", "seed", "seconds", "submit"] : ["prompt", "seconds", "submit"])
+    : (props.seed ? ["prompt", "seed", "submit"] : ["prompt", "submit"])
+
+  const submit = () => {
+    const p = prompt.trim()
+    if (!p || busy) return
+    setBusy(true); setErr(null)
+    const params: Record<string, unknown> = { kind: props.kind, prompt: p }
+    if (props.seed && useSeed) params.seed = props.seed
+    if (props.kind === "video") params.seconds = secs
+    props.gw.request<{ path?: string; err?: string }>("eikon.generate", params)
+      .then(r => {
+        if (r.err) { setErr(r.err); setBusy(false); return }
+        if (r.path) return props.onDone(r.path, p)
+        setErr("no path returned"); setBusy(false)
+      })
+      .catch(e => { setErr(e instanceof Error ? e.message : String(e)); setBusy(false) })
+  }
+
+  useKeyboard(key => {
+    if (busy) return
+    if (key.name === "tab") {
+      key.preventDefault()
+      const i = fields.indexOf(field)
+      const next = fields[(i + (key.shift ? fields.length - 1 : 1)) % fields.length]!
+      setField(next)
+      return
+    }
+    if (field === "prompt") return
+    if (field === "seed" && (key.name === "space" || key.name === "left" || key.name === "right")) {
+      setUseSeed(v => !v)
+      return
+    }
+    if (field === "seconds") {
+      if (key.name === "left") return setSecs(v => Math.max(1, v - 1))
+      if (key.name === "right") return setSecs(v => Math.min(4, v + 1))
+    }
+    if (field === "submit" && (key.name === "return" || key.name === "space")) {
+      submit()
+    }
+  })
+  const lbl = (id: Field, text: string) => (
+    <box width={12} flexShrink={0}>
+      <text fg={field === id ? theme.accent : theme.textMuted}>
+        {field === id ? "▸ " : "  "}{text}
+      </text>
+    </box>
+  )
+
+  return (
+    <box flexDirection="column" width={72}>
+      <box height={1}><text fg={theme.primary}><strong>
+        {`Generate ${props.kind} — ${props.state}`}
+      </strong></text></box>
+      <box height={1} />
+
+      <box flexDirection="row">
+        {lbl("prompt", "Prompt")}
+        <box flexGrow={1} minWidth={0}>
+          <textarea
+            ref={ta}
+            initialValue={prompt}
+            onContentChange={() => { if (ta.current) setPrompt(ta.current.plainText) }}
+            focused={field === "prompt"}
+            placeholder={props.kind === "image" ? "describe the image…" : "describe the motion…"}
+            textColor={theme.text}
+            placeholderColor={theme.textMuted}
+            backgroundColor={field === "prompt" ? theme.backgroundElement : undefined}
+            focusedBackgroundColor={theme.backgroundElement}
+            minHeight={4}
+            maxHeight={6}
+          />
+        </box>
+      </box>
+
+      {props.seed ? (
+        <box height={1} flexDirection="row" marginTop={1}>
+          {lbl("seed", "Seed")}
+          <box flexGrow={1} minWidth={0} height={1}>
+            <text fg={field === "seed" ? theme.text : theme.textMuted}>
+              {useSeed ? "● base.png" : "○ none"}
+            </text>
+          </box>
+        </box>
+      ) : null}
+
+      {props.kind === "video" ? (
+        <box height={1} flexDirection="row" marginTop={1}>
+          {lbl("seconds", "Seconds")}
+          <box width={20} height={1}>
+            <slider orientation="horizontal" min={1} max={4} value={secs}
+                    foregroundColor={field === "seconds" ? theme.accent : theme.textMuted}
+                    backgroundColor={theme.border}
+                    onChange={v => setSecs(Math.round(v))} />
+          </box>
+          <box width={6} height={1}>
+            <text fg={field === "seconds" ? theme.text : theme.textMuted}>{`  ${secs}s`}</text>
+          </box>
+        </box>
+      ) : null}
+
+      <box height={1} marginTop={1} flexDirection="row">
+        {lbl("submit", busy ? "" : "▸ Generate")}
+        <box flexGrow={1} minWidth={0} height={1}>
+          {busy
+            ? <Spinner color={theme.accent} label="generating…" />
+            : err
+              ? <text fg={theme.warning}>{err}</text>
+              : <text fg={theme.textMuted}>Enter on Generate to submit</text>}
+        </box>
+      </box>
+
+      <box height={1} marginTop={1}>
+        <text fg={theme.textMuted}>
+          {"Tab field  ·  Enter submit  ·  Esc cancel"}
+        </text>
+      </box>
+    </box>
+  )
+}
+
+export function openGenerate(
+  dialog: DialogContext,
+  gw: Gateway,
+  opts: Opts,
+): Promise<{ path: string; prompt: string } | null> {
+  return new Promise(resolve => {
+    dialog.replace(
+      <Generate
+        {...opts} gw={gw}
+        onDone={(p, txt) => { resolve(p ? { path: p, prompt: txt } : null); dialog.clear() }}
+      />,
+      () => resolve(null),
+    )
+  })
+}

--- a/src/dialogs/new-eikon.tsx
+++ b/src/dialogs/new-eikon.tsx
@@ -26,14 +26,23 @@ export function openNewEikon(
   opts: { initial?: string } = {},
 ): Promise<NewEikon | null> {
   return new Promise(resolve => {
-    const done = (r: NewEikon | null) => { dialog.clear(); resolve(r) }
-    dialog.replace(<Form initial={opts.initial} done={done} dialog={dialog} />)
+    // Chaining to openTextPrompt calls dialog.replace(), which fires
+    // this entry's onClose. `chained` marks that hand-off so onClose
+    // doesn't resolve(null) while the prompt is still up.
+    let chained = false
+    dialog.replace(
+      <Form initial={opts.initial} dialog={dialog}
+        onChain={() => { chained = true }}
+        done={r => { chained = true; dialog.clear(); resolve(r) }} />,
+      () => { if (!chained) resolve(null) },
+    )
   })
 }
 
 const Form = (props: {
   initial?: string
   dialog: DialogContext
+  onChain: () => void
   done: (r: NewEikon | null) => void
 }) => {
   const theme = useTheme().theme
@@ -46,20 +55,19 @@ const Form = (props: {
   const submit = async () => {
     if (!ok) return
     if (from === "blank") return props.done({ name: slug, from: "blank" })
+    props.onChain()
     if (from === "file") {
       const file = await openTextPrompt(props.dialog, {
         title: "Source file",
         label: "absolute or ~ path (png / jpg / webp / gif / mp4)",
       })
-      if (!file) return props.done(null)
-      return props.done({ name: slug, from: "file", file })
+      return props.done(file ? { name: slug, from: "file", file } : null)
     }
     const src = await openTextPrompt(props.dialog, {
       title: "Install eikon",
       label: INSTALL_HINT,
     })
-    if (!src) return props.done(null)
-    props.done({ name: slug, from: "install", src })
+    props.done(src ? { name: slug, from: "install", src } : null)
   }
 
   useKeyboard(key => {

--- a/src/dialogs/new-eikon.tsx
+++ b/src/dialogs/new-eikon.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { useTheme } from "../theme"
+import { knobs } from "../utils/eikon-knobs"
+import { openTextPrompt } from "./text-prompt"
+import type { DialogContext } from "../ui/dialog"
+
+export type NewEikon =
+  | { name: string; from: "blank" }
+  | { name: string; from: "file"; file: string }
+  | { name: string; from: "install"; src: string }
+
+type From = "blank" | "file" | "install"
+type Field = "name" | "from"
+const ORDER: readonly Field[] = ["name", "from"] as const
+const FROMS: readonly { id: From; label: string; hint: string }[] = [
+  { id: "blank",   label: "blank",        hint: "author in Studio" },
+  { id: "file",    label: "local file",   hint: "png / jpg / webp / gif / mp4" },
+  { id: "install", label: "install from", hint: "catalog name · git URL · http://… · local dir" },
+]
+
+const INSTALL_HINT = "catalog name · github.com/u/r · git URL · http://…/ · local dir"
+
+export function openNewEikon(
+  dialog: DialogContext,
+  opts: { initial?: string } = {},
+): Promise<NewEikon | null> {
+  return new Promise(resolve => {
+    const done = (r: NewEikon | null) => { dialog.clear(); resolve(r) }
+    dialog.replace(<Form initial={opts.initial} done={done} dialog={dialog} />)
+  })
+}
+
+const Form = (props: {
+  initial?: string
+  dialog: DialogContext
+  done: (r: NewEikon | null) => void
+}) => {
+  const theme = useTheme().theme
+  const [name, setName] = useState(props.initial ?? "")
+  const [from, setFrom] = useState<From>("blank")
+  const [field, setField] = useState<Field>("name")
+  const slug = name ? knobs.slug(name) : ""
+  const ok = slug.length > 0
+
+  const submit = async () => {
+    if (!ok) return
+    if (from === "blank") return props.done({ name: slug, from: "blank" })
+    if (from === "file") {
+      const file = await openTextPrompt(props.dialog, {
+        title: "Source file",
+        label: "absolute or ~ path (png / jpg / webp / gif / mp4)",
+      })
+      if (!file) return props.done(null)
+      return props.done({ name: slug, from: "file", file })
+    }
+    const src = await openTextPrompt(props.dialog, {
+      title: "Install eikon",
+      label: INSTALL_HINT,
+    })
+    if (!src) return props.done(null)
+    props.done({ name: slug, from: "install", src })
+  }
+
+  useKeyboard(key => {
+    if (key.name === "escape") return props.done(null)
+    if (key.name === "tab") {
+      const i = ORDER.indexOf(field)
+      return setField(ORDER[(i + (key.shift ? -1 : 1) + ORDER.length) % ORDER.length]!)
+    }
+    if (key.name === "return") return void submit()
+    if (field === "name") {
+      if (key.name === "backspace") return setName(n => n.slice(0, -1))
+      if (key.raw && key.raw.length === 1 && /[A-Za-z0-9 _-]/.test(key.raw))
+        return setName(n => n + key.raw)
+      return
+    }
+    // field === "from"
+    if (key.name === "up") {
+      const i = FROMS.findIndex(f => f.id === from)
+      return setFrom(FROMS[Math.max(0, i - 1)]!.id)
+    }
+    if (key.name === "down") {
+      const i = FROMS.findIndex(f => f.id === from)
+      return setFrom(FROMS[Math.min(FROMS.length - 1, i + 1)]!.id)
+    }
+  })
+
+  const bg = (f: Field) => field === f ? theme.backgroundElement : undefined
+
+  return (
+    <box flexDirection="column" width={60}>
+      <box height={1}><text fg={theme.primary}><strong>New eikon</strong></text></box>
+      <box height={1} />
+      <box height={1} flexDirection="row" backgroundColor={bg("name")}>
+        <box width={9}><text fg={theme.textMuted}>Name</text></box>
+        <text>
+          <span fg={theme.text}>{name}</span>
+          {field === "name" ? <span fg={theme.accent}>█</span> : null}
+        </text>
+      </box>
+      <box height={1}><text fg={theme.textMuted}>
+        {slug ? `  → ${slug}` : "  type a name"}
+      </text></box>
+      <box height={1} />
+      <box height={1} backgroundColor={bg("from")}>
+        <text fg={theme.textMuted}>From  (↑↓)</text>
+      </box>
+      {FROMS.map(f => {
+        const on = f.id === from
+        const fg = on ? theme.accent : theme.text
+        return (
+          <box key={f.id} height={1} flexDirection="row" backgroundColor={bg("from")}>
+            <box width={2}><text fg={fg}>{on ? "▸ " : "  "}</text></box>
+            <box width={14}><text fg={fg}>{f.label}</text></box>
+            <text fg={theme.textMuted}>{f.hint}</text>
+          </box>
+        )
+      })}
+      <box height={1} />
+      <box height={1}><text fg={theme.textMuted}>
+        {ok ? "Enter create  ·  Tab next field  ·  Esc cancel" : "type a name"}
+      </text></box>
+    </box>
+  )
+}

--- a/src/dialogs/path-prompt.tsx
+++ b/src/dialogs/path-prompt.tsx
@@ -1,0 +1,106 @@
+// Single-line path prompt with Tab-completion. Tab calls `complete.path`
+// (same RPC the `@file:` popover uses), picks the first item whose `text`
+// passes `filter` (directories always pass so navigation works), and
+// replaces the input. Up to 5 matches show below the input as muted text.
+// Enter submits, Esc cancels.
+
+import { useEffect, useRef, useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { useTheme } from "../theme"
+import type { DialogContext } from "../ui/dialog"
+import type { Gateway } from "../context/gateway"
+
+type Item = { readonly text: string; readonly display: string; readonly meta: string }
+
+type Props = {
+  title: string
+  label?: string
+  initial?: string
+  filter?: RegExp
+  gw: Gateway
+  onSubmit: (value: string) => void
+}
+
+const PathPrompt = (props: Props) => {
+  const theme = useTheme().theme
+  const [value, setValue] = useState(props.initial ?? "")
+  const [items, setItems] = useState<Item[]>([])
+  const seq = useRef(0)
+
+  const ok = (it: Item) => it.meta === "dir" || !props.filter || props.filter.test(it.text)
+
+  useEffect(() => {
+    if (!value.trim()) { setItems([]); return }
+    const me = ++seq.current
+    const t = setTimeout(() => {
+      props.gw.request<{ items: Item[] }>("complete.path", { word: value })
+        .then(r => { if (seq.current === me) setItems((r.items ?? []).filter(ok).slice(0, 5)) })
+        .catch(() => { if (seq.current === me) setItems([]) })
+    }, 120)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, props.gw])
+
+  useKeyboard(key => {
+    if (key.name !== "tab") return
+    key.preventDefault()
+    const hit = items[0]
+    if (hit) setValue(hit.text)
+  })
+
+  return (
+    <box flexDirection="column" width={72}>
+      <box height={1}><text fg={theme.primary}><strong>{props.title}</strong></text></box>
+      <box height={1} />
+      {props.label ? <box height={1}><text fg={theme.textMuted}>{props.label}</text></box> : null}
+      <box height={1} flexDirection="row" overflow="hidden">
+        <box flexShrink={0}><text fg={theme.accent}>{"┃ "}</text></box>
+        <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
+          <input
+            value={value}
+            onInput={setValue}
+            onSubmit={() => { const v = value.trim(); if (v) props.onSubmit(v) }}
+            focused
+            textColor={theme.text}
+            backgroundColor={theme.backgroundElement}
+            focusedBackgroundColor={theme.backgroundElement}
+          />
+        </box>
+      </box>
+      <box height={1} />
+      {items.length > 0 ? items.map(it => (
+        <box key={it.text} height={1} flexDirection="row" overflow="hidden">
+          <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
+            <text fg={theme.textMuted}>{it.text}</text>
+          </box>
+          {it.meta ? (
+            <box flexShrink={0} height={1}><text fg={theme.textMuted}>{`  ${it.meta}`}</text></box>
+          ) : null}
+        </box>
+      )) : null}
+      {items.length > 0 ? <box height={1} /> : null}
+      <box height={1}><text fg={theme.textMuted}>
+        {value.trim()
+          ? `Tab complete  ·  Enter confirm  ·  Esc cancel${items.length > 0 ? `  ·  ${items.length} match${items.length === 1 ? "" : "es"}` : ""}`
+          : "Type a path  ·  Esc cancel"}
+      </text></box>
+    </box>
+  )
+}
+
+export function openPathPrompt(
+  dialog: DialogContext,
+  gw: Gateway,
+  opts: { title: string; label?: string; initial?: string; filter?: RegExp },
+): Promise<string | null> {
+  return new Promise(resolve => {
+    dialog.replace(
+      <PathPrompt
+        title={opts.title} label={opts.label} initial={opts.initial}
+        filter={opts.filter} gw={gw}
+        onSubmit={v => { resolve(v); dialog.clear() }}
+      />,
+      () => resolve(null),
+    )
+  })
+}

--- a/src/service/eikon-gen.ts
+++ b/src/service/eikon-gen.ts
@@ -1,0 +1,103 @@
+// Direct subprocess bridge to hermes-agent's image_generate /
+// video_generate tool functions. No gateway RPC — the installed
+// hermes-agent venv is on disk and the tool modules are plain
+// synchronous Python that returns a JSON string. We call them with
+// `python -c`, parse stdout, and normalize to a local file path.
+//
+// `GenerateFn` is the injectable surface so tests (and future
+// providers) can swap the backend without touching callers.
+
+import { existsSync } from "node:fs"
+import { hermesPath } from "./hermes-home"
+
+export type GenerateKind = "image" | "video"
+export type GenerateOpts = { seed?: string; seconds?: number; aspect?: string }
+export type GenerateOut = { path: string } | { err: string }
+export type GenerateFn = (kind: GenerateKind, prompt: string, opts: GenerateOpts) => Promise<GenerateOut>
+
+const ROOT = () => hermesPath("hermes-agent")
+const PY = () => {
+  for (const v of ["venv", ".venv"]) {
+    const p = `${ROOT()}/${v}/bin/python`
+    if (existsSync(p)) return p
+  }
+  return "python3"
+}
+
+const q = (s: string) => JSON.stringify(s)
+
+function code(kind: GenerateKind, prompt: string, o: GenerateOpts): string {
+  if (kind === "image") return [
+    "from tools.image_generation_tool import image_generate_tool as g",
+    `print(g(${q(prompt)}, aspect_ratio=${q(o.aspect ?? "square")}))`,
+  ].join("; ")
+  const args: string[] = [`"prompt":${q(prompt)}`, `"aspect_ratio":${q(o.aspect ?? "1:1")}`]
+  if (o.seconds) args.push(`"duration":${o.seconds}`)
+  if (o.seed) args.push(`"image_url":${q(o.seed)}`)
+  return [
+    "from tools.video_generation_tool import _handle_video_generate as g",
+    `print(g({${args.join(",")}}))`,
+  ].join("; ")
+}
+
+/** Probe whether each gen backend is configured — cheaper than
+ *  `toolsets.list` and checks provider availability, not just the
+ *  toolset toggle. */
+export async function probe(): Promise<{ image: boolean; video: boolean }> {
+  const root = ROOT()
+  if (!existsSync(root)) return { image: false, video: false }
+  const src = [
+    "import json",
+    "from tools.image_generation_tool import check_image_generation_requirements as ci",
+    "from tools.video_generation_tool import check_video_generation_requirements as cv",
+    "print(json.dumps({'image': bool(ci()), 'video': bool(cv())}))",
+  ].join("; ")
+  const r = Bun.spawn([PY(), "-c", src], { cwd: root, stdout: "pipe", stderr: "pipe" })
+  const out = await new Response(r.stdout).text()
+  if ((await r.exited) !== 0) return { image: false, video: false }
+  const last = out.trim().split("\n").pop()!
+  try { return JSON.parse(last) } catch { return { image: false, video: false } }
+}
+
+async function fetchTo(url: string, ext: string): Promise<string> {
+  const tmp = `${process.env.TMPDIR ?? "/tmp"}/eikon-gen-${Date.now()}${ext}`
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`download ${res.status}`)
+  await Bun.write(tmp, await res.arrayBuffer())
+  return tmp
+}
+
+export const generate: GenerateFn = async (kind, prompt, opts) => {
+  const r = Bun.spawn([PY(), "-c", code(kind, prompt, opts)],
+    { cwd: ROOT(), stdout: "pipe", stderr: "pipe" })
+  const [out, err, exit] = await Promise.all([
+    new Response(r.stdout).text(),
+    new Response(r.stderr).text(),
+    r.exited,
+  ])
+  if (exit !== 0) return { err: (err || out).trim().split("\n").slice(-3).join(" ") || `python exited ${exit}` }
+  const last = out.trim().split("\n").pop()
+  if (!last) return { err: "no output" }
+  let j: { success?: boolean; image?: string; video?: string; error?: string }
+  try { j = JSON.parse(last) } catch { return { err: `unparseable: ${last.slice(0, 200)}` } }
+  if (j.success === false || j.error) return { err: j.error ?? "provider error" }
+  const ref = j.image ?? j.video
+  if (!ref) return { err: "provider returned no asset" }
+  if (ref.startsWith("/") || ref.startsWith("file://"))
+    return { path: ref.replace(/^file:\/\//, "") }
+  if (/^https?:\/\//.test(ref))
+    return fetchTo(ref, kind === "image" ? ".png" : ".mp4")
+      .then(p => ({ path: p }))
+      .catch(e => ({ err: `download: ${e instanceof Error ? e.message : e}` }))
+  return { err: `unrecognized asset ref: ${ref.slice(0, 80)}` }
+}
+
+// Swappable for tests; callers take GenerateFn as a parameter.
+let impl: GenerateFn = generate
+let probeImpl = probe
+export const current = (): GenerateFn => impl
+export const setImpl = (fn: GenerateFn | null) => { impl = fn ?? generate }
+export const setProbe = (fn: typeof probe | null) => { probeImpl = fn ?? probe }
+export const probeCached = () => probeImpl()
+
+export * as gen from "./eikon-gen"

--- a/src/service/eikon-gen.ts
+++ b/src/service/eikon-gen.ts
@@ -7,7 +7,7 @@
 // `GenerateFn` is the injectable surface so tests (and future
 // providers) can swap the backend without touching callers.
 
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { hermesPath } from "./hermes-home"
 
 export type GenerateKind = "image" | "video"
@@ -24,12 +24,47 @@ const PY = () => {
   return "python3"
 }
 
+/** API keys live in ~/.hermes/.env (per AGENTS.md: env file is keys-
+ *  only). Bun auto-loads .env from the project cwd, not from
+ *  HERMES_HOME, so the python subprocess won't see them unless we
+ *  parse the file and merge it into the child env. Quoted values
+ *  and `export ` prefixes are stripped; existing process env wins
+ *  so per-shell overrides still apply. */
+function dotenv(): Record<string, string> {
+  const out: Record<string, string> = {}
+  const path = hermesPath(".env")
+  if (!existsSync(path)) return out
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const ln = raw.trim()
+    if (!ln || ln.startsWith("#")) continue
+    const eq = ln.indexOf("=")
+    if (eq < 1) continue
+    const k = ln.slice(0, eq).replace(/^export\s+/, "").trim()
+    let v = ln.slice(eq + 1).trim()
+    if ((v.startsWith('"') && v.endsWith('"')) ||
+        (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1)
+    out[k] = v
+  }
+  return out
+}
+
+const env = (): Record<string, string> => {
+  // Merge order: ~/.hermes/.env < process.env so a live shell override wins.
+  const base = dotenv()
+  for (const [k, v] of Object.entries(process.env)) if (v !== undefined) base[k] = v
+  return base
+}
+
 const q = (s: string) => JSON.stringify(s)
 
 function code(kind: GenerateKind, prompt: string, o: GenerateOpts): string {
+  // _handle_image_generate / _handle_video_generate route through
+  // `image_gen.provider` / `video_gen.provider` config so a plugin
+  // (openai, xai, etc.) wins when configured; the raw _tool funcs
+  // only know about the in-tree FAL backend.
   if (kind === "image") return [
-    "from tools.image_generation_tool import image_generate_tool as g",
-    `print(g(${q(prompt)}, aspect_ratio=${q(o.aspect ?? "square")}))`,
+    "from tools.image_generation_tool import _handle_image_generate as g",
+    `print(g({"prompt": ${q(prompt)}, "aspect_ratio": ${q(o.aspect ?? "square")}}))`,
   ].join("; ")
   const args: string[] = [`"prompt":${q(prompt)}`, `"aspect_ratio":${q(o.aspect ?? "1:1")}`]
   if (o.seconds) args.push(`"duration":${o.seconds}`)
@@ -52,7 +87,7 @@ export async function probe(): Promise<{ image: boolean; video: boolean }> {
     "from tools.video_generation_tool import check_video_generation_requirements as cv",
     "print(json.dumps({'image': bool(ci()), 'video': bool(cv())}))",
   ].join("; ")
-  const r = Bun.spawn([PY(), "-c", src], { cwd: root, stdout: "pipe", stderr: "pipe" })
+  const r = Bun.spawn([PY(), "-c", src], { cwd: root, env: env(), stdout: "pipe", stderr: "pipe" })
   const out = await new Response(r.stdout).text()
   if ((await r.exited) !== 0) return { image: false, video: false }
   const last = out.trim().split("\n").pop()!
@@ -69,7 +104,7 @@ async function fetchTo(url: string, ext: string): Promise<string> {
 
 export const generate: GenerateFn = async (kind, prompt, opts) => {
   const r = Bun.spawn([PY(), "-c", code(kind, prompt, opts)],
-    { cwd: ROOT(), stdout: "pipe", stderr: "pipe" })
+    { cwd: ROOT(), env: env(), stdout: "pipe", stderr: "pipe" })
   const [out, err, exit] = await Promise.all([
     new Response(r.stdout).text(),
     new Response(r.stderr).text(),

--- a/src/service/eikon-gen.ts
+++ b/src/service/eikon-gen.ts
@@ -115,7 +115,7 @@ export const generate: GenerateFn = async (kind, prompt, opts) => {
   if (!last) return { err: "no output" }
   let j: { success?: boolean; image?: string; video?: string; error?: string }
   try { j = JSON.parse(last) } catch { return { err: `unparseable: ${last.slice(0, 200)}` } }
-  if (j.success === false || j.error) return { err: j.error ?? "provider error" }
+  if (j.success === false || j.error) return { err: String(j.error ?? "provider error") }
   const ref = j.image ?? j.video
   if (!ref) return { err: "provider returned no asset" }
   if (ref.startsWith("/") || ref.startsWith("file://"))

--- a/src/service/eikon.ts
+++ b/src/service/eikon.ts
@@ -64,6 +64,16 @@ export function list(): Installed[] {
     })
 }
 
+/** Folder names under eikons/ regardless of whether they've been
+ *  saved yet — used by the Open picker so a fresh `ensure()`d draft
+ *  (which `list()` skips until it has a .eikon) is still reachable. */
+export function raw(): string[] {
+  const root = ROOT()
+  if (!existsSync(root)) return []
+  return readdirSync(root, { withFileTypes: true })
+    .filter(e => e.isDirectory()).map(e => e.name)
+}
+
 const IMG = /\.(png|jpe?g|webp|gif|bmp)$/i
 const VID = /\.(mp4|webm|mov|mkv)$/i
 

--- a/src/service/eikon.ts
+++ b/src/service/eikon.ts
@@ -214,7 +214,7 @@ export async function save(s: Session): Promise<string> {
     if (!fs) {
       if (!src) fs = blank
       else {
-        const out = await cached(r, src, s.spatial, s.fps, k)
+        const out = await cached(r, src, s.spatial, s.tone, s.fps, k)
         if ("err" in out) throw new Error(out.err)
         fs = out.frames
       }

--- a/src/tabs/EikonGallery.tsx
+++ b/src/tabs/EikonGallery.tsx
@@ -25,7 +25,7 @@ import { eikon } from "../service/eikon"
 
 type Row = {
   path: string; name: string; slug: string; author?: string; bundled: boolean
-  w: number; h: number; states: number; url?: string; hasSource: boolean
+  w: number; h: number; url?: string; hasSource: boolean
 }
 
 export const EikonGallery = memo((props: { focused: boolean; onEdit?: (name: string) => void }) => {
@@ -46,7 +46,7 @@ export const EikonGallery = memo((props: { focused: boolean; onEdit?: (name: str
       return {
         path: e.path, name: e.meta.name, slug, author: e.meta.author,
         bundled: e.path.startsWith(BUNDLED_EIKON_DIR),
-        w: e.meta.width, h: e.meta.height, states: e.meta.states.length,
+        w: e.meta.width, h: e.meta.height,
         url: (mine?.sourceUrl ?? e.meta.source_url) as string | undefined,
         hasSource: mine?.hasSource ?? !!eikon.findSource(slug),
       }
@@ -137,7 +137,7 @@ export const EikonGallery = memo((props: { focused: boolean; onEdit?: (name: str
                           <span fg={theme.textMuted}>{r.bundled ? "  (bundled)" : ""}</span>
                         </text></box>
                         <box height={1}><text fg={theme.textMuted}>
-                          {`  ${r.author ?? "—"} · ${r.states} states · ${r.w}×${r.h} · `}
+                          {`  ${r.author ?? "—"} · ${r.w}×${r.h} · `}
                           <span fg={r.hasSource ? theme.success : r.url ? theme.textMuted : theme.border}>
                             {r.hasSource ? "● source" : r.url ? "○ source available" : "— no source"}
                           </span>

--- a/src/tabs/EikonGallery.tsx
+++ b/src/tabs/EikonGallery.tsx
@@ -2,7 +2,7 @@
 // Same content model as the Ctrl+K "Pick Avatar" palette entry, but as
 // a full tab body with a larger preview and delete/new affordances.
 
-import { memo, useEffect, useMemo, useState, useSyncExternalStore } from "react"
+import { memo, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react"
 import { readFileSync } from "node:fs"
 import { basename, dirname } from "node:path"
 import { useTheme } from "../theme"
@@ -13,8 +13,7 @@ import { HintBar } from "../ui/hint"
 import { VBAR } from "../ui/table"
 import { useKeys, handleListKey, useFollow } from "../keys"
 import { openConfirm } from "../dialogs/confirm"
-import { openTextPrompt } from "../dialogs/text-prompt"
-import { DialogSelect } from "../ui/dialog-select"
+import { openNewEikon } from "../dialogs/new-eikon"
 import { useKeyboard } from "@opentui/react"
 import { AnimatedAvatar } from "../components/avatar/AnimatedAvatar"
 import { listEikons, parseEikon, type ParsedEikon } from "../components/avatar/eikon"
@@ -69,30 +68,27 @@ export const EikonGallery = memo((props: { focused: boolean; onEdit?: (name: str
     toast.show({ variant: "success", message: `Avatar → ${cur.name}` })
   }
 
-  const doInstall = async () => {
-    const src = await openTextPrompt(dialog, {
-      title: "Install eikon",
-      label: "catalog name · github.com/u/r · git URL · http://…/ · local dir",
-    })
-    if (!src) return
-    toast.show({ variant: "info", message: `Installing from ${src}…` })
-    await eikon.fetchSource(src)
-      .then(out => toast.show({ variant: "success", message: `Installed '${out.name}' (${out.n} files)` }))
+  const doNew = useCallback(async () => {
+    const res = await openNewEikon(dialog, {})
+    if (!res) return
+    if (res.from === "blank") {
+      eikon.ensure(res.name)
+      return props.onEdit?.(res.name)
+    }
+    if (res.from === "file") {
+      eikon.ensure(res.name)
+      try { eikon.adopt(res.name, res.file, "base") }
+      catch (e) { return toast.error(e instanceof Error ? e : new Error(String(e))) }
+      return props.onEdit?.(res.name)
+    }
+    toast.show({ variant: "info", message: `Installing '${res.name}' from ${res.src}…` })
+    await eikon.fetchSource(res.src, { name: res.name })
+      .then(out => {
+        toast.show({ variant: "success", message: `Installed '${out.name}' (${out.n} files)` })
+        prefs.set("eikon", out.name)
+      })
       .catch(e => toast.error(e instanceof Error ? e : new Error(String(e))))
-  }
-
-  const doNew = () => dialog.replace(
-    <DialogSelect title="New eikon" filterable={false}
-      options={[
-        { title: "Blank — author in Studio", value: "blank" },
-        { title: "Install from…", value: "install",
-          description: "catalog name, git URL, local dir, or http manifest" },
-      ]}
-      onSelect={o => {
-        dialog.clear()
-        if (o.value === "blank") return props.onEdit?.("")
-        void doInstall()
-      }} />, () => {})
+  }, [dialog, toast, props])
 
   const del = async () => {
     if (!cur || cur.bundled) return

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -24,7 +24,7 @@ import { useToast } from "../ui/toast"
 import { TabShell } from "../ui/shell"
 import { HintBar } from "../ui/hint"
 import { DialogSelect } from "../ui/dialog-select"
-import { openConfirm } from "../dialogs/confirm"
+import { openConfirm, openSaveDiscard } from "../dialogs/confirm"
 import { openTextPrompt } from "../dialogs/text-prompt"
 import * as prefs from "../context/preferences"
 import { eikon } from "../service/eikon"
@@ -66,6 +66,7 @@ const HEAD: readonly Row[] = [
     show: (s, live, url) => !live && !!url },
   { id: "fork",       kind: "action", label: "fork state",  show: (_s, live) => live },
   { id: "reset",      kind: "action", label: "reset knobs", show: (_s, live) => live },
+  { id: "revert",     kind: "action", label: "revert",      show: s => s.dirty },
   { id: "-2",         kind: "divider", label: "", show: (_s, live) => live },
 ]
 
@@ -234,6 +235,7 @@ function valueOf(s: Session, r: Rasterizer, row: Row, src?: string,
   if (row.id === "name") return s.name
   if (row.id === "fork") return s.per[s.state] ? "(forked)" : "▸ copy base → " + s.state
   if (row.id === "reset") return "▸ defaults"
+  if (row.id === "revert") return "▸ reload from disk"
   if (row.id === "fetch") return busy ? "fetching…"
     : peek ? `▸ download to edit  (${peek.n} files, ${mb(peek.bytes)})` : "▸ download to edit"
   if (row.kind === "knob" && row.knob) {
@@ -357,6 +359,7 @@ export const EikonStudio = memo((props: {
   const [peek, setPeek] = useState<{ n: number; bytes: number } | undefined>(undefined)
   const [thumbs, setThumbs] = useState<Map<AvatarState, Frame | undefined>>(new Map())
   const [err, setErr] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
   const frame = frames[tick % frames.length] ?? BLANK
 
   const r = useMemo(() => eikon.pick(s?.rasterizer ?? prefs.get("eikonRasterizer")), [s?.rasterizer])
@@ -434,6 +437,28 @@ export const EikonStudio = memo((props: {
 
   const rows = useMemo(() => (s ? buildRows(r, s, live, url) : []), [r, s, live, url])
   const navRows = useMemo(() => rows.map((x, i) => ({ ...x, i })).filter(x => x.kind !== "divider"), [rows])
+  // Keep selection anchored to its row's id when navRows mutates (the
+  // `revert` row inserts into HEAD when a knob is touched, shifting
+  // knob indices). selRow is the id the user intends to sit on; it's
+  // updated by the keyboard handler (setSelBy) and read here when the
+  // row list changes to re-resolve the index.
+  const selRow = useRef<string | undefined>(undefined)
+  const setSelBy = useCallback<typeof setSel>((arg) => {
+    setSel(prev => {
+      const next = typeof arg === "function" ? (arg as (p: number) => number)(prev) : arg
+      selRow.current = navRows[next]?.id
+      return next
+    })
+  }, [navRows])
+  const prevRows = useRef(navRows)
+  useEffect(() => {
+    if (prevRows.current === navRows) return
+    prevRows.current = navRows
+    const id = selRow.current
+    if (!id) return
+    const ni = navRows.findIndex(x => x.id === id)
+    if (ni >= 0 && ni !== selRef.current) setSel(ni)
+  }, [navRows])
   // Knobs pane: ↑↓ keeps the selected row in view. Rows already carry
   // `id="knob-<row.id>"` (reconciler-id rule) — resolve via that.
   const kScroll = (ni: number) => {
@@ -525,9 +550,11 @@ export const EikonStudio = memo((props: {
     if (!s.dirty) return toast.show({ variant: "info", message: "Nothing to save" })
     if (!live) return toast.show({ variant: "warning",
       message: "No source — fetch or attach before saving" })
+    setSaving(true)
     await eikon.save({ ...s, dirty: false })
       .then(f => { mutate(p => ({ ...p, dirty: false })); toast.show({ variant: "success", message: `Saved → ${basename(f)}` }) })
       .catch(e => toast.error(e instanceof Error ? e : new Error(String(e))))
+      .finally(() => setSaving(false))
   }, [s, live, toast])
 
   const doSelectRasterizer = () => {
@@ -570,6 +597,7 @@ export const EikonStudio = memo((props: {
   const doAction = async (id: string) => {
     if (!s) return
     if (id === "fork") return mutate(knobs.fork)
+    if (id === "revert") { void discard(); return }
     if (id === "reset") {
       const ok = await openConfirm(dialog, { title: "Reset knobs?", body: "Restore rasterizer defaults and drop all per-state overrides.", danger: true })
       if (ok) mutate(p => knobs.reset(p, r))
@@ -640,18 +668,19 @@ export const EikonStudio = memo((props: {
   const discard = async () => {
     const cur = sRef.current
     if (!cur?.dirty) return false
-    const ok = await openConfirm(dialog, {
-      title: "Discard unsaved edits?", danger: true,
-      body: `Reload '${cur.name}' from disk and drop in-memory changes.`,
+    const pick = await openSaveDiscard(dialog, {
+      title: "Unsaved edits",
+      body: `'${cur.name}' has unsaved changes. Save them, discard them, or keep editing?`,
     })
-    if (ok) open(cur.name)
+    if (pick === "save") { await doSave(); open(cur.name) }
+    if (pick === "discard") open(cur.name)
     return true
   }
 
   useKeyboard((key: ParsedKey) => {
     if (!props.focused || dialog.open()) return
     if (key.eventType === "release") return
-    if (keys.match("eikon.save", key)) return void doSave()
+    if (keys.match("eikon.save", key)) { if (!saving) void doSave(); return }
     if (key.name === "escape") return void discard()
     if (key.name === "tab") {
       const i = PANES.indexOf(pane)
@@ -666,7 +695,7 @@ export const EikonStudio = memo((props: {
     }
     if (pane === "knobs") {
       if (handleListKey(keys, key, {
-        count: navRows.length, setSel, scrollTo: kScroll,
+        count: navRows.length, setSel: setSelBy, scrollTo: kScroll,
         page: Math.max(1, (ksb.current?.viewport.height ?? 10) - 1),
         onActivate: activate,
         onToggle: toggle,
@@ -764,7 +793,7 @@ export const EikonStudio = memo((props: {
   )
 
   const panel = (
-    <TabShell title={`Knobs${s?.dirty ? "  ·  ● unsaved" : ""}`} focus={pane === "knobs"} grow={1}>
+    <TabShell title={s ? `Knobs — ${s.name}` : "Knobs"} focus={pane === "knobs"} grow={1}>
       {!s
         ? <box flexGrow={1} alignItems="center" justifyContent="center">
             <text fg={theme.textMuted}>No eikon open. Enter to create one.</text>
@@ -777,8 +806,8 @@ export const EikonStudio = memo((props: {
               return (
                 <KnobRow key={`${r.name}:${row.id}`} id={`knob-${row.id}`} row={row} s={s} r={r} src={src}
                          on={on} dim={dim} peek={peek} busy={row.id === "fetch" && fetching}
-                         onHover={() => { if (ni >= 0) { setPane("knobs"); setSel(ni) } }}
-                         onClick={() => { if (ni >= 0) { setSel(ni); setPane("knobs"); act(row, "click") } }}
+                         onHover={() => { if (ni >= 0) { setPane("knobs"); setSelBy(ni) } }}
+                         onClick={() => { if (ni >= 0) { setSelBy(ni); setPane("knobs"); act(row, "click") } }}
                          onSlide={row.knob?.kind === "slider"
                            ? v => mutate(p => knobs.edit(p, k => knobs.setSlider(k, row.id, row.knob!, v)))
                            : undefined} />
@@ -823,7 +852,7 @@ export const EikonStudio = memo((props: {
         {top}
         {strip}
       </scrollbox>
-      <HintBar pairs={hint} suffix={s?.dirty ? "● unsaved" : undefined} />
+      <HintBar pairs={hint} suffix={saving ? "● saving…" : s?.dirty ? "● unsaved" : undefined} />
     </box>
   )
 })

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -76,8 +76,8 @@ const HEAD: readonly Row[] = [
   { id: "-1",         kind: "divider", label: "" },
   { id: "fetch",      kind: "action", label: "fetch source",
     show: (s, live, url) => !live && !!url },
-  { id: "knobsfor",   kind: "action", label: "knobs for",  show: (_s, live) => live },
-  { id: "reset",      kind: "action", label: "reset knobs", show: (_s, live) => live },
+  { id: "knobsfor",   kind: "action", label: "tune",        show: (_s, live) => live },
+  { id: "reset",      kind: "action", label: "reset",       show: (_s, live) => live },
   { id: "revert",     kind: "action", label: "revert",      show: s => s.dirty },
   { id: "-2",         kind: "divider", label: "", show: (_s, live) => live },
 ]
@@ -88,11 +88,11 @@ const HEAD: readonly Row[] = [
 // one from the knob kind.
 const HELP: Readonly<Record<string, string>> = {
   open:       "Which eikon you're editing. Enter to switch, create a new one, or install from elsewhere.",
-  rasterizer: "The engine that turns your source image/video into text art. Each rasterizer exposes its own look-and-feel knobs below the divider.",
+  rasterizer: "The engine that turns your source image/video into text art. Each rasterizer exposes its own look-and-feel settings below the divider.",
   source:     "The image or video file the avatar is rendered from. Enter to pick a local file, generate one with AI, or clear it. Each state can have its own source.",
   fetch:      "Download this eikon's published source media so you can re-tune it locally.",
-  knobsfor:   "←→ toggles whether the knobs below apply to every state or just the one selected in the strip.",
-  reset:      "Restore every knob to this rasterizer's defaults and drop per-state overrides.",
+  knobsfor:   "←→ toggles whether the settings below apply to every state or just the one selected in the strip.",
+  reset:      "Restore every setting below to this rasterizer's defaults and drop per-state overrides.",
   revert:     "Throw away unsaved edits and reload this eikon from disk.",
 }
 
@@ -841,7 +841,7 @@ export const EikonStudio = memo((props: {
     if (id === "knobsfor") return mutate(p => p.per[p.state] ? knobs.unfork(p) : knobs.fork(p))
     if (id === "revert") { void discard(); return }
     if (id === "reset") {
-      const ok = await openConfirm(dialog, { title: "Reset knobs?", body: "Restore rasterizer defaults and drop all per-state overrides.", danger: true })
+      const ok = await openConfirm(dialog, { title: "Reset settings?", body: "Restore rasterizer defaults and drop all per-state overrides.", danger: true })
       if (ok) mutate(p => knobs.reset(p, r))
       return
     }
@@ -864,7 +864,7 @@ export const EikonStudio = memo((props: {
       <DialogSelect title={`State: ${s.state}`} filterable={false}
         options={[
           { title: "Source…", value: "source" },
-          { title: s.per[s.state] ? "Clear override (back to base)" : "Fork knobs from base", value: "fork" },
+          { title: s.per[s.state] ? "Clear override (back to base)" : "Tune this state only", value: "fork" },
         ]}
         onSelect={o => {
           if (o.value === "source") { doSource(); return }

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -14,9 +14,11 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import { extend, useKeyboard, useTerminalDimensions } from "@opentui/react"
 import { SliderRenderable } from "@opentui/core"
 import type { ParsedKey, ScrollBoxRenderable } from "@opentui/core"
-import { readFileSync } from "node:fs"
+import { readFileSync, statSync } from "node:fs"
 import { basename } from "node:path"
+import type { ReactNode } from "react"
 import { useTheme } from "../theme"
+import type { Theme } from "../theme/types"
 import { Spinner } from "../ui/spinner"
 import { useKeys, handleListKey } from "../keys"
 import { useDialog } from "../ui/dialog"
@@ -73,7 +75,7 @@ const HEAD: readonly Row[] = [
   { id: "-1",         kind: "divider", label: "" },
   { id: "fetch",      kind: "action", label: "fetch source",
     show: (s, live, url) => !live && !!url },
-  { id: "fork",       kind: "action", label: "fork state",  show: (_s, live) => live },
+  { id: "knobsfor",   kind: "action", label: "knobs for",  show: (_s, live) => live },
   { id: "reset",      kind: "action", label: "reset knobs", show: (_s, live) => live },
   { id: "revert",     kind: "action", label: "revert",      show: s => s.dirty },
   { id: "-2",         kind: "divider", label: "", show: (_s, live) => live },
@@ -237,12 +239,24 @@ function SpatialBar(props: {
 
 // ── Knob row renderers ───────────────────────────────────────────────
 
-function valueOf(s: Session, r: Rasterizer, row: Row, src?: string,
-                 peek?: { n: number; bytes: number }, busy?: boolean): string {
+function valueOf(s: Session, r: Rasterizer, row: Row, theme: Theme,
+                 src?: string, peek?: { n: number; bytes: number }, busy?: boolean): string | ReactNode {
   if (row.id === "open") return `${s.name} ▸`
-  if (row.id === "rasterizer") return `${r.name} ▸`
-  if (row.id === "source") return src ? src.replace(process.env.HOME ?? "", "~") : "(none — Enter to attach)"
-  if (row.id === "fork") return s.per[s.state] ? "(forked)" : "▸ copy base → " + s.state
+  if (row.id === "rasterizer") {
+    const a = r.available()
+    if (a === true) return `${r.name} ▸`
+    return <><span>{`${r.name} ▸`}</span><span fg={theme.warning}>{` ⚠ ${a}`}</span></>
+  }
+  if (row.id === "source") {
+    if (!src) return "(none — Enter to attach)"
+    const d = s.dims
+    const sz = (() => { try { return mb(statSync(src).size) } catch { return "?" } })()
+    return d ? `${basename(src)} · ${d.w}×${d.h} · ${sz}` : `${basename(src)} · ${sz}`
+  }
+  if (row.id === "knobsfor") {
+    const forked = !!s.per[s.state]
+    return `◂ ${forked ? `${s.state} only` : "all states"} ▸`
+  }
   if (row.id === "reset") return "▸ defaults"
   if (row.id === "revert") return "▸ reload from disk"
   if (row.id === "fetch") return busy ? "fetching…"
@@ -290,7 +304,7 @@ function KnobRow(props: {
         {props.busy && row.id === "fetch"
           ? <Spinner color={theme.accent} label="fetching…" />
           : <text fg={dim ? theme.textMuted : theme.text}>
-              {valueOf(props.s, props.r, row, props.src, props.peek, props.busy)}
+              {valueOf(props.s, props.r, row, theme, props.src, props.peek, props.busy)}
             </text>}
       </box>
     </box>
@@ -329,9 +343,8 @@ function Strip(props: {
                 : f ? f.map((ln, i) => <text key={i} fg={on ? theme.text : theme.textMuted}>{ln}</text>)
                 : <text fg={theme.textMuted}>+</text>}
             </box>
-            <box height={1}><text fg={on ? theme.accent : theme.textMuted}>
-              {`${own ? "*" : " "}${has ? "📎" : " "}${st}`}
-            </text></box>
+            <box height={1}><text fg={on ? theme.accent : theme.textMuted}>{st}</text></box>
+            <box height={1}><text fg={theme.textMuted}>{has ? "own src" : own ? "forked" : ""}</text></box>
           </box>
         )
       })}
@@ -810,7 +823,7 @@ export const EikonStudio = memo((props: {
 
   const doAction = async (id: string) => {
     if (!s) return
-    if (id === "fork") return mutate(knobs.fork)
+    if (id === "knobsfor") return mutate(p => p.per[p.state] ? knobs.unfork(p) : knobs.fork(p))
     if (id === "revert") { void discard(); return }
     if (id === "reset") {
       const ok = await openConfirm(dialog, { title: "Reset knobs?", body: "Restore rasterizer defaults and drop all per-state overrides.", danger: true })
@@ -879,7 +892,9 @@ export const EikonStudio = memo((props: {
   const toggle   = () => act(navRows[selRef.current], "space")
   const adjust = (d: 1 | -1) => {
     const row = navRows[selRef.current]
-    if (row) stepRow(row, d)
+    if (!row) return
+    if (row.id === "knobsfor") return void doAction("knobsfor")
+    stepRow(row, d)
   }
 
   const discard = async () => {
@@ -967,7 +982,7 @@ export const EikonStudio = memo((props: {
 
   const hint: Array<readonly [string, string]> =
     !s                   ? [["Enter", "new eikon"], ["Shift+→", "gallery"]]
-  : pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "open"], [keys.print("list.new"), "new"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
+  : pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "edit"], [keys.print("list.new"), "new"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
   : pane === "preview" ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.toggle"), "play/pause"], ["wheel", "zoom"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
   :                      [["←→", "state"], [keys.print("list.activate"), "actions"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
 
@@ -994,6 +1009,9 @@ export const EikonStudio = memo((props: {
   const preview = (
     <TabShell title={spatialOk ? title : `${title}  ·  (ffmpeg not installed)`}
               error={previewErr} focus={pane === "preview"}>
+      {!live && baked
+        ? <box height={1}><text fg={theme.textMuted}>Viewing baked output — fetch or attach a source to edit.</text></box>
+        : null}
       {spatialOk && live && s
         ? <>
             <PanBars sp={s.spatial} sel={spSel} focused={pane === "preview"}
@@ -1034,10 +1052,10 @@ export const EikonStudio = memo((props: {
     </TabShell>
   )
 
-  // Strip cell = 10 (bordered thumb) + 1 (label). TabShell chrome =
+  // Strip cell = 10 (bordered thumb) + 2 (label lines). TabShell chrome =
   // border(2) + padding(2) + title(1) + gap(1). flexBasis=0 on TabShell
   // would collapse it in a column, so pin the wrapper height.
-  const STRIP_H = 17
+  const STRIP_H = 18
   const strip = s ? (
     <box id="studio-strip" flexShrink={0} height={STRIP_H}>
       <TabShell title="States" focus={pane === "strip"}>

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -27,7 +27,9 @@ import { DialogSelect } from "../ui/dialog-select"
 import { openConfirm } from "../dialogs/confirm"
 import { openTextPrompt } from "../dialogs/text-prompt"
 import { openPathPrompt } from "../dialogs/path-prompt"
+import { openGenerate, type GenerateKind } from "../dialogs/eikon-generate"
 import { useGateway } from "../context/gateway"
+import type { Gateway } from "../context/gateway"
 import * as prefs from "../context/preferences"
 import { eikon } from "../service/eikon"
 import type { ParsedEikon } from "../components/avatar/eikon"
@@ -35,6 +37,7 @@ import { W, H, FPS0, caps, thumb, cached, resetCache, prewarm,
          type Rasterizer, type KnobDef, type Spatial, type Frame } from "../utils/eikon-render"
 import { knobs, STATES, type Session } from "../utils/eikon-knobs"
 import type { AvatarState } from "../components/avatar/states"
+import { useSpinnerGlyph } from "../ui/spinner"
 
 // SliderRenderable ships in @opentui/core but isn't in react's default
 // catalogue; register it once so `<slider>` is a valid intrinsic.
@@ -292,10 +295,12 @@ function KnobRow(props: {
 
 function Strip(props: {
   s: Session; frames: Map<AvatarState, Frame | undefined>
+  pending: ReadonlySet<AvatarState>
   focused: boolean; onPick: (st: AvatarState) => void
   onEmpty?: (st: AvatarState) => void
 }) {
   const theme = useTheme().theme
+  const glyph = useSpinnerGlyph(props.pending.size > 0)
   return (
     <box flexDirection="row" gap={1}>
       {STATES.map(st => {
@@ -303,7 +308,8 @@ function Strip(props: {
         const own = !!props.s.per[st]
         const has = !!props.s.sources[st]
         const f = props.frames.get(st)
-        const empty = !f
+        const gen = props.pending.has(st)
+        const empty = !f && !gen
         return (
           <box key={st} flexDirection="column" alignItems="center"
                onMouseDown={() => {
@@ -313,8 +319,9 @@ function Strip(props: {
             <box border borderStyle="rounded"
                  borderColor={on && props.focused ? theme.primary : on ? theme.accent : theme.border}
                  width={18} height={10} overflow="hidden" alignItems="center" justifyContent="center">
-              {f ? f.map((ln, i) => <text key={i} fg={on ? theme.text : theme.textMuted}>{ln}</text>)
-                 : <text fg={theme.textMuted}>+</text>}
+              {gen ? <text fg={theme.accent}>{`${glyph} gen`}</text>
+                : f ? f.map((ln, i) => <text key={i} fg={on ? theme.text : theme.textMuted}>{ln}</text>)
+                : <text fg={theme.textMuted}>+</text>}
             </box>
             <box height={1}><text fg={on ? theme.accent : theme.textMuted}>
               {`${own ? "*" : " "}${has ? "📎" : " "}${st}`}
@@ -329,6 +336,21 @@ function Strip(props: {
 // ── Main ─────────────────────────────────────────────────────────────
 
 const BLANK: Frame = Array.from({ length: H }, () => " ".repeat(W))
+
+// One-shot toolset probe — `toolsets.list` is server state, not session
+// state, so the result is process-stable until the agent restarts. Cache
+// the Promise so concurrent opens share the round trip; reset on null
+// gateway (test reseed). The set holds enabled toolset names.
+let toolsetsCache: Promise<Set<string>> | null = null
+const probeToolsets = (gw: Gateway): Promise<Set<string>> => {
+  if (toolsetsCache) return toolsetsCache
+  toolsetsCache = gw.request<{ toolsets?: Array<{ name: string; enabled?: boolean }> }>("toolsets.list", {})
+    .then(r => new Set((r.toolsets ?? []).filter(t => t.enabled !== false).map(t => t.name)))
+    .catch(() => new Set<string>())
+  return toolsetsCache
+}
+/** Test-only — wipe the toolset cache between mountNode calls. */
+export const resetToolsetsCache = () => { toolsetsCache = null }
 
 export const EikonStudio = memo((props: {
   focused: boolean
@@ -365,6 +387,8 @@ export const EikonStudio = memo((props: {
   const [peek, setPeek] = useState<{ n: number; bytes: number } | undefined>(undefined)
   const [thumbs, setThumbs] = useState<Map<AvatarState, Frame | undefined>>(new Map())
   const [err, setErr] = useState<string | null>(null)
+  const [pending, setPending] = useState<ReadonlySet<AvatarState>>(new Set())
+  const [tools, setTools] = useState<Set<string> | null>(null)
   const frame = frames[tick % frames.length] ?? BLANK
 
   const r = useMemo(() => eikon.pick(s?.rasterizer ?? prefs.get("eikonRasterizer")), [s?.rasterizer])
@@ -402,6 +426,15 @@ export const EikonStudio = memo((props: {
   }, [open, props.name])
 
   useEffect(() => { if (props.name !== undefined) open(props.name || knobs.slug("new")) }, [props.name, open])
+
+  // Probe enabled toolsets once per process so the source menu can hide
+  // Generate rows when image_gen/video_gen aren't on. Cached at module
+  // scope — repeated mounts share one round trip.
+  useEffect(() => {
+    let dead = false
+    void probeToolsets(gw).then(s => { if (!dead) setTools(s) })
+    return () => { dead = true }
+  }, [gw])
 
   const src = useMemo(() => (s ? eikon.findSource(s.name, s.state) : undefined), [s?.name, s?.state, s?.sources])
   const live = useMemo(() => !!(s && eikon.findSource(s.name)), [s?.name, s?.sources])
@@ -545,11 +578,40 @@ export const EikonStudio = memo((props: {
     )
   }
 
+  const runGenerate = async (st: AvatarState, kind: GenerateKind) => {
+    if (!s) return
+    const seed = s.sources.base ? eikon.findSource(s.name) : undefined
+    setPending(prev => { const n = new Set(prev); n.add(st); return n })
+    const out = await openGenerate(dialog, gw, {
+      state: st, kind, seed, lastPrompt: s.prompts?.[st],
+    })
+    if (!out) {
+      setPending(prev => { const n = new Set(prev); n.delete(st); return n })
+      return
+    }
+    const role = st === "idle" && !s.sources.base ? "base" : st
+    try {
+      const f = eikon.adopt(s.name, out.path, role)
+      mutate(p => ({
+        ...p,
+        sources: { ...p.sources, [role]: f },
+        prompts: { ...p.prompts, [st]: out.prompt },
+        dirty: true,
+      }))
+    } catch (e) {
+      toast.error(e instanceof Error ? e : new Error(String(e)))
+    } finally {
+      setPending(prev => { const n = new Set(prev); n.delete(st); return n })
+    }
+  }
+
   const doSource = (forSt?: AvatarState) => {
     if (!s) return
     const st = forSt ?? s.state
     const has = !!s.sources[st]
     const opts: Array<{ title: string; value: string }> = [{ title: "Local file…", value: "local" }]
+    if (tools?.has("image_gen")) opts.push({ title: "Generate image…", value: "gen-image" })
+    if (tools?.has("video_gen")) opts.push({ title: "Generate video…", value: "gen-video" })
     if (has && st !== "idle") opts.push({ title: "Same as base", value: "same" })
     if (has) opts.push({ title: "Remove", value: "remove" })
     dialog.replace(
@@ -567,6 +629,8 @@ export const EikonStudio = memo((props: {
             catch (e) { toast.error(e instanceof Error ? e : new Error(String(e))) }
             return
           }
+          if (o.value === "gen-image") return void runGenerate(st, "image")
+          if (o.value === "gen-video") return void runGenerate(st, "video")
           dialog.clear()
           mutate(prev => {
             const next = { ...prev.sources }
@@ -814,7 +878,7 @@ export const EikonStudio = memo((props: {
   const strip = s ? (
     <box id="studio-strip" flexShrink={0} height={STRIP_H}>
       <TabShell title="States" focus={pane === "strip"}>
-        <Strip s={s} frames={thumbs} focused={pane === "strip"}
+        <Strip s={s} frames={thumbs} pending={pending} focused={pane === "strip"}
                onPick={st => { setPane("strip"); mutate(p => knobs.setState(p, st)) }}
                onEmpty={st => doSource(st)} />
       </TabShell>

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -55,6 +55,9 @@ declare module "@opentui/react" {
 
 type Pane = "knobs" | "preview" | "strip"
 const PANES: readonly Pane[] = ["knobs", "preview", "strip"]
+// Help footer rows (fixed so the narrow layout can size the panel
+// exactly — no scrollbar unless row count actually overflows).
+const HELP_H = 3
 // Stable contentOptions — inline `{}` would re-set on every reconcile.
 const COL = { flexDirection: "column" } as const
 
@@ -1077,7 +1080,7 @@ export const EikonStudio = memo((props: {
                 )
               })}
             </scrollbox>
-            <box flexShrink={0} minHeight={2} marginTop={1} overflow="hidden">
+            <box flexShrink={0} height={HELP_H} marginTop={1} overflow="hidden">
               <text fg={theme.textMuted} wrapMode="word">{help}</text>
             </box>
           </>}
@@ -1111,7 +1114,8 @@ export const EikonStudio = memo((props: {
   ) : (
     <>
       <box id="studio-preview" flexShrink={0} height={PREVIEW_H}>{preview}</box>
-      <box id="studio-knobs" flexShrink={0} height={Math.max(rows.length, 1) + 6}>{panel}</box>
+      <box id="studio-knobs" flexShrink={0}
+           height={Math.max(rows.length, 1) + HELP_H + 1 + 6}>{panel}</box>
     </>
   )
   return (

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -262,7 +262,7 @@ function KnobRow(props: {
          backgroundColor={on ? theme.backgroundElement : undefined}
          onMouseMove={props.onHover} onMouseDown={props.onClick}>
       <box width={2}><text fg={on ? theme.primary : theme.textMuted}>{on ? "▸ " : "  "}</text></box>
-      <box width={12}><text fg={dim ? theme.textMuted : on ? theme.text : theme.textMuted}>{row.label}</text></box>
+      <box width={14}><text fg={dim ? theme.textMuted : on ? theme.text : theme.textMuted}>{row.label}</text></box>
       {slider ? (
         <>
           <box width={20} height={1}>
@@ -393,7 +393,20 @@ export const EikonStudio = memo((props: {
     if (n) open(n)
   }, [open, props.name])
 
-  useEffect(() => { if (props.name !== undefined) open(props.name || knobs.slug("new")) }, [props.name, open])
+  const dialogRef = useRef(dialog); dialogRef.current = dialog
+  useEffect(() => {
+    if (props.name === undefined) return
+    const next = props.name || knobs.slug("new")
+    const cur = sRef.current
+    if (cur?.name === next) return
+    if (!cur?.dirty) return open(next)
+    let dead = false
+    void openConfirm(dialogRef.current, {
+      title: "Discard unsaved edits?", danger: true,
+      body: `Switch to '${next}' and drop in-memory changes to '${cur.name}'.`,
+    }).then(ok => { if (!dead && ok) open(next) })
+    return () => { dead = true }
+  }, [props.name, open])
 
   const src = useMemo(() => (s ? eikon.findSource(s.name, s.state) : undefined), [s?.name, s?.state, s?.sources])
   const live = useMemo(() => !!(s && eikon.findSource(s.name)), [s?.name, s?.sources])
@@ -509,6 +522,7 @@ export const EikonStudio = memo((props: {
   // Knob-row actions.
   const doSave = useCallback(async () => {
     if (!s) return
+    if (!s.dirty) return toast.show({ variant: "info", message: "Nothing to save" })
     if (!live) return toast.show({ variant: "warning",
       message: "No source — fetch or attach before saving" })
     await eikon.save({ ...s, dirty: false })
@@ -647,7 +661,7 @@ export const EikonStudio = memo((props: {
       return
     }
     if (!s) {
-      if (key.name === "return") return void doPrompt("source")
+      if (key.name === "return") return open(knobs.slug("new"))
       return
     }
     if (pane === "knobs") {
@@ -706,7 +720,8 @@ export const EikonStudio = memo((props: {
     :       "no source — Enter on 'source' to attach")
 
   const hint: Array<readonly [string, string]> =
-    pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "open"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
+    !s                   ? [["Enter", "new eikon"], ["Shift+→", "gallery"]]
+  : pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "open"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
   : pane === "preview" ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.toggle"), "play/pause"], ["wheel", "zoom"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
   :                      [["←→", "state"], [keys.print("list.activate"), "actions"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
 

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -56,8 +56,8 @@ declare module "@opentui/react" {
 type Pane = "knobs" | "preview" | "strip"
 const PANES: readonly Pane[] = ["knobs", "preview", "strip"]
 // Help footer rows (fixed so the narrow layout can size the panel
-// exactly — no scrollbar unless row count actually overflows).
-const HELP_H = 3
+// deterministically without measuring post-wrap).
+const HELP_H = 4
 // Stable contentOptions — inline `{}` would re-set on every reconcile.
 const COL = { flexDirection: "column" } as const
 
@@ -103,7 +103,7 @@ const HEAD: readonly Row[] = [
 const HELP: Readonly<Record<string, string>> = {
   open:       "Which eikon you're editing. Enter to switch, create a new one, or install from elsewhere.",
   rasterizer: "The engine that turns your source image/video into text art. Each rasterizer exposes its own look-and-feel settings below the divider.",
-  source:     "The image or video file the avatar is rendered from. Enter to pick a local file, generate one with AI, or clear it. Each state can have its own source.",
+  source:     "The image or video file the avatar is rendered from. Enter to pick, generate, or clear.",
   fetch:      "Download this eikon's published source media so you can re-tune it locally.",
   knobsfor:   "←→ toggles whether the settings below apply to every state or just the one selected in the strip.",
   reset:      "Restore every setting below to this rasterizer's defaults and drop per-state overrides.",
@@ -112,8 +112,12 @@ const HELP: Readonly<Record<string, string>> = {
 
 const FLIPS: readonly Flip[] = ["none", "h", "v", "hv"]
 
-function helpOf(row: Row | undefined): string {
+function helpOf(row: Row | undefined): ReactNode {
   if (!row) return ""
+  if (row.id === "source") return <>
+    <span>{HELP.source} </span>
+    <strong>Use /eikon-create to generate source files interactively (recommended).</strong>
+  </>
   const head = HELP[row.id]
   if (head) return head
   if (!row.knob) return ""

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -739,12 +739,6 @@ export const EikonStudio = memo((props: {
     await apply(res)
   }, [dialog, apply])
 
-  const doRename = useCallback(async () => {
-    if (!sRef.current) return
-    const res = await openNewEikon(dialog, { initial: sRef.current.name })
-    await apply(res)
-  }, [dialog, apply])
-
   // Installed-folder eikons take precedence over bundled flat-file
   // duplicates by slug; trailers are appended in doOpen.
   const eikonOptions = useCallback(() => {
@@ -758,10 +752,13 @@ export const EikonStudio = memo((props: {
       .map(e => {
         const slug = e.meta.name.toLowerCase()
         return { title: e.meta.name, value: slug, category: "bundled",
-                 hint: `${e.meta.states.length}st · ${e.meta.width}×${e.meta.height}` }
+                 hint: `${e.meta.width}×${e.meta.height}` }
       })
       .filter(o => !seen.has(o.value))
-    return [...installed, ...bundled]
+    // Folders with no .eikon yet (fresh `ensure()`d) — list() skips them.
+    const raw = eikon.raw().filter(n => !seen.has(n)).map(n =>
+      ({ title: n, value: n, category: "installed", hint: "(unsaved)" }))
+    return [...installed, ...raw, ...bundled]
   }, [])
 
   const doInstall = useCallback(async () => {
@@ -788,23 +785,6 @@ export const EikonStudio = memo((props: {
     ]
     dialog.replace(
       <DialogSelect title="Open eikon" current={cur?.name} options={opts}
-        footer={
-          cur ? (
-            <box height={1} flexDirection="row" onMouseDown={() => { dialog.clear(); void doRename() }}>
-              <text fg={theme.textMuted}>{"r: rename '"}</text>
-              <text fg={theme.accent}>{cur.name}</text>
-              <text fg={theme.textMuted}>{"'"}</text>
-            </box>
-          ) : undefined
-        }
-        onKey={(key: ParsedKey) => {
-          if (cur && key.name === "r" && !key.ctrl && !key.meta && !key.shift) {
-            dialog.clear()
-            void doRename()
-            return true
-          }
-          return false
-        }}
         onSelect={o => {
           dialog.clear()
           if (o.value === "__new") return void doNew()
@@ -813,7 +793,7 @@ export const EikonStudio = memo((props: {
         }} />,
       () => {},
     )
-  }, [dialog, eikonOptions, switchTo, doNew, doInstall, doRename, theme])
+  }, [dialog, eikonOptions, switchTo, doNew, doInstall])
 
   const doAction = async (id: string) => {
     if (!s) return
@@ -1004,7 +984,9 @@ export const EikonStudio = memo((props: {
     <TabShell title={spatialOk ? title : `${title}  ·  (ffmpeg not installed)`}
               error={previewErr} focus={pane === "preview"}>
       {!live && baked
-        ? <box height={1}><text fg={theme.textMuted}>Viewing baked output — fetch or attach a source to edit.</text></box>
+        ? <box height={1} overflow="hidden">
+            <text fg={theme.textMuted} wrapMode="none">Baked — fetch or attach a source to edit.</text>
+          </box>
         : null}
       {spatialOk && live && s
         ? <>

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -87,6 +87,9 @@ const HEAD: readonly Row[] = [
   { id: "contrast",   kind: "tone",    label: "contrast",   show: (_s, live) => live,
     knob: { kind: "slider", min: 0.25, max: 4, step: 0.05, default: 1,
             hint: "Spread pixel values around their mean. ×1 = source as-is; higher sharpens, lower flattens. Applied to the image before rasterizing." } },
+  { id: "invert",     kind: "tone",    label: "invert",     show: (_s, live) => live,
+    knob: { kind: "toggle", default: true,
+            hint: "Swap light↔dark in the source pixels. On for a light subject on a dark terminal background — turn off if the subject is darker than its surround." } },
   { id: "flip",       kind: "tone",    label: "flip",       show: (_s, live) => live,
     knob: { kind: "cycle", options: ["none", "h", "v", "hv"], default: "none",
             hint: "Mirror the source horizontally, vertically, or both before rasterizing." } },
@@ -306,6 +309,7 @@ function valueOf(s: Session, r: Rasterizer, row: Row, theme: Theme,
   if (row.id === "revert") return "▸ reload from disk"
   if (row.kind === "tone") {
     if (row.id === "contrast") return `×${s.tone.contrast.toFixed(2)}`
+    if (row.id === "invert") return s.tone.invert ? "● on" : "○ off"
     if (row.id === "flip") return `◂ ${s.tone.flip} ▸`
   }
   if (row.id === "fetch") return busy ? "fetching…"
@@ -924,6 +928,7 @@ export const EikonStudio = memo((props: {
         const cur = sRef.current?.tone.contrast ?? 1
         return setTone({ contrast: +Math.max(def.min, Math.min(def.max, cur + d * def.step)).toFixed(2) })
       }
+      if (row.id === "invert") return setTone({ invert: !sRef.current?.tone.invert })
       if (row.id === "flip") {
         const cur = sRef.current?.tone.flip ?? "none"
         const i = FLIPS.indexOf(cur)

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -44,6 +44,7 @@ import { W, H, FPS0, caps, thumb, cached, resetCache, prewarm,
 import { knobs, STATES, type Session } from "../utils/eikon-knobs"
 import type { AvatarState } from "../components/avatar/states"
 import { useSpinnerGlyph } from "../ui/spinner"
+import type { MouseEvent } from "@opentui/core"
 
 // SliderRenderable ships in @opentui/core but isn't in react's default
 // catalogue; register it once so `<slider>` is a valid intrinsic.
@@ -80,6 +81,32 @@ const HEAD: readonly Row[] = [
   { id: "revert",     kind: "action", label: "revert",      show: s => s.dirty },
   { id: "-2",         kind: "divider", label: "", show: (_s, live) => live },
 ]
+
+// One-sentence help per row, shown at the bottom of the Settings
+// pane when the row is selected/hovered. Rasterizer-declared knobs
+// fall through to helpOf() which reads KnobDef.hint or synthesizes
+// one from the knob kind.
+const HELP: Readonly<Record<string, string>> = {
+  open:       "Which eikon you're editing. Enter to switch, create a new one, or install from elsewhere.",
+  rasterizer: "The engine that turns your source image/video into text art. Each rasterizer exposes its own look-and-feel knobs below the divider.",
+  source:     "The image or video file the avatar is rendered from. Enter to pick a local file, generate one with AI, or clear it. Each state can have its own source.",
+  fetch:      "Download this eikon's published source media so you can re-tune it locally.",
+  knobsfor:   "←→ toggles whether the knobs below apply to every state or just the one selected in the strip.",
+  reset:      "Restore every knob to this rasterizer's defaults and drop per-state overrides.",
+  revert:     "Throw away unsaved edits and reload this eikon from disk.",
+}
+
+function helpOf(row: Row | undefined): string {
+  if (!row) return ""
+  const head = HELP[row.id]
+  if (head) return head
+  if (row.kind !== "knob" || !row.knob) return ""
+  if (row.knob.hint) return row.knob.hint
+  if (row.knob.kind === "cycle")
+    return `←→ or Enter cycles: ${row.knob.options.join(" · ")}.`
+  if (row.knob.kind === "toggle") return "Space or Enter toggles on/off."
+  return `←→ or drag adjusts (${row.knob.min}–${row.knob.max}); scroll while selected also works.`
+}
 
 function buildRows(r: Rasterizer, s: Session, live: boolean, url?: string): Row[] {
   const dyn = live
@@ -145,7 +172,8 @@ function PanBars(props: {
   const slack = 1 - z
   const on = (i: number) => props.focused && props.sel === i
   const fg = (i: number) => on(i) ? theme.accent : theme.textMuted
-  const wheel = (k: SpKey) => (e: { scroll?: { direction: string } }) => {
+  const wheel = (k: SpKey) => (e: MouseEvent) => {
+    e.stopPropagation()
     const d = e.scroll?.direction
     if (d === "up" || d === "left") props.onWheel(k, -1)
     if (d === "down" || d === "right") props.onWheel(k, 1)
@@ -202,7 +230,8 @@ function SpatialBar(props: {
     { label: "zoom", k: "zoom", min: 0.1, max: 1.0, v: props.sp.zoom, i: 2 },
     { label: "fps",  k: "fps",  min: 4,   max: 30,  v: props.fps,     i: 3 },
   ]
-  const wheel = (k: SpKey) => (e: { scroll?: { direction: string } }) => {
+  const wheel = (k: SpKey) => (e: MouseEvent) => {
+    e.stopPropagation()
     const d = e.scroll?.direction
     if (d === "up") props.onWheel(k, -1)
     if (d === "down") props.onWheel(k, 1)
@@ -276,16 +305,28 @@ function KnobRow(props: {
   peek?: { n: number; bytes: number }; busy?: boolean
   onHover: () => void; onClick: () => void
   onSlide?: (v: number) => void
+  onWheel?: (d: 1 | -1) => void
 }) {
   const theme = useTheme().theme
   const { row, on, dim } = props
   if (row.kind === "divider")
     return <box id={props.id} height={1}><text fg={theme.border}>{"─".repeat(24)}</text></box>
   const slider = row.knob?.kind === "slider" ? row.knob : undefined
+  // Wheel over the selected slider row adjusts it and stops bubbling
+  // so the enclosing scrollboxes don't also move. Unselected / non-
+  // slider rows let the event through for normal list scrolling.
+  const scroll = (e: MouseEvent) => {
+    if (!on || !slider || !props.onWheel) return
+    e.stopPropagation()
+    const d = e.scroll?.direction
+    if (d === "up" || d === "left") props.onWheel(-1)
+    if (d === "down" || d === "right") props.onWheel(1)
+  }
   return (
     <box id={props.id} height={1} flexDirection="row"
          backgroundColor={on ? theme.backgroundElement : undefined}
-         onMouseMove={props.onHover} onMouseDown={props.onClick}>
+         onMouseMove={props.onHover} onMouseDown={props.onClick}
+         onMouseScroll={scroll}>
       <box width={2}><text fg={on ? theme.primary : theme.textMuted}>{on ? "▸ " : "  "}</text></box>
       <box width={14}><text fg={dim ? theme.textMuted : on ? theme.text : theme.textMuted}>{row.label}</text></box>
       {slider ? (
@@ -936,12 +977,20 @@ export const EikonStudio = memo((props: {
     if (key.name === "return") return doStripMenu()
   })
 
-  // Preview mouse: wheel-zoom only (drag-pan removed — sliders cover it).
-  const onScroll = (e: { scroll?: { direction: string } }) => {
+  // Preview wheel: pan-y by default; +Shift → pan-x; +Ctrl → zoom.
+  // Always swallowed so the outer scrollbox never moves while the
+  // pointer is over the frame.
+  const onScroll = (e: MouseEvent) => {
+    e.stopPropagation()
     if (!spatialOk || !live || !e.scroll) return
     const d = e.scroll.direction
     if (d !== "up" && d !== "down") return
-    mutate(p => ({ ...p, spatial: knobs.zoom(p.spatial, d === "up" ? -1 : 1), dirty: true }))
+    const sign = d === "up" ? -1 : 1
+    if (e.modifiers.ctrl)
+      return mutate(p => ({ ...p, spatial: knobs.zoom(p.spatial, sign), dirty: true }))
+    if (e.modifiers.shift)
+      return mutate(p => ({ ...p, spatial: knobs.pan(p.spatial, sign, 0), dirty: true }))
+    mutate(p => ({ ...p, spatial: knobs.pan(p.spatial, 0, sign), dirty: true }))
   }
 
   const n = frames.length
@@ -957,7 +1006,7 @@ export const EikonStudio = memo((props: {
   const hint: Array<readonly [string, string]> =
     !s                   ? [["Enter", "new eikon"], ["Shift+→", "gallery"]]
   : pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "edit"], [keys.print("list.new"), "new"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
-  : pane === "preview" ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.toggle"), "play/pause"], ["wheel", "zoom"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
+  : pane === "preview" ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.toggle"), "play/pause"], ["wheel", "pan"], ["Ctrl+wheel", "zoom"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
   :                      [["←→", "state"], [keys.print("list.activate"), "actions"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
 
   // TabShell chrome = border(2) + padding(2) + title(1) + gap(1).
@@ -1003,28 +1052,35 @@ export const EikonStudio = memo((props: {
     </TabShell>
   )
 
+  const help = helpOf(navRows[sel])
   const panel = (
-    <TabShell title={s ? `Knobs — ${s.name}` : "Knobs"} focus={pane === "knobs"} grow={1}>
+    <TabShell title={s ? `Settings — ${s.name}` : "Settings"} focus={pane === "knobs"} grow={1}>
       {!s
         ? <box flexGrow={1} alignItems="center" justifyContent="center">
             <text fg={theme.textMuted}>No eikon open. Enter to create or pick one.</text>
           </box>
-        : <scrollbox ref={ksb} scrollY flexGrow={1} contentOptions={COL}>
-            {rows.map((row, i) => {
-              const ni = navRows.findIndex(x => x.i === i)
-              const on = pane === "knobs" && ni === sel
-              const dim = row.kind === "knob" && !src
-              return (
-                <KnobRow key={`${r.name}:${row.id}`} id={`knob-${row.id}`} row={row} s={s} r={r} src={src}
-                         on={on} dim={dim} peek={peek} busy={row.id === "fetch" && fetching}
-                         onHover={() => { if (ni >= 0) { setPane("knobs"); setSelBy(ni) } }}
-                         onClick={() => { if (ni >= 0) { setSelBy(ni); setPane("knobs"); act(row, "click") } }}
-                         onSlide={row.knob?.kind === "slider"
-                           ? v => mutate(p => knobs.edit(p, k => knobs.setSlider(k, row.id, row.knob!, v)))
-                           : undefined} />
-              )
-            })}
-          </scrollbox>}
+        : <>
+            <scrollbox ref={ksb} scrollY flexGrow={1} contentOptions={COL}>
+              {rows.map((row, i) => {
+                const ni = navRows.findIndex(x => x.i === i)
+                const on = pane === "knobs" && ni === sel
+                const dim = row.kind === "knob" && !src
+                return (
+                  <KnobRow key={`${r.name}:${row.id}`} id={`knob-${row.id}`} row={row} s={s} r={r} src={src}
+                           on={on} dim={dim} peek={peek} busy={row.id === "fetch" && fetching}
+                           onHover={() => { if (ni >= 0) { setPane("knobs"); setSelBy(ni) } }}
+                           onClick={() => { if (ni >= 0) { setSelBy(ni); setPane("knobs"); act(row, "click") } }}
+                           onWheel={d => stepRow(row, d)}
+                           onSlide={row.knob?.kind === "slider"
+                             ? v => mutate(p => knobs.edit(p, k => knobs.setSlider(k, row.id, row.knob!, v)))
+                             : undefined} />
+                )
+              })}
+            </scrollbox>
+            <box flexShrink={0} minHeight={2} marginTop={1} overflow="hidden">
+              <text fg={theme.textMuted} wrapMode="word">{help}</text>
+            </box>
+          </>}
     </TabShell>
   )
 

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -39,8 +39,8 @@ import { listEikons } from "../components/avatar/eikon"
 import * as prefs from "../context/preferences"
 import { eikon } from "../service/eikon"
 import type { ParsedEikon } from "../components/avatar/eikon"
-import { W, H, FPS0, caps, thumb, cached, resetCache, prewarm,
-         type Rasterizer, type KnobDef, type Spatial, type Frame } from "../utils/eikon-render"
+import { W, H, FPS0, caps, thumb, cached, resetCache, prewarm, T0,
+         type Rasterizer, type KnobDef, type Spatial, type Tone, type Flip, type Frame } from "../utils/eikon-render"
 import { knobs, STATES, type Session } from "../utils/eikon-knobs"
 import type { AvatarState } from "../components/avatar/states"
 import { useSpinnerGlyph } from "../ui/spinner"
@@ -61,7 +61,7 @@ const HELP_H = 3
 // Stable contentOptions — inline `{}` would re-set on every reconcile.
 const COL = { flexDirection: "column" } as const
 
-type RowKind = "select" | "prompt" | "action" | "divider" | "knob"
+type RowKind = "select" | "prompt" | "action" | "divider" | "header" | "knob" | "tone"
 type Row = {
   id: string; kind: RowKind; label: string
   knob?: KnobDef
@@ -83,6 +83,14 @@ const HEAD: readonly Row[] = [
   { id: "reset",      kind: "action", label: "reset",       show: (_s, live) => live },
   { id: "revert",     kind: "action", label: "revert",      show: s => s.dirty },
   { id: "-2",         kind: "divider", label: "", show: (_s, live) => live },
+  { id: "h-input",    kind: "header",  label: "input", show: (_s, live) => live },
+  { id: "contrast",   kind: "tone",    label: "contrast",   show: (_s, live) => live,
+    knob: { kind: "slider", min: 0.25, max: 4, step: 0.05, default: 1,
+            hint: "Spread pixel values around their mean. ×1 = source as-is; higher sharpens, lower flattens. Applied to the image before rasterizing." } },
+  { id: "flip",       kind: "tone",    label: "flip",       show: (_s, live) => live,
+    knob: { kind: "cycle", options: ["none", "h", "v", "hv"], default: "none",
+            hint: "Mirror the source horizontally, vertically, or both before rasterizing." } },
+  { id: "-3",         kind: "divider", label: "", show: (_s, live) => live },
 ]
 
 // One-sentence help per row, shown at the bottom of the Settings
@@ -99,11 +107,13 @@ const HELP: Readonly<Record<string, string>> = {
   revert:     "Throw away unsaved edits and reload this eikon from disk.",
 }
 
+const FLIPS: readonly Flip[] = ["none", "h", "v", "hv"]
+
 function helpOf(row: Row | undefined): string {
   if (!row) return ""
   const head = HELP[row.id]
   if (head) return head
-  if (row.kind !== "knob" || !row.knob) return ""
+  if (!row.knob) return ""
   if (row.knob.hint) return row.knob.hint
   if (row.knob.kind === "cycle")
     return `←→ or Enter cycles: ${row.knob.options.join(" · ")}.`
@@ -116,7 +126,10 @@ function buildRows(r: Rasterizer, s: Session, live: boolean, url?: string): Row[
     ? Object.entries(r.knobs).map<Row>(([id, def]) =>
         ({ id, kind: "knob", label: def.label ?? id, knob: def }))
     : []
-  return [...HEAD.filter(h => h.show ? h.show(s, live, url) : true), ...dyn]
+  const head = HEAD.filter(h => h.show ? h.show(s, live, url) : true)
+  return dyn.length
+    ? [...head, { id: "h-r", kind: "header", label: r.name }, ...dyn]
+    : head
 }
 
 // ── Minimap (read-only) ──────────────────────────────────────────────
@@ -291,6 +304,10 @@ function valueOf(s: Session, r: Rasterizer, row: Row, theme: Theme,
   }
   if (row.id === "reset") return "▸ defaults"
   if (row.id === "revert") return "▸ reload from disk"
+  if (row.kind === "tone") {
+    if (row.id === "contrast") return `×${s.tone.contrast.toFixed(2)}`
+    if (row.id === "flip") return `◂ ${s.tone.flip} ▸`
+  }
   if (row.id === "fetch") return busy ? "fetching…"
     : peek ? `▸ download to edit  (${peek.n} files, ${mb(peek.bytes)})` : "▸ download to edit"
   if (row.kind === "knob" && row.knob) {
@@ -312,9 +329,21 @@ function KnobRow(props: {
 }) {
   const theme = useTheme().theme
   const { row, on, dim } = props
+  const slider = row.knob?.kind === "slider" ? row.knob : undefined
+  const sval = !slider ? 0
+    : row.kind === "tone" ? props.s.tone.contrast
+    : Number(knobs.eff(props.s, props.s.state)[row.id] ?? slider.default)
+  // SliderRenderable's `value` setter fires onChange, so a prop
+  // update driven by open()/revert()/reset() echoes straight back
+  // into onSlide and re-dirties the just-cleaned session. Track the
+  // value we last pushed *to* the slider and drop onChange calls
+  // that are just that echo.
+  const pushed = useRef(sval); pushed.current = sval
+  const slide = (v: number) => { if (v !== pushed.current) props.onSlide?.(v) }
   if (row.kind === "divider")
     return <box id={props.id} height={1}><text fg={theme.border}>{"─".repeat(24)}</text></box>
-  const slider = row.knob?.kind === "slider" ? row.knob : undefined
+  if (row.kind === "header")
+    return <box id={props.id} height={1}><text fg={theme.textMuted}><u>{row.label}</u></text></box>
   // Wheel over the selected slider row adjusts it and stops bubbling
   // so the enclosing scrollboxes don't also move. Unselected / non-
   // slider rows let the event through for normal list scrolling.
@@ -336,10 +365,10 @@ function KnobRow(props: {
         <>
           <box width={20} height={1}>
             <slider orientation="horizontal" min={slider.min} max={slider.max}
-                    value={Number(knobs.eff(props.s, props.s.state)[row.id] ?? slider.default)}
+                    value={sval}
                     foregroundColor={on ? theme.accent : theme.textMuted}
                     backgroundColor={theme.border}
-                    onChange={props.onSlide} />
+                    onChange={slide} />
           </box>
           <box width={1} />
         </>
@@ -470,6 +499,7 @@ export const EikonStudio = memo((props: {
       if (p) prewarm(p, next.fps)
     }
     setS(next)
+    selRow.current = undefined
     setSel(0); setPane("knobs"); setErr(null); setTick(0); setFrames([BLANK])
   }, [])
 
@@ -532,17 +562,20 @@ export const EikonStudio = memo((props: {
   }, [url, live])
 
   const rows = useMemo(() => (s ? buildRows(r, s, live, url) : []), [r, s, live, url])
-  const navRows = useMemo(() => rows.map((x, i) => ({ ...x, i })).filter(x => x.kind !== "divider"), [rows])
-  // Keep selection anchored to its row's id when navRows mutates (the
-  // `revert` row inserts into HEAD when a knob is touched, shifting
-  // knob indices). selRow is the id the user intends to sit on; it's
-  // updated by the keyboard handler (setSelBy) and read here when the
-  // row list changes to re-resolve the index.
+  const navRows = useMemo(() => rows.map((x, i) => ({ ...x, i }))
+    .filter(x => x.kind !== "divider" && x.kind !== "header"), [rows])
+  // Keep selection anchored to its row identity when navRows mutates
+  // (the `revert` row inserts into HEAD on first dirty, shifting
+  // indices). Anchor on kind+id so a rasterizer knob that reuses a
+  // HEAD id (e.g. a plugin declaring its own `contrast`) can't hijack
+  // the resolved index.
   const selRow = useRef<string | undefined>(undefined)
+  const rid = (x: Row) => `${x.kind}:${x.id}`
   const setSelBy = useCallback<typeof setSel>((arg) => {
     setSel(prev => {
       const next = typeof arg === "function" ? (arg as (p: number) => number)(prev) : arg
-      selRow.current = navRows[next]?.id
+      const row = navRows[next]
+      selRow.current = row ? rid(row) : undefined
       return next
     })
   }, [navRows])
@@ -552,14 +585,14 @@ export const EikonStudio = memo((props: {
     prevRows.current = navRows
     const id = selRow.current
     if (!id) return
-    const ni = navRows.findIndex(x => x.id === id)
+    const ni = navRows.findIndex(x => rid(x) === id)
     if (ni >= 0 && ni !== selRef.current) setSel(ni)
   }, [navRows])
   // Knobs pane: ↑↓ keeps the selected row in view. Rows already carry
   // `id="knob-<row.id>"` (reconciler-id rule) — resolve via that.
   const kScroll = (ni: number) => {
     const row = navRows[ni]
-    if (row) ksb.current?.scrollChildIntoView(`knob-${row.id}`)
+    if (row) ksb.current?.scrollChildIntoView(`knob-${row.kind}-${row.id}`)
   }
 
   // Render the current state's full clip. Sourceless falls through
@@ -576,7 +609,7 @@ export const EikonStudio = memo((props: {
     }
     const ctrl = new AbortController()
     setBusy(true)
-    void cached(r, src, s.spatial, s.fps, knobs.eff(s, s.state), ctrl.signal).then(out => {
+    void cached(r, src, s.spatial, s.tone, s.fps, knobs.eff(s, s.state), ctrl.signal).then(out => {
       if (ctrl.signal.aborted) return
       setBusy(false)
       if ("err" in out) { setErr(out.err); return }
@@ -584,7 +617,7 @@ export const EikonStudio = memo((props: {
       setTick(t => t % out.frames.length)
     })
     return () => ctrl.abort()
-  }, [s?.spatial, s?.base, s?.per, s?.state, s?.fps, s?.rasterizer, src, r, baked])
+  }, [s?.spatial, s?.tone, s?.base, s?.per, s?.state, s?.fps, s?.rasterizer, src, r, baked])
 
   // Playback ticker — pure index advance over the already-rendered
   // `frames`. Zero work per tick; the filmstrip effect above did it
@@ -611,7 +644,7 @@ export const EikonStudio = memo((props: {
           const f = baked?.states.get(st)?.frames[0]
           return Promise.resolve([st, f ? thumb(f) : undefined] as const)
         }
-        return cached(r, sp, s.spatial, s.fps, knobs.eff(s, st))
+        return cached(r, sp, s.spatial, s.tone, s.fps, knobs.eff(s, st))
           .then(res => [st, "err" in res ? undefined : thumb(res.frames[0]!)] as const)
       })
       void Promise.all(jobs).then(done => {
@@ -878,8 +911,26 @@ export const EikonStudio = memo((props: {
     )
   }
 
-  /** Step a knob row (cycle/toggle forward, slider ±). */
+  const setTone = (t: Partial<Tone>) =>
+    mutate(p => ({ ...p, tone: { ...p.tone, ...t }, dirty: true }))
+
+  /** Step a knob row (cycle/toggle forward, slider ±). Tone rows
+   *  (contrast/flip) write to `s.tone`; rasterizer knobs to `s.base`
+   *  or `s.per[state]` via `knobs.edit`. */
   const stepRow = (row: Row, d: 1 | -1) => {
+    if (row.kind === "tone") {
+      if (row.id === "contrast") {
+        const def = row.knob as Extract<KnobDef, { kind: "slider" }>
+        const cur = sRef.current?.tone.contrast ?? 1
+        return setTone({ contrast: +Math.max(def.min, Math.min(def.max, cur + d * def.step)).toFixed(2) })
+      }
+      if (row.id === "flip") {
+        const cur = sRef.current?.tone.flip ?? "none"
+        const i = FLIPS.indexOf(cur)
+        return setTone({ flip: FLIPS[(i + d + FLIPS.length) % FLIPS.length]! })
+      }
+      return
+    }
     if (row.kind !== "knob" || !row.knob) return
     mutate(p => knobs.edit(p, k => knobs.step(k, row.id, row.knob!, d)))
   }
@@ -898,7 +949,7 @@ export const EikonStudio = memo((props: {
       if (via === "space" && row.id === "reset") return
       return void doAction(row.id)
     }
-    if (row.kind === "knob") {
+    if (row.kind === "tone" || row.kind === "knob") {
       // slider has neither toggle nor activate semantics → Enter/Space
       // are inert (←→ and drag are the inputs).
       if (row.knob!.kind === "slider") return
@@ -1069,14 +1120,15 @@ export const EikonStudio = memo((props: {
                 const on = pane === "knobs" && ni === sel
                 const dim = row.kind === "knob" && !src
                 return (
-                  <KnobRow key={`${r.name}:${row.id}`} id={`knob-${row.id}`} row={row} s={s} r={r} src={src}
+                  <KnobRow key={`${row.kind}:${r.name}:${row.id}`} id={`knob-${row.kind}-${row.id}`} row={row} s={s} r={r} src={src}
                            on={on} dim={dim} peek={peek} busy={row.id === "fetch" && fetching}
                            onHover={() => { if (ni >= 0) { setPane("knobs"); setSelBy(ni) } }}
                            onClick={() => { if (ni >= 0) { setSelBy(ni); setPane("knobs"); act(row, "click") } }}
                            onWheel={d => stepRow(row, d)}
-                           onSlide={row.knob?.kind === "slider"
-                             ? v => mutate(p => knobs.edit(p, k => knobs.setSlider(k, row.id, row.knob!, v)))
-                             : undefined} />
+                           onSlide={row.knob?.kind !== "slider" ? undefined
+                             : row.kind === "tone"
+                               ? v => setTone({ contrast: +v.toFixed(2) })
+                               : v => mutate(p => knobs.edit(p, k => knobs.setSlider(k, row.id, row.knob!, v)))} />
                 )
               })}
             </scrollbox>

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -26,6 +26,10 @@ import { HintBar } from "../ui/hint"
 import { DialogSelect } from "../ui/dialog-select"
 import { openConfirm } from "../dialogs/confirm"
 import { openTextPrompt } from "../dialogs/text-prompt"
+import { openNewEikon } from "../dialogs/new-eikon"
+import { BUNDLED_EIKON_DIR } from "../components/avatar/bundled"
+import { hermesPath } from "../service/hermes-home"
+import { listEikons } from "../components/avatar/eikon"
 import * as prefs from "../context/preferences"
 import { eikon } from "../service/eikon"
 import type { ParsedEikon } from "../components/avatar/eikon"
@@ -57,9 +61,9 @@ const mb = (n: number) => n < 1024 ? `${n} B`
   : n < 1 << 20 ? `${(n / 1024).toFixed(0)} KB` : `${(n / (1 << 20)).toFixed(1)} MB`
 
 const HEAD: readonly Row[] = [
+  { id: "open",       kind: "select", label: "eikon" },
   { id: "rasterizer", kind: "select", label: "rasterizer" },
   { id: "source",     kind: "prompt", label: "source" },
-  { id: "name",       kind: "prompt", label: "name" },
   // { id: "glyph",   kind: "prompt", label: "glyph" }, // reserved — PRD § 3
   { id: "-1",         kind: "divider", label: "" },
   { id: "fetch",      kind: "action", label: "fetch source",
@@ -229,9 +233,9 @@ function SpatialBar(props: {
 
 function valueOf(s: Session, r: Rasterizer, row: Row, src?: string,
                  peek?: { n: number; bytes: number }, busy?: boolean): string {
+  if (row.id === "open") return `${s.name} ▸`
   if (row.id === "rasterizer") return `${r.name} ▸`
   if (row.id === "source") return src ? src.replace(process.env.HOME ?? "", "~") : "(none — Enter to attach)"
-  if (row.id === "name") return s.name
   if (row.id === "fork") return s.per[s.state] ? "(forked)" : "▸ copy base → " + s.state
   if (row.id === "reset") return "▸ defaults"
   if (row.id === "fetch") return busy ? "fetching…"
@@ -545,13 +549,124 @@ export const EikonStudio = memo((props: {
       const role = s.state === "idle" && !s.sources.base ? "base" : s.state
       try { const f = eikon.adopt(s.name, v, role); mutate(p => ({ ...p, sources: { ...p.sources, [role]: f }, dirty: true })) }
       catch (e) { toast.error(e instanceof Error ? e : new Error(String(e))) }
-      return
-    }
-    if (id === "name") {
-      const v = await openTextPrompt(dialog, { title: "Name", initial: s.name })
-      if (v) mutate(p => ({ ...p, name: knobs.slug(v), dirty: true }))
     }
   }
+
+  // Prompts before discarding when the current draft is dirty.
+  const switchTo = useCallback(async (name: string) => {
+    const cur = sRef.current
+    if (cur?.name === name) return
+    if (cur?.dirty) {
+      const ok = await openConfirm(dialog, {
+        title: "Discard unsaved edits?", danger: true,
+        body: `Open '${name}' and drop in-memory changes to '${cur.name}'.`,
+      })
+      if (!ok) return
+    }
+    open(name)
+  }, [dialog, open])
+
+  const apply = useCallback(async (res: Awaited<ReturnType<typeof openNewEikon>>) => {
+    if (!res) return
+    if (res.from === "blank") {
+      eikon.ensure(res.name)
+      return switchTo(res.name)
+    }
+    if (res.from === "file") {
+      eikon.ensure(res.name)
+      try { eikon.adopt(res.name, res.file, "base") }
+      catch (e) { return toast.error(e instanceof Error ? e : new Error(String(e))) }
+      return switchTo(res.name)
+    }
+    toast.show({ variant: "info", message: `Installing '${res.name}' from ${res.src}…` })
+    await eikon.fetchSource(res.src, { name: res.name })
+      .then(out => {
+        toast.show({ variant: "success", message: `Installed '${out.name}' (${out.n} files)` })
+        void switchTo(out.name)
+      })
+      .catch(e => toast.error(e instanceof Error ? e : new Error(String(e))))
+  }, [switchTo, toast])
+
+  const doNew = useCallback(async () => {
+    const res = await openNewEikon(dialog, {})
+    await apply(res)
+  }, [dialog, apply])
+
+  const doRename = useCallback(async () => {
+    if (!sRef.current) return
+    const res = await openNewEikon(dialog, { initial: sRef.current.name })
+    await apply(res)
+  }, [dialog, apply])
+
+  // Installed-folder eikons take precedence over bundled flat-file
+  // duplicates by slug; trailers are appended in doOpen.
+  const eikonOptions = useCallback(() => {
+    const installed = eikon.list().map(e => ({
+      title: e.name, value: e.name, category: "installed",
+      hint: e.hasSource ? "● source" : e.sourceUrl ? "○ source available" : "—",
+    }))
+    const seen = new Set(installed.map(o => o.value))
+    const bundled = listEikons([BUNDLED_EIKON_DIR, hermesPath("eikons")])
+      .filter(e => e.path.startsWith(BUNDLED_EIKON_DIR))
+      .map(e => {
+        const slug = e.meta.name.toLowerCase()
+        return { title: e.meta.name, value: slug, category: "bundled",
+                 hint: `${e.meta.states.length}st · ${e.meta.width}×${e.meta.height}` }
+      })
+      .filter(o => !seen.has(o.value))
+    return [...installed, ...bundled]
+  }, [])
+
+  const doInstall = useCallback(async () => {
+    const src = await openTextPrompt(dialog, {
+      title: "Install eikon",
+      label: "catalog name · github.com/u/r · git URL · http://…/ · local dir",
+    })
+    if (!src) return
+    toast.show({ variant: "info", message: `Installing from ${src}…` })
+    await eikon.fetchSource(src)
+      .then(out => {
+        toast.show({ variant: "success", message: `Installed '${out.name}' (${out.n} files)` })
+        void switchTo(out.name)
+      })
+      .catch(e => toast.error(e instanceof Error ? e : new Error(String(e))))
+  }, [dialog, switchTo, toast])
+
+  const doOpen = useCallback(() => {
+    const cur = sRef.current
+    const opts = [
+      ...eikonOptions(),
+      { title: "+ New…",      value: "__new",     category: "" },
+      { title: "+ Install…",  value: "__install", category: "" },
+    ]
+    dialog.replace(
+      <DialogSelect title="Open eikon" current={cur?.name} options={opts}
+        footer={
+          cur ? (
+            <box height={1} flexDirection="row" onMouseDown={() => { dialog.clear(); void doRename() }}>
+              <text fg={theme.textMuted}>{"r: rename '"}</text>
+              <text fg={theme.accent}>{cur.name}</text>
+              <text fg={theme.textMuted}>{"'"}</text>
+            </box>
+          ) : undefined
+        }
+        onKey={(key: ParsedKey) => {
+          if (cur && key.name === "r" && !key.ctrl && !key.meta && !key.shift) {
+            dialog.clear()
+            void doRename()
+            return true
+          }
+          return false
+        }}
+        onSelect={o => {
+          dialog.clear()
+          if (o.value === "__new") return void doNew()
+          if (o.value === "__install") return void doInstall()
+          void switchTo(o.value)
+        }} />,
+      () => {},
+    )
+  }, [dialog, eikonOptions, switchTo, doNew, doInstall, doRename, theme])
 
   const doAction = async (id: string) => {
     if (!s) return
@@ -602,7 +717,10 @@ export const EikonStudio = memo((props: {
    *  actions (reset → confirm dialog) are Enter/click only. */
   const act = (row: Row | undefined, via: "enter" | "space" | "click") => {
     if (!row || !sRef.current) return
-    if (row.kind === "select") return doSelectRasterizer()
+    if (row.kind === "select") {
+      if (row.id === "open") return doOpen()
+      return doSelectRasterizer()
+    }
     if (row.kind === "prompt") return void doPrompt(row.id)
     if (row.kind === "action") {
       if (via === "space" && row.id === "reset") return
@@ -647,7 +765,7 @@ export const EikonStudio = memo((props: {
       return
     }
     if (!s) {
-      if (key.name === "return") return void doPrompt("source")
+      if (key.name === "return") return void doNew()
       return
     }
     if (pane === "knobs") {
@@ -656,7 +774,7 @@ export const EikonStudio = memo((props: {
         page: Math.max(1, (ksb.current?.viewport.height ?? 10) - 1),
         onActivate: activate,
         onToggle: toggle,
-        onNew: () => void doPrompt("source"),
+        onNew: () => void doNew(),
       })) return
       if (key.name === "left") return adjust(-1)
       if (key.name === "right") return adjust(1)
@@ -706,7 +824,7 @@ export const EikonStudio = memo((props: {
     :       "no source — Enter on 'source' to attach")
 
   const hint: Array<readonly [string, string]> =
-    pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "open"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
+    pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "open"], [keys.print("list.new"), "new"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
   : pane === "preview" ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.toggle"), "play/pause"], ["wheel", "zoom"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
   :                      [["←→", "state"], [keys.print("list.activate"), "actions"], [keys.print("eikon.save"), "save"], ["Tab", "pane"]]
 
@@ -752,7 +870,7 @@ export const EikonStudio = memo((props: {
     <TabShell title={`Knobs${s?.dirty ? "  ·  ● unsaved" : ""}`} focus={pane === "knobs"} grow={1}>
       {!s
         ? <box flexGrow={1} alignItems="center" justifyContent="center">
-            <text fg={theme.textMuted}>No eikon open. Enter to create one.</text>
+            <text fg={theme.textMuted}>No eikon open. Enter to create or pick one.</text>
           </box>
         : <scrollbox ref={ksb} scrollY flexGrow={1} contentOptions={COL}>
             {rows.map((row, i) => {

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -26,6 +26,8 @@ import { HintBar } from "../ui/hint"
 import { DialogSelect } from "../ui/dialog-select"
 import { openConfirm } from "../dialogs/confirm"
 import { openTextPrompt } from "../dialogs/text-prompt"
+import { openPathPrompt } from "../dialogs/path-prompt"
+import { useGateway } from "../context/gateway"
 import * as prefs from "../context/preferences"
 import { eikon } from "../service/eikon"
 import type { ParsedEikon } from "../components/avatar/eikon"
@@ -291,6 +293,7 @@ function KnobRow(props: {
 function Strip(props: {
   s: Session; frames: Map<AvatarState, Frame | undefined>
   focused: boolean; onPick: (st: AvatarState) => void
+  onEmpty?: (st: AvatarState) => void
 }) {
   const theme = useTheme().theme
   return (
@@ -300,14 +303,18 @@ function Strip(props: {
         const own = !!props.s.per[st]
         const has = !!props.s.sources[st]
         const f = props.frames.get(st)
+        const empty = !f
         return (
           <box key={st} flexDirection="column" alignItems="center"
-               onMouseDown={() => props.onPick(st)}>
+               onMouseDown={() => {
+                 props.onPick(st)
+                 if (empty) props.onEmpty?.(st)
+               }}>
             <box border borderStyle="rounded"
                  borderColor={on && props.focused ? theme.primary : on ? theme.accent : theme.border}
                  width={18} height={10} overflow="hidden" alignItems="center" justifyContent="center">
               {f ? f.map((ln, i) => <text key={i} fg={on ? theme.text : theme.textMuted}>{ln}</text>)
-                 : <text fg={theme.textMuted}>·</text>}
+                 : <text fg={theme.textMuted}>+</text>}
             </box>
             <box height={1}><text fg={on ? theme.accent : theme.textMuted}>
               {`${own ? "*" : " "}${has ? "📎" : " "}${st}`}
@@ -331,6 +338,7 @@ export const EikonStudio = memo((props: {
   const theme = useTheme().theme
   const keys = useKeys()
   const dialog = useDialog()
+  const gw = useGateway()
   const toast = useToast()
   const dims = useTerminalDimensions()
   const wide = dims.width >= 120
@@ -537,16 +545,42 @@ export const EikonStudio = memo((props: {
     )
   }
 
+  const doSource = (forSt?: AvatarState) => {
+    if (!s) return
+    const st = forSt ?? s.state
+    const has = !!s.sources[st]
+    const opts: Array<{ title: string; value: string }> = [{ title: "Local file…", value: "local" }]
+    if (has && st !== "idle") opts.push({ title: "Same as base", value: "same" })
+    if (has) opts.push({ title: "Remove", value: "remove" })
+    dialog.replace(
+      <DialogSelect title={`Source for '${st}'`} filterable={false} options={opts}
+        onSelect={async o => {
+          if (o.value === "local") {
+            const p = await openPathPrompt(dialog, gw, {
+              title: `Source for '${st}'`,
+              label: "png/jpg/webp/gif/mp4/webm/mov  ·  Tab completes",
+              filter: /\.(png|jpe?g|webp|gif|mp4|webm|mov)$/i,
+            })
+            if (!p) return
+            const role = st === "idle" && !s.sources.base ? "base" : st
+            try { const f = eikon.adopt(s.name, p, role); mutate(prev => ({ ...prev, sources: { ...prev.sources, [role]: f }, dirty: true })) }
+            catch (e) { toast.error(e instanceof Error ? e : new Error(String(e))) }
+            return
+          }
+          dialog.clear()
+          mutate(prev => {
+            const next = { ...prev.sources }
+            delete next[st]
+            return { ...prev, sources: next, dirty: true }
+          })
+        }} />,
+      () => {},
+    )
+  }
+
   const doPrompt = async (id: string) => {
     if (!s) return
-    if (id === "source") {
-      const v = await openTextPrompt(dialog, { title: "Source image", label: `for state '${s.state}' (png/jpg/webp/gif/mp4)` })
-      if (!v) return
-      const role = s.state === "idle" && !s.sources.base ? "base" : s.state
-      try { const f = eikon.adopt(s.name, v, role); mutate(p => ({ ...p, sources: { ...p.sources, [role]: f }, dirty: true })) }
-      catch (e) { toast.error(e instanceof Error ? e : new Error(String(e))) }
-      return
-    }
+    if (id === "source") return doSource()
     if (id === "name") {
       const v = await openTextPrompt(dialog, { title: "Name", initial: s.name })
       if (v) mutate(p => ({ ...p, name: knobs.slug(v), dirty: true }))
@@ -579,12 +613,12 @@ export const EikonStudio = memo((props: {
     dialog.replace(
       <DialogSelect title={`State: ${s.state}`} filterable={false}
         options={[
-          { title: "Attach source image…", value: "attach" },
+          { title: "Source…", value: "source" },
           { title: s.per[s.state] ? "Clear override (back to base)" : "Fork knobs from base", value: "fork" },
         ]}
         onSelect={o => {
+          if (o.value === "source") { doSource(); return }
           dialog.clear()
-          if (o.value === "attach") return void doPrompt("source")
           mutate(s.per[s.state] ? knobs.unfork : knobs.fork)
         }} />,
       () => {},
@@ -781,7 +815,8 @@ export const EikonStudio = memo((props: {
     <box id="studio-strip" flexShrink={0} height={STRIP_H}>
       <TabShell title="States" focus={pane === "strip"}>
         <Strip s={s} frames={thumbs} focused={pane === "strip"}
-               onPick={st => { setPane("strip"); mutate(p => knobs.setState(p, st)) }} />
+               onPick={st => { setPane("strip"); mutate(p => knobs.setState(p, st)) }}
+               onEmpty={st => doSource(st)} />
       </TabShell>
     </box>
   ) : null

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -30,8 +30,8 @@ import { openConfirm, openSaveDiscard } from "../dialogs/confirm"
 import { openTextPrompt } from "../dialogs/text-prompt"
 import { openPathPrompt } from "../dialogs/path-prompt"
 import { openGenerate, type GenerateKind } from "../dialogs/eikon-generate"
+import { gen } from "../service/eikon-gen"
 import { useGateway } from "../context/gateway"
-import type { Gateway } from "../context/gateway"
 import { openNewEikon } from "../dialogs/new-eikon"
 import { BUNDLED_EIKON_DIR } from "../components/avatar/bundled"
 import { hermesPath } from "../service/hermes-home"
@@ -356,20 +356,14 @@ function Strip(props: {
 
 const BLANK: Frame = Array.from({ length: H }, () => " ".repeat(W))
 
-// One-shot toolset probe — `toolsets.list` is server state, not session
-// state, so the result is process-stable until the agent restarts. Cache
-// the Promise so concurrent opens share the round trip; reset on null
-// gateway (test reseed). The set holds enabled toolset names.
-let toolsetsCache: Promise<Set<string>> | null = null
-const probeToolsets = (gw: Gateway): Promise<Set<string>> => {
-  if (toolsetsCache) return toolsetsCache
-  toolsetsCache = gw.request<{ toolsets?: Array<{ name: string; enabled?: boolean }> }>("toolsets.list", {})
-    .then(r => new Set((r.toolsets ?? []).filter(t => t.enabled !== false).map(t => t.name)))
-    .catch(() => new Set<string>())
-  return toolsetsCache
-}
-/** Test-only — wipe the toolset cache between mountNode calls. */
-export const resetToolsetsCache = () => { toolsetsCache = null }
+// One-shot gen backend probe — calls the installed hermes-agent's
+// check_*_requirements() directly so the source menu reflects actual
+// provider availability (configured key/gateway), not just the
+// toolset toggle. Cached at module scope; tests reset via setImpl.
+let genCaps: Promise<{ image: boolean; video: boolean }> | null = null
+const probeGen = () => (genCaps ??= gen.probeCached())
+/** Test-only — wipe the gen-caps cache between mountNode calls. */
+export const resetToolsetsCache = () => { genCaps = null }
 
 export const EikonStudio = memo((props: {
   focused: boolean
@@ -408,7 +402,7 @@ export const EikonStudio = memo((props: {
   const [err, setErr] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [pending, setPending] = useState<ReadonlySet<AvatarState>>(new Set())
-  const [tools, setTools] = useState<Set<string> | null>(null)
+  const [genOk, setGenOk] = useState<{ image: boolean; video: boolean } | null>(null)
   const frame = frames[tick % frames.length] ?? BLANK
 
   const r = useMemo(() => eikon.pick(s?.rasterizer ?? prefs.get("eikonRasterizer")), [s?.rasterizer])
@@ -460,14 +454,14 @@ export const EikonStudio = memo((props: {
     return () => { dead = true }
   }, [props.name, open])
 
-  // Probe enabled toolsets once per process so the source menu can hide
-  // Generate rows when image_gen/video_gen aren't on. Cached at module
-  // scope — repeated mounts share one round trip.
+  // Probe gen backends once per process so the source menu can hide
+  // Generate rows when no image/video provider is configured. Cached
+  // at module scope — repeated mounts share one subprocess.
   useEffect(() => {
     let dead = false
-    void probeToolsets(gw).then(s => { if (!dead) setTools(s) })
+    void probeGen().then(c => { if (!dead) setGenOk(c) })
     return () => { dead = true }
-  }, [gw])
+  }, [])
 
   const src = useMemo(() => (s ? eikon.findSource(s.name, s.state) : undefined), [s?.name, s?.state, s?.sources])
   const live = useMemo(() => !!(s && eikon.findSource(s.name)), [s?.name, s?.sources])
@@ -640,7 +634,7 @@ export const EikonStudio = memo((props: {
     if (!s) return
     const seed = s.sources.base ? eikon.findSource(s.name) : undefined
     setPending(prev => { const n = new Set(prev); n.add(st); return n })
-    const out = await openGenerate(dialog, gw, {
+    const out = await openGenerate(dialog, gen.current(), {
       state: st, kind, seed, lastPrompt: s.prompts?.[st],
     })
     if (!out) {
@@ -668,8 +662,8 @@ export const EikonStudio = memo((props: {
     const st = forSt ?? s.state
     const has = !!s.sources[st]
     const opts: Array<{ title: string; value: string }> = [{ title: "Local file…", value: "local" }]
-    if (tools?.has("image_gen")) opts.push({ title: "Generate image…", value: "gen-image" })
-    if (tools?.has("video_gen")) opts.push({ title: "Generate video…", value: "gen-video" })
+    if (genOk?.image) opts.push({ title: "Generate image…", value: "gen-image" })
+    if (genOk?.video) opts.push({ title: "Generate video…", value: "gen-video" })
     if (has && st !== "idle") opts.push({ title: "Same as base", value: "same" })
     if (has) opts.push({ title: "Remove", value: "remove" })
     dialog.replace(

--- a/src/utils/eikon-knobs.ts
+++ b/src/utils/eikon-knobs.ts
@@ -25,6 +25,9 @@ export type Studio = {
   per: Partial<Record<AvatarState, KnobValues>>
   glyph: string
   sources: Partial<Record<AvatarState | "base", string>>
+  /** Per-state last generation prompt — pre-fills the generate dialog
+   *  on a state's next open so users can iterate without retyping. */
+  prompts?: Partial<Record<AvatarState, string>>
 }
 
 export type Session = Studio & {
@@ -44,6 +47,7 @@ export function fresh(name: string, r: Rasterizer, seed?: Partial<Studio>): Sess
     per: seed?.per ?? {},
     glyph: seed?.glyph ?? "◆",
     sources: seed?.sources ?? {},
+    prompts: seed?.prompts ?? {},
   }
 }
 
@@ -118,7 +122,7 @@ export const slug = (v: string) =>
 /** Persisted slice of a session. */
 export const toStudio = (s: Session): Studio => ({
   rasterizer: s.rasterizer, spatial: s.spatial, fps: s.fps, base: s.base,
-  per: s.per, glyph: s.glyph, sources: s.sources,
+  per: s.per, glyph: s.glyph, sources: s.sources, prompts: s.prompts,
 })
 
 export * as knobs from "./eikon-knobs"

--- a/src/utils/eikon-knobs.ts
+++ b/src/utils/eikon-knobs.ts
@@ -43,7 +43,7 @@ export function fresh(name: string, r: Rasterizer, seed?: Partial<Studio>): Sess
     name, state: "idle", dims: null, dirty: false,
     rasterizer: seed?.rasterizer ?? r.name,
     spatial: seed?.spatial ?? { ...S0 },
-    tone: seed?.tone ?? { ...T0 },
+    tone: { ...T0, ...seed?.tone },
     fps: seed?.fps ?? FPS0,
     base: seed?.base ?? defaults(r),
     per: seed?.per ?? {},

--- a/src/utils/eikon-knobs.ts
+++ b/src/utils/eikon-knobs.ts
@@ -6,8 +6,8 @@
 // (see utils/eikon-render.ts); `step()` is generic over `KnobDef`.
 
 import type { AvatarState } from "../components/avatar/states"
-import type { KnobDef, KnobValues, Rasterizer, Spatial } from "./eikon-render"
-import { S0, FPS0, defaults } from "./eikon-render"
+import type { KnobDef, KnobValues, Rasterizer, Spatial, Tone } from "./eikon-render"
+import { S0, T0, FPS0, defaults } from "./eikon-render"
 
 export const STATES: readonly AvatarState[] = ["idle", "listening", "thinking", "speaking", "working", "error"]
 
@@ -20,6 +20,7 @@ const wrap = <T,>(arr: readonly T[], cur: T, d: 1 | -1): T =>
 export type Studio = {
   rasterizer: string
   spatial: Spatial
+  tone: Tone
   fps: number
   base: KnobValues
   per: Partial<Record<AvatarState, KnobValues>>
@@ -42,6 +43,7 @@ export function fresh(name: string, r: Rasterizer, seed?: Partial<Studio>): Sess
     name, state: "idle", dims: null, dirty: false,
     rasterizer: seed?.rasterizer ?? r.name,
     spatial: seed?.spatial ?? { ...S0 },
+    tone: seed?.tone ?? { ...T0 },
     fps: seed?.fps ?? FPS0,
     base: seed?.base ?? defaults(r),
     per: seed?.per ?? {},
@@ -114,15 +116,15 @@ export function swap(s: Session, r: Rasterizer): Session {
 }
 
 export const reset = (s: Session, r: Rasterizer): Session =>
-  ({ ...s, spatial: { ...S0 }, base: defaults(r), per: {}, dirty: true })
+  ({ ...s, spatial: { ...S0 }, tone: { ...T0 }, base: defaults(r), per: {}, dirty: true })
 
 export const slug = (v: string) =>
   v.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "") || "wip"
 
 /** Persisted slice of a session. */
 export const toStudio = (s: Session): Studio => ({
-  rasterizer: s.rasterizer, spatial: s.spatial, fps: s.fps, base: s.base,
-  per: s.per, glyph: s.glyph, sources: s.sources, prompts: s.prompts,
+  rasterizer: s.rasterizer, spatial: s.spatial, tone: s.tone, fps: s.fps,
+  base: s.base, per: s.per, glyph: s.glyph, sources: s.sources, prompts: s.prompts,
 })
 
 export * as knobs from "./eikon-knobs"

--- a/src/utils/eikon-render.ts
+++ b/src/utils/eikon-render.ts
@@ -29,8 +29,8 @@ export const S0: Spatial = { zoom: 1.0, ox: 0.5, oy: 0.5 }
 /** Pixel-domain prep applied to the gray Window before it reaches
  *  any rasterizer. Rasterizer knobs are glyph-domain only. */
 export type Flip = "none" | "h" | "v" | "hv"
-export type Tone = { contrast: number; flip: Flip }
-export const T0: Tone = { contrast: 1.0, flip: "none" }
+export type Tone = { contrast: number; invert: boolean; flip: Flip }
+export const T0: Tone = { contrast: 1.0, invert: true, flip: "none" }
 
 export type KnobDef =
   | { kind: "cycle";  label?: string; hint?: string; options: readonly string[]; default: string }
@@ -232,7 +232,7 @@ function hit(key: string): Frame[] | undefined {
 export function resetCache() { cache.clear(); clips.clear() }
 
 const keyOf = (r: string, src: string, sp: Spatial, tn: Tone, fps: number, k: KnobValues) =>
-  `${r}|${src}|${fps}|${sp.zoom.toFixed(3)}:${sp.ox.toFixed(3)}:${sp.oy.toFixed(3)}|${tn.contrast.toFixed(2)}:${tn.flip}|${JSON.stringify(k)}`
+  `${r}|${src}|${fps}|${sp.zoom.toFixed(3)}:${sp.ox.toFixed(3)}:${sp.oy.toFixed(3)}|${tn.contrast.toFixed(2)}:${+tn.invert}:${tn.flip}|${JSON.stringify(k)}`
 
 /** Decode → crop → tone → rasterize (all frames), with LRU over the result. */
 export async function cached(r: Rasterizer, src: string, sp: Spatial, tn: Tone,
@@ -318,6 +318,7 @@ export function tone(win: Window, t: Tone): Window {
       for (let i = 0; i < sz; i++) g[o + i] = clamp(Math.round((g[o + i]! - m) * con + m), 0, 255)
     }
   }
+  if (t.invert) for (let i = 0; i < g.length; i++) g[i] = 255 - g[i]!
   return win
 }
 
@@ -330,8 +331,6 @@ export const chafa: Rasterizer = {
                  hint: "Secondary glyph set used where the primary leaves gaps." },
     dither:    { kind: "cycle",  options: ["none", "ordered", "diffusion", "noise"], default: "none",
                  hint: "Adds texture to smooth gradients so mid-tones don't band." },
-    invert:    { kind: "toggle", default: true,
-                 hint: "Flip light↔dark. On for dark terminal backgrounds." },
   },
   available: () => caps.chafa ? true : "chafa not installed",
   async render(win, k, signal) {
@@ -344,11 +343,9 @@ export const chafa: Rasterizer = {
       ...(fill === "none" ? [] : [`--fill=${fill}`]),
       `--dither=${String(k.dither ?? "none")}`,
       // chafa's default --preprocess auto-levels the input, which
-      // would undo the studio-owned tone() pass.
+      // would undo the studio-owned tone() pass. Invert is also
+      // applied upstream (255-g), so --invert is never passed.
       "--preprocess", "off",
-      // --invert tells chafa the terminal bg is light, which flips its
-      // luminance→density mapping — correct semantics for mono output.
-      ...(k.invert ? ["--invert"] : []),
       "-",
     ]
     if (signal?.aborted) return { err: "aborted" }
@@ -383,10 +380,10 @@ function mean(g: Uint8Array): number {
   return s / g.length
 }
 
-function braille(g: Uint8Array, w: number, h: number, inv: boolean): Frame {
+function braille(g: Uint8Array, w: number, h: number): Frame {
   const at = sample(g, w, h, W * 2, H * 4)
-  // Mean threshold on the already-tone()d plane — contrast is
-  // studio-owned and applied upstream, so no `con` parameter here.
+  // Mean threshold on the already-tone()d plane — contrast/invert
+  // are studio-owned and applied upstream.
   const thr = mean(g)
   const rows: string[] = []
   for (let y = 0; y < H; y++) {
@@ -394,8 +391,7 @@ function braille(g: Uint8Array, w: number, h: number, inv: boolean): Frame {
     for (let x = 0; x < W; x++) {
       let bits = 0
       for (let dy = 0; dy < 4; dy++) for (let dx = 0; dx < 2; dx++) {
-        const v = at(x * 2 + dx, y * 4 + dy)
-        if ((v > thr) !== inv) bits |= DOT[dy]![dx]!
+        if (at(x * 2 + dx, y * 4 + dy) > thr) bits |= DOT[dy]![dx]!
       }
       row += String.fromCodePoint(0x2800 + bits)
     }
@@ -404,17 +400,13 @@ function braille(g: Uint8Array, w: number, h: number, inv: boolean): Frame {
   return rows
 }
 
-function block(g: Uint8Array, w: number, h: number, inv: boolean): Frame {
+function block(g: Uint8Array, w: number, h: number): Frame {
   const at = sample(g, w, h, W, H)
   const n = RAMP.length - 1
   const rows: string[] = []
   for (let y = 0; y < H; y++) {
     let row = ""
-    for (let x = 0; x < W; x++) {
-      const v = at(x, y)
-      const i = Math.round((inv ? 255 - v : v) / 255 * n)
-      row += RAMP[i]
-    }
+    for (let x = 0; x < W; x++) row += RAMP[Math.round(at(x, y) / 255 * n)]
     rows.push(row)
   }
   return rows
@@ -425,16 +417,13 @@ export const native: Rasterizer = {
   knobs: {
     symbols:  { kind: "cycle",  options: ["braille", "block"], default: "braille",
                 hint: "Glyph family used to draw pixels. Braille is denser; block is bolder." },
-    invert:   { kind: "toggle", default: true,
-                hint: "Flip light↔dark. On for dark terminal backgrounds." },
   },
   available: () => caps.ffmpeg ? true : "ffmpeg not installed",
   async render(win, k) {
-    const inv = !!k.invert
     const fn = k.symbols === "block" ? block : braille
     const sz = win.w * win.h
     const frames = Array.from({ length: win.frames }, (_, i) =>
-      fn(win.gray.subarray(i * sz, (i + 1) * sz), win.w, win.h, inv))
+      fn(win.gray.subarray(i * sz, (i + 1) * sz), win.w, win.h))
     return { frames }
   },
 }

--- a/src/utils/eikon-render.ts
+++ b/src/utils/eikon-render.ts
@@ -26,6 +26,12 @@ const MAXF = 256
 export type Spatial = { zoom: number; ox: number; oy: number }
 export const S0: Spatial = { zoom: 1.0, ox: 0.5, oy: 0.5 }
 
+/** Pixel-domain prep applied to the gray Window before it reaches
+ *  any rasterizer. Rasterizer knobs are glyph-domain only. */
+export type Flip = "none" | "h" | "v" | "hv"
+export type Tone = { contrast: number; flip: Flip }
+export const T0: Tone = { contrast: 1.0, flip: "none" }
+
 export type KnobDef =
   | { kind: "cycle";  label?: string; hint?: string; options: readonly string[]; default: string }
   | { kind: "toggle"; label?: string; hint?: string; default: boolean }
@@ -225,19 +231,19 @@ function hit(key: string): Frame[] | undefined {
 
 export function resetCache() { cache.clear(); clips.clear() }
 
-const keyOf = (r: string, src: string, sp: Spatial, fps: number, k: KnobValues) =>
-  `${r}|${src}|${fps}|${sp.zoom.toFixed(3)}:${sp.ox.toFixed(3)}:${sp.oy.toFixed(3)}|${JSON.stringify(k)}`
+const keyOf = (r: string, src: string, sp: Spatial, tn: Tone, fps: number, k: KnobValues) =>
+  `${r}|${src}|${fps}|${sp.zoom.toFixed(3)}:${sp.ox.toFixed(3)}:${sp.oy.toFixed(3)}|${tn.contrast.toFixed(2)}:${tn.flip}|${JSON.stringify(k)}`
 
-/** Decode → crop → rasterize (all frames), with LRU over the result. */
-export async function cached(r: Rasterizer, src: string, sp: Spatial, fps: number,
-                             k: KnobValues, signal?: AbortSignal): Promise<Rendered> {
-  const key = keyOf(r.name, src, sp, fps, k)
+/** Decode → crop → tone → rasterize (all frames), with LRU over the result. */
+export async function cached(r: Rasterizer, src: string, sp: Spatial, tn: Tone,
+                             fps: number, k: KnobValues, signal?: AbortSignal): Promise<Rendered> {
+  const key = keyOf(r.name, src, sp, tn, fps, k)
   const got = hit(key)
   if (got) return { frames: got }
   const cl = await decode(src, fps)
   if (typeof cl === "string") return { err: cl }
   if (signal?.aborted) return { err: "aborted" }
-  const out = await r.render(crop(cl, sp), k, signal)
+  const out = await r.render(tone(crop(cl, sp), tn), k, signal)
   if ("err" in out) return out
   if (signal?.aborted) return { err: "aborted" }
   return { frames: put(key, out.frames) }
@@ -276,10 +282,13 @@ export function thumb(frame: Frame, w = 16, h = 8): Frame {
 
 // ── chafa ────────────────────────────────────────────────────────────
 
-/** Apply flip/contrast on every plane of the gray buffer in-place. */
-function tone(win: Window, flip: string, con: number): Window {
+/** Apply flip/contrast on every plane of the gray buffer in-place.
+ *  Called by `cached()` after `crop()` so every rasterizer sees the
+ *  same tone-mapped Window; rasterizers never touch contrast/flip. */
+export function tone(win: Window, t: Tone): Window {
   const { gray: g, w, h, frames: n } = win
   const sz = w * h
+  const flip = t.flip, con = clamp(t.contrast, 0.25, 4.0)
   for (let f = 0; f < n; f++) {
     const o = f * sz
     if (flip === "h" || flip === "hv")
@@ -323,24 +332,19 @@ export const chafa: Rasterizer = {
                  hint: "Adds texture to smooth gradients so mid-tones don't band." },
     invert:    { kind: "toggle", default: true,
                  hint: "Flip light↔dark. On for dark terminal backgrounds." },
-    flip:      { kind: "cycle",  options: ["none", "h", "v", "hv"], default: "none",
-                 hint: "Mirror the source horizontally, vertically, or both." },
-    contrast:  { kind: "slider", min: 0.5, max: 3.0, step: 0.1, default: 1.0,
-                 hint: "Push mid-tones toward black/white. >1 sharpens edges; <1 flattens." },
   },
   available: () => caps.chafa ? true : "chafa not installed",
   async render(win, k, signal) {
     const bin = caps.chafa
     if (!bin) return { err: "chafa not installed" }
     const fill = String(k.fill ?? "none")
-    tone(win, String(k.flip ?? "none"), clamp(Number(k.contrast ?? 1), 0.5, 3.0))
     const args = [
       `--size=${W}x${H * win.frames}`, "--format=symbols", "--stretch", "--colors=none",
       `--symbols=${String(k.symbols ?? "braille")}`,
       ...(fill === "none" ? [] : [`--fill=${fill}`]),
       `--dither=${String(k.dither ?? "none")}`,
-      // chafa's default --preprocess auto-levels the input, which would
-      // undo the in-process contrast multiply.
+      // chafa's default --preprocess auto-levels the input, which
+      // would undo the studio-owned tone() pass.
       "--preprocess", "off",
       // --invert tells chafa the terminal bg is light, which flips its
       // luminance→density mapping — correct semantics for mono output.
@@ -379,13 +383,11 @@ function mean(g: Uint8Array): number {
   return s / g.length
 }
 
-function braille(g: Uint8Array, w: number, h: number, inv: boolean, con: number): Frame {
+function braille(g: Uint8Array, w: number, h: number, inv: boolean): Frame {
   const at = sample(g, w, h, W * 2, H * 4)
-  // Mean-centered threshold: pivot the binarisation around the
-  // plane's actual luminance so photographic sources (bright sky,
-  // dark subject) still respond to the contrast knob.
-  const m = mean(g)
-  const thr = m + (128 - m) / con
+  // Mean threshold on the already-tone()d plane — contrast is
+  // studio-owned and applied upstream, so no `con` parameter here.
+  const thr = mean(g)
   const rows: string[] = []
   for (let y = 0; y < H; y++) {
     let row = ""
@@ -402,15 +404,14 @@ function braille(g: Uint8Array, w: number, h: number, inv: boolean, con: number)
   return rows
 }
 
-function block(g: Uint8Array, w: number, h: number, inv: boolean, con: number): Frame {
+function block(g: Uint8Array, w: number, h: number, inv: boolean): Frame {
   const at = sample(g, w, h, W, H)
-  const m = mean(g)
   const n = RAMP.length - 1
   const rows: string[] = []
   for (let y = 0; y < H; y++) {
     let row = ""
     for (let x = 0; x < W; x++) {
-      const v = clamp((at(x, y) - m) * con + m, 0, 255)
+      const v = at(x, y)
       const i = Math.round((inv ? 255 - v : v) / 255 * n)
       row += RAMP[i]
     }
@@ -426,17 +427,14 @@ export const native: Rasterizer = {
                 hint: "Glyph family used to draw pixels. Braille is denser; block is bolder." },
     invert:   { kind: "toggle", default: true,
                 hint: "Flip light↔dark. On for dark terminal backgrounds." },
-    contrast: { kind: "slider", min: 0.5, max: 3.0, step: 0.1, default: 1.0,
-                hint: "Push mid-tones toward black/white. >1 sharpens edges; <1 flattens." },
   },
   available: () => caps.ffmpeg ? true : "ffmpeg not installed",
   async render(win, k) {
-    const con = clamp(Number(k.contrast ?? 1), 0.5, 3.0)
     const inv = !!k.invert
     const fn = k.symbols === "block" ? block : braille
     const sz = win.w * win.h
     const frames = Array.from({ length: win.frames }, (_, i) =>
-      fn(win.gray.subarray(i * sz, (i + 1) * sz), win.w, win.h, inv, con))
+      fn(win.gray.subarray(i * sz, (i + 1) * sz), win.w, win.h, inv))
     return { frames }
   },
 }

--- a/src/utils/eikon-render.ts
+++ b/src/utils/eikon-render.ts
@@ -294,8 +294,21 @@ function tone(win: Window, flip: string, con: number): Window {
         const t = new Uint8Array(a); a.set(b); b.set(t)
       }
   }
-  if (Math.abs(con - 1) > 1e-3)
-    for (let i = 0; i < g.length; i++) g[i] = clamp(Math.round((g[i]! - 128) * con + 128), 0, 255)
+  if (Math.abs(con - 1) > 1e-3) {
+    // Center on the per-plane mean, not 128 — a photographic source
+    // whose pixels cluster well above or below mid-gray (a bright
+    // moon scene, a dark owl on a dark branch) barely shifts under
+    // a 128-pivot multiply because most of the dynamic range sits
+    // in the clamp tails. Mean-centering keeps the slider effective
+    // across arbitrary luminance distributions.
+    for (let f = 0; f < n; f++) {
+      const o = f * sz
+      let sum = 0
+      for (let i = 0; i < sz; i++) sum += g[o + i]!
+      const m = sum / sz
+      for (let i = 0; i < sz; i++) g[o + i] = clamp(Math.round((g[o + i]! - m) * con + m), 0, 255)
+    }
+  }
   return win
 }
 
@@ -360,9 +373,19 @@ function sample(g: Uint8Array, w: number, h: number, fw: number, fh: number) {
     g[Math.min(h - 1, Math.floor(gy * sy)) * w + Math.min(w - 1, Math.floor(gx * sx))]!
 }
 
+function mean(g: Uint8Array): number {
+  let s = 0
+  for (let i = 0; i < g.length; i++) s += g[i]!
+  return s / g.length
+}
+
 function braille(g: Uint8Array, w: number, h: number, inv: boolean, con: number): Frame {
   const at = sample(g, w, h, W * 2, H * 4)
-  const thr = 128 / con
+  // Mean-centered threshold: pivot the binarisation around the
+  // plane's actual luminance so photographic sources (bright sky,
+  // dark subject) still respond to the contrast knob.
+  const m = mean(g)
+  const thr = m + (128 - m) / con
   const rows: string[] = []
   for (let y = 0; y < H; y++) {
     let row = ""
@@ -381,12 +404,13 @@ function braille(g: Uint8Array, w: number, h: number, inv: boolean, con: number)
 
 function block(g: Uint8Array, w: number, h: number, inv: boolean, con: number): Frame {
   const at = sample(g, w, h, W, H)
+  const m = mean(g)
   const n = RAMP.length - 1
   const rows: string[] = []
   for (let y = 0; y < H; y++) {
     let row = ""
     for (let x = 0; x < W; x++) {
-      const v = clamp((at(x, y) - 128) * con + 128, 0, 255)
+      const v = clamp((at(x, y) - m) * con + m, 0, 255)
       const i = Math.round((inv ? 255 - v : v) / 255 * n)
       row += RAMP[i]
     }

--- a/src/utils/eikon-render.ts
+++ b/src/utils/eikon-render.ts
@@ -27,9 +27,9 @@ export type Spatial = { zoom: number; ox: number; oy: number }
 export const S0: Spatial = { zoom: 1.0, ox: 0.5, oy: 0.5 }
 
 export type KnobDef =
-  | { kind: "cycle";  label?: string; options: readonly string[]; default: string }
-  | { kind: "toggle"; label?: string; default: boolean }
-  | { kind: "slider"; label?: string; min: number; max: number; step: number; default: number }
+  | { kind: "cycle";  label?: string; hint?: string; options: readonly string[]; default: string }
+  | { kind: "toggle"; label?: string; hint?: string; default: boolean }
+  | { kind: "slider"; label?: string; hint?: string; min: number; max: number; step: number; default: number }
 
 export type KnobValues = Record<string, string | number | boolean>
 
@@ -302,12 +302,18 @@ function tone(win: Window, flip: string, con: number): Window {
 export const chafa: Rasterizer = {
   name: "chafa",
   knobs: {
-    symbols:   { kind: "cycle",  options: ["braille", "block", "ascii", "sextant", "quad", "half", "wedge"], default: "braille" },
-    fill:      { kind: "cycle",  options: ["none", "stipple", "ascii", "braille"], default: "none" },
-    dither:    { kind: "cycle",  options: ["none", "ordered", "diffusion", "noise"], default: "none" },
-    invert:    { kind: "toggle", default: true },
-    flip:      { kind: "cycle",  options: ["none", "h", "v", "hv"], default: "none" },
-    contrast:  { kind: "slider", min: 0.5, max: 3.0, step: 0.1, default: 1.0 },
+    symbols:   { kind: "cycle",  options: ["braille", "block", "ascii", "sextant", "quad", "half", "wedge"], default: "braille",
+                 hint: "Glyph family used to draw pixels. Braille is densest; block is boldest; ascii is most compatible." },
+    fill:      { kind: "cycle",  options: ["none", "stipple", "ascii", "braille"], default: "none",
+                 hint: "Secondary glyph set used where the primary leaves gaps." },
+    dither:    { kind: "cycle",  options: ["none", "ordered", "diffusion", "noise"], default: "none",
+                 hint: "Adds texture to smooth gradients so mid-tones don't band." },
+    invert:    { kind: "toggle", default: true,
+                 hint: "Flip light↔dark. On for dark terminal backgrounds." },
+    flip:      { kind: "cycle",  options: ["none", "h", "v", "hv"], default: "none",
+                 hint: "Mirror the source horizontally, vertically, or both." },
+    contrast:  { kind: "slider", min: 0.5, max: 3.0, step: 0.1, default: 1.0,
+                 hint: "Push mid-tones toward black/white. >1 sharpens edges; <1 flattens." },
   },
   available: () => caps.chafa ? true : "chafa not installed",
   async render(win, k, signal) {
@@ -392,9 +398,12 @@ function block(g: Uint8Array, w: number, h: number, inv: boolean, con: number): 
 export const native: Rasterizer = {
   name: "native",
   knobs: {
-    symbols:  { kind: "cycle",  options: ["braille", "block"], default: "braille" },
-    invert:   { kind: "toggle", default: true },
-    contrast: { kind: "slider", min: 0.5, max: 3.0, step: 0.1, default: 1.0 },
+    symbols:  { kind: "cycle",  options: ["braille", "block"], default: "braille",
+                hint: "Glyph family used to draw pixels. Braille is denser; block is bolder." },
+    invert:   { kind: "toggle", default: true,
+                hint: "Flip light↔dark. On for dark terminal backgrounds." },
+    contrast: { kind: "slider", min: 0.5, max: 3.0, step: 0.1, default: 1.0,
+                hint: "Push mid-tones toward black/white. >1 sharpens edges; <1 flattens." },
   },
   available: () => caps.ffmpeg ? true : "ffmpeg not installed",
   async render(win, k) {

--- a/test/eikon-baked.test.tsx
+++ b/test/eikon-baked.test.tsx
@@ -39,8 +39,9 @@ test("baked mode: plays packed frames, hides spatial, shows fetch row", async ()
   // knobs absent, fork/reset hidden.
   expect(f).toContain("fetch source")
   expect(f).toContain("download to edit")
-  expect(f).not.toContain("fork state")
-  expect(f).not.toContain("reset knobs")
+  // Live-only action rows absent in baked mode.
+  expect(f).not.toMatch(/▸?\s+tune\s+◂/)
+  expect(f).not.toMatch(/▸?\s+reset\s+▸ defaults/)
   // peek hint lands async.
   await until(t, () => t.frame().includes("1 files"))
   // Tab to preview, Space still toggles play (⏸ appears in title).

--- a/test/eikon-gen.test.ts
+++ b/test/eikon-gen.test.ts
@@ -31,6 +31,7 @@ test("generate(image) spawns venv python against image_generation_tool and retur
   expect("path" in out && out.path).toBe(ASSET)
   const argv = await Bun.file(join(HH, "gen-argv")).text()
   expect(argv).toContain("image_generation_tool")
+  expect(argv).toContain("_handle_image_generate")
   expect(argv).toContain("a wise owl")
   expect(argv).toContain("square")
 })
@@ -63,6 +64,18 @@ test("probe() reads check_*_requirements", async () => {
   const argv = await Bun.file(join(HH, "gen-argv")).text()
   expect(argv).toContain("check_image_generation_requirements")
   expect(argv).toContain("check_video_generation_requirements")
+})
+
+test("dotenv keys reach the child process so providers see API keys", async () => {
+  // Fake python echoes whatever env keys are present so we can assert.
+  writeFileSync(PY,
+    `#!/usr/bin/env bash\n` +
+    `echo "FAKE_GEN_KEY=$FAKE_GEN_KEY"\n` +
+    `echo '{"success": true, "image": "${ASSET}"}'\n`)
+  chmodSync(PY, 0o755)
+  writeFileSync(join(HH, ".env"), 'FAKE_GEN_KEY="reached-the-child"\n')
+  const out = await gen.generate("image", "x", {})
+  expect("path" in out).toBe(true)
 })
 
 test("probe() returns false/false when hermes-agent install absent", async () => {

--- a/test/eikon-gen.test.ts
+++ b/test/eikon-gen.test.ts
@@ -1,0 +1,72 @@
+import { test, expect, beforeAll, afterAll } from "bun:test"
+import { mkdirSync, writeFileSync, chmodSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { gen } from "../src/service/eikon-gen"
+
+// HERMES_HOME is a tmpdir (preload). Drop a fake hermes-agent install
+// whose venv python echoes a provider-shaped JSON so generate() can be
+// tested end-to-end without any real API.
+const HH = process.env.HERMES_HOME!
+const ROOT = join(HH, "hermes-agent")
+const BIN = join(ROOT, "venv", "bin")
+const PY = join(BIN, "python")
+const ASSET = join(HH, "gen-out.png")
+
+beforeAll(() => {
+  mkdirSync(BIN, { recursive: true })
+  writeFileSync(ASSET, new Uint8Array([137, 80, 78, 71]))
+  // Fake python: last arg is the -c body; echo args to a sidecar and
+  // emit a success JSON pointing at ASSET. Lets us assert the exact
+  // tool-module call embedded in the -c string.
+  writeFileSync(PY,
+    `#!/usr/bin/env bash\n` +
+    `printf '%s\\n' "$@" > "${join(HH, "gen-argv")}"\n` +
+    `echo '{"success": true, "image": "${ASSET}"}'\n`)
+  chmodSync(PY, 0o755)
+})
+afterAll(() => rmSync(ROOT, { recursive: true, force: true }))
+
+test("generate(image) spawns venv python against image_generation_tool and returns local path", async () => {
+  const out = await gen.generate("image", "a wise owl", { aspect: "square" })
+  expect("path" in out && out.path).toBe(ASSET)
+  const argv = await Bun.file(join(HH, "gen-argv")).text()
+  expect(argv).toContain("image_generation_tool")
+  expect(argv).toContain("a wise owl")
+  expect(argv).toContain("square")
+})
+
+test("generate(video) embeds duration + image_url seed in the -c body", async () => {
+  const out = await gen.generate("video", "owl blinks", { seconds: 3, seed: "/tmp/base.png" })
+  expect("path" in out).toBe(true)
+  const argv = await Bun.file(join(HH, "gen-argv")).text()
+  expect(argv).toContain("video_generation_tool")
+  expect(argv).toContain('"duration":3')
+  expect(argv).toContain('"image_url":"/tmp/base.png"')
+})
+
+test("generate parses error shape", async () => {
+  writeFileSync(PY,
+    `#!/usr/bin/env bash\necho '{"success": false, "error": "no FAL_KEY"}'\n`)
+  chmodSync(PY, 0o755)
+  const out = await gen.generate("image", "x", {})
+  expect("err" in out && out.err).toBe("no FAL_KEY")
+})
+
+test("probe() reads check_*_requirements", async () => {
+  writeFileSync(PY,
+    `#!/usr/bin/env bash\n` +
+    `printf '%s\\n' "$@" > "${join(HH, "gen-argv")}"\n` +
+    `echo '{"image": true, "video": false}'\n`)
+  chmodSync(PY, 0o755)
+  const c = await gen.probe()
+  expect(c).toEqual({ image: true, video: false })
+  const argv = await Bun.file(join(HH, "gen-argv")).text()
+  expect(argv).toContain("check_image_generation_requirements")
+  expect(argv).toContain("check_video_generation_requirements")
+})
+
+test("probe() returns false/false when hermes-agent install absent", async () => {
+  rmSync(ROOT, { recursive: true, force: true })
+  const c = await gen.probe()
+  expect(c).toEqual({ image: false, video: false })
+})

--- a/test/eikon-knobs.test.ts
+++ b/test/eikon-knobs.test.ts
@@ -58,10 +58,10 @@ describe("eikon-knobs", () => {
   })
 
   test("swap resets tonal, preserves spatial", () => {
-    const moved = { ...s0, spatial: { zoom: 0.5, ox: 0.3, oy: 0.7 }, base: { ...s0.base, invert: false } }
+    const moved = { ...s0, spatial: { zoom: 0.5, ox: 0.3, oy: 0.7 }, base: { ...s0.base, symbols: "block" } }
     const sw = knobs.swap(moved, native)
     expect(sw.spatial.zoom).toBe(0.5)
-    expect(sw.base.invert).toBe(true)  // back to default
+    expect(sw.base.symbols).toBe("braille")  // back to default
     expect(sw.per).toEqual({})
   })
 

--- a/test/eikon-layout.test.tsx
+++ b/test/eikon-layout.test.tsx
@@ -131,6 +131,12 @@ run("layout probe (narrow)", async () => {
   expect(iBody).toBeLessThan(iZoom)
   // Knobs rows render (not collapsed).
   expect(f).toContain("rasterizer")
+  // Panel sized to fit: every settings row visible, no inner
+  // scrollbar glyphs inside the panel band.
+  const iLast = lines.findIndex(l => l.includes("gain"))
+  expect(iLast).toBeGreaterThan(iKnob)
+  for (const l of lines.slice(iKnob, iLast + 1))
+    expect(l).not.toMatch(/[▀▄█]\s*│\s*$/)
   un()
 })
 

--- a/test/eikon-layout.test.tsx
+++ b/test/eikon-layout.test.tsx
@@ -27,7 +27,7 @@ function seed(name: string, sp = { zoom: 0.6, ox: 0.3, oy: 0.7 }) {
   const p = eikon.ensure(name)
   writeFileSync(join(p.source, "base.png"), PX)
   writeFileSync(eikon.file(name), JSON.stringify({ eikon: 1, name, width: 48, height: 24 }) + "\n")
-  eikon.writeStudio(name, { rasterizer: "stub", spatial: sp, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+  eikon.writeStudio(name, { rasterizer: "stub", spatial: sp, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
 }
 
 run("layout probe (wide)", async () => {
@@ -179,7 +179,7 @@ const tall: Rasterizer = {
 run("wide: knobs overflow scrolls inside its panel", async () => {
   const un = eikon.register(tall); seed("tall")
   eikon.writeStudio("tall", { rasterizer: "tall", spatial: { zoom: 1, ox: 0.5, oy: 0.5 },
-    fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+    tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
   const prefs = await import("../src/context/preferences")
   prefs.set("eikon", "tall")
   await using t = await mountNode(<EikonGroup focused sub={0} setSub={() => {}} />, { width: 180, height: 60 })

--- a/test/eikon-layout.test.tsx
+++ b/test/eikon-layout.test.tsx
@@ -63,7 +63,7 @@ run("layout probe (wide)", async () => {
   expect(iMini).toBeGreaterThanOrEqual(iZoom)
   expect(iStrip).toBeGreaterThan(iZoom)
   // Knobs title is on the same line as Preview title (side-by-side).
-  expect(lines.find(l => l.includes("Preview"))!).toContain("Knobs")
+  expect(lines.find(l => l.includes("Preview"))!).toContain("Settings")
   un()
 })
 
@@ -120,7 +120,7 @@ run("layout probe (narrow)", async () => {
   if (process.env.DUMP) console.log(f)
   const iPrev = lines.findIndex(l => l.includes("Preview"))
   const iZoom = lines.findIndex(l => l.includes("zoom"))
-  const iKnob = lines.findIndex(l => l.includes("Knobs"))
+  const iKnob = lines.findIndex(l => l.includes("Settings"))
   // Stacking order: preview (with SpatialBar) above knobs.
   expect(iPrev).toBeGreaterThanOrEqual(0)
   expect(iZoom).toBeGreaterThan(iPrev)

--- a/test/eikon-layout.test.tsx
+++ b/test/eikon-layout.test.tsx
@@ -27,7 +27,7 @@ function seed(name: string, sp = { zoom: 0.6, ox: 0.3, oy: 0.7 }) {
   const p = eikon.ensure(name)
   writeFileSync(join(p.source, "base.png"), PX)
   writeFileSync(eikon.file(name), JSON.stringify({ eikon: 1, name, width: 48, height: 24 }) + "\n")
-  eikon.writeStudio(name, { rasterizer: "stub", spatial: sp, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+  eikon.writeStudio(name, { rasterizer: "stub", spatial: sp, tone: { contrast: 1, invert: true, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
 }
 
 run("layout probe (wide)", async () => {
@@ -179,7 +179,7 @@ const tall: Rasterizer = {
 run("wide: knobs overflow scrolls inside its panel", async () => {
   const un = eikon.register(tall); seed("tall")
   eikon.writeStudio("tall", { rasterizer: "tall", spatial: { zoom: 1, ox: 0.5, oy: 0.5 },
-    tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+    tone: { contrast: 1, invert: true, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
   const prefs = await import("../src/context/preferences")
   prefs.set("eikon", "tall")
   await using t = await mountNode(<EikonGroup focused sub={0} setSub={() => {}} />, { width: 180, height: 60 })

--- a/test/eikon-render.test.ts
+++ b/test/eikon-render.test.ts
@@ -15,9 +15,9 @@ describe("eikon-render", () => {
 
   test("defaults() seeds from KnobDef", () => {
     expect(defaults(chafa)).toEqual({
-      symbols: "braille", fill: "none", dither: "none", invert: true,
+      symbols: "braille", fill: "none", dither: "none",
     })
-    expect(defaults(native).symbols).toBe("braille")
+    expect(defaults(native)).toEqual({ symbols: "braille" })
   })
 
   test("available() gates on caps", () => {
@@ -48,12 +48,13 @@ describe("eikon-render", () => {
     if ("err" in out) throw new Error(out.err)
     const row = out.frames[0]![H >> 1]!
     expect(row.slice(0, W >> 1)).not.toBe(row.slice(W >> 1))
-    // block mode: left heavy (inverted), right light.
+    // block mode: right (white) half heavy — invert is studio-owned
+    // and not applied here, so rasterizer maps bright→dense directly.
     const b = await native.render(windowOf(g, 64, 64), { ...defaults(native), symbols: "block" })
     if ("err" in b) throw new Error(b.err)
     const br = b.frames[0]![H >> 1]!
-    expect("@#%*".includes(br[4]!)).toBe(true)
-    expect(" .:".includes(br[W - 4]!)).toBe(true)
+    expect("@#%*".includes(br[W - 4]!)).toBe(true)
+    expect(" .:".includes(br[4]!)).toBe(true)
   })
 
   test("cached() LRU hits on identical key; miss re-renders", async () => {
@@ -82,11 +83,12 @@ describe("eikon-render", () => {
     resetCache()
     spawnSync("ffmpeg", ["-hide_banner","-loglevel","error","-f","lavfi",
       "-i","nullsrc=s=64x64,format=gray,geq=lum=255*gte(X\\,32)","-frames:v","1","-y",IMG])
-    // Crop window at ox=1 zoom=0.3 sits entirely in the right (white) half.
+    // Crop window at ox=1 zoom=0.3 sits entirely in the right (white)
+    // half; T0.invert maps it to all-black → all-light glyphs.
     const out = await cached(native, IMG, { zoom: 0.3, ox: 1, oy: 0.5 }, T0, 16, { ...defaults(native), symbols: "block" })
     if ("err" in out) throw new Error(out.err)
     expect(out.frames[0]!.every(r => /^[ .:]+$/.test(r))).toBe(true)
-    // ox=0 → all-black → invert on → all-heavy.
+    // ox=0 → all-black → inverted → all-heavy.
     const l = await cached(native, IMG, { zoom: 0.3, ox: 0, oy: 0.5 }, T0, 16, { ...defaults(native), symbols: "block" })
     if ("err" in l) throw new Error(l.err)
     expect(l.frames[0]!.every(r => /^[@#%*]+$/.test(r))).toBe(true)
@@ -118,7 +120,7 @@ describe("eikon-render", () => {
     runc("tone: flip applied on the gray buffer before rasterize", async () => {
     resetCache()
     const a = await cached(chafa, IMG, S0, T0, 16, { ...defaults(chafa), symbols: "block" })
-    const b = await cached(chafa, IMG, S0, { contrast: 1, flip: "h" }, 16, { ...defaults(chafa), symbols: "block" })
+    const b = await cached(chafa, IMG, S0, { ...T0, flip: "h" }, 16, { ...defaults(chafa), symbols: "block" })
     if ("err" in a || "err" in b) throw new Error("render err")
     // Horizontal flip of a left/right step swaps where the █ run sits.
     const ar = a.frames[0]![H >> 1]!, br = b.frames[0]![H >> 1]!
@@ -134,9 +136,15 @@ describe("eikon-render", () => {
     const g = new Uint8Array(64).fill(200)
     g[0] = g[1] = g[2] = g[3] = 40
     const win = windowOf(new Uint8Array(g), 8, 8)
-    tone(win, { contrast: 2, flip: "none" })
+    tone(win, { contrast: 2, invert: false, flip: "none" })
     expect(win.gray[10]).toBeGreaterThan(200)
     expect(win.gray[0]).toBeLessThan(40)
+  })
+
+  test("tone: invert is 255-g, post-contrast", () => {
+    const g = Uint8Array.of(0, 64, 128, 255)
+    tone(windowOf(g, 4, 1), { contrast: 1, invert: true, flip: "none" })
+    expect(Array.from(g)).toEqual([255, 191, 127, 0])
   })
 
   runc("chafa: symbol classes incl. non-BMP (sextant/wedge) accepted, no U+FFFD", async () => {
@@ -199,8 +207,8 @@ describe("eikon-render", () => {
     const out = await native.render(windowOf(g, 4, 4, 3), { ...defaults(native), symbols: "block" })
     if ("err" in out) throw new Error(out.err)
     expect(out.frames.length).toBe(3)
-    // invert on → black=heavy, white=light.
-    expect(out.frames[0]![0]![0]).toBe("@")
-    expect(out.frames[2]![0]![0]).toBe(" ")
+    // No rasterizer invert; bright plane → dense glyph.
+    expect(out.frames[0]![0]![0]).toBe(" ")
+    expect(out.frames[2]![0]![0]).toBe("@")
   })
 })

--- a/test/eikon-render.test.ts
+++ b/test/eikon-render.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { caps, native, chafa, thumb, cached, resetCache, defaults, windowOf, S0, W, H } from "../src/utils/eikon-render"
+import { caps, native, chafa, thumb, cached, resetCache, defaults, windowOf, tone, S0, T0, W, H } from "../src/utils/eikon-render"
 
 describe("eikon-render", () => {
   test("thumb nearest-neighbor 48×24 → 16×8, center-pick", () => {
@@ -16,7 +16,6 @@ describe("eikon-render", () => {
   test("defaults() seeds from KnobDef", () => {
     expect(defaults(chafa)).toEqual({
       symbols: "braille", fill: "none", dither: "none", invert: true,
-      flip: "none", contrast: 1.0,
     })
     expect(defaults(native).symbols).toBe("braille")
   })
@@ -69,10 +68,10 @@ describe("eikon-render", () => {
     if (!caps.ffmpeg) return
     const IMG = "/tmp/eikon-cache.png"
     spawnSync("ffmpeg", ["-hide_banner","-loglevel","error","-f","lavfi","-i","color=gray:s=32x32","-frames:v","1","-y",IMG])
-    await cached(stub, IMG, S0, 16, {})
-    await cached(stub, IMG, S0, 16, {})
+    await cached(stub, IMG, S0, T0, 16, {})
+    await cached(stub, IMG, S0, T0, 16, {})
     expect(n).toBe(1)
-    await cached(stub, IMG, { zoom: 0.5, ox: 0.3, oy: 0.7 }, 16, {})
+    await cached(stub, IMG, { zoom: 0.5, ox: 0.3, oy: 0.7 }, T0, 16, {})
     expect(n).toBe(2)
   })
 
@@ -84,11 +83,11 @@ describe("eikon-render", () => {
     spawnSync("ffmpeg", ["-hide_banner","-loglevel","error","-f","lavfi",
       "-i","nullsrc=s=64x64,format=gray,geq=lum=255*gte(X\\,32)","-frames:v","1","-y",IMG])
     // Crop window at ox=1 zoom=0.3 sits entirely in the right (white) half.
-    const out = await cached(native, IMG, { zoom: 0.3, ox: 1, oy: 0.5 }, 16, { ...defaults(native), symbols: "block" })
+    const out = await cached(native, IMG, { zoom: 0.3, ox: 1, oy: 0.5 }, T0, 16, { ...defaults(native), symbols: "block" })
     if ("err" in out) throw new Error(out.err)
     expect(out.frames[0]!.every(r => /^[ .:]+$/.test(r))).toBe(true)
     // ox=0 → all-black → invert on → all-heavy.
-    const l = await cached(native, IMG, { zoom: 0.3, ox: 0, oy: 0.5 }, 16, { ...defaults(native), symbols: "block" })
+    const l = await cached(native, IMG, { zoom: 0.3, ox: 0, oy: 0.5 }, T0, 16, { ...defaults(native), symbols: "block" })
     if ("err" in l) throw new Error(l.err)
     expect(l.frames[0]!.every(r => /^[@#%*]+$/.test(r))).toBe(true)
   })
@@ -99,7 +98,7 @@ describe("eikon-render", () => {
     resetCache()
     // One spawn visible: chafa. (We can't count spawns here, but the
     // fact that this works at all proves png() is well-formed.)
-    const out = await cached(chafa, IMG, S0, 16, defaults(chafa))
+    const out = await cached(chafa, IMG, S0, T0, 16, defaults(chafa))
     expect("err" in out).toBe(false)
   })
 
@@ -108,18 +107,18 @@ describe("eikon-render", () => {
     spawnSync("ffmpeg", ["-hide_banner","-loglevel","error","-f","lavfi",
       "-i","mandelbrot=s=256x256","-frames:v","1","-y","/tmp/eikon-mand.png"])
     const M = "/tmp/eikon-mand.png"
-    const base = await cached(chafa, M, S0, 16, defaults(chafa))
-    const dith = await cached(chafa, M, S0, 16, { ...defaults(chafa), dither: "diffusion" })
-    const fill = await cached(chafa, M, S0, 16, { ...defaults(chafa), symbols: "block", fill: "stipple" })
+    const base = await cached(chafa, M, S0, T0, 16, defaults(chafa))
+    const dith = await cached(chafa, M, S0, T0, 16, { ...defaults(chafa), dither: "diffusion" })
+    const fill = await cached(chafa, M, S0, T0, 16, { ...defaults(chafa), symbols: "block", fill: "stipple" })
     if ("err" in base || "err" in dith || "err" in fill) throw new Error("render err")
     expect(dith.frames[0]!.join("\n")).not.toBe(base.frames[0]!.join("\n"))
     expect(fill.frames[0]!.join("")).toMatch(/[░▒▓]/)
   })
 
-  runc("chafa: flip/contrast applied on the gray buffer (no ffmpeg)", async () => {
+    runc("tone: flip applied on the gray buffer before rasterize", async () => {
     resetCache()
-    const a = await cached(chafa, IMG, S0, 16, { ...defaults(chafa), symbols: "block", flip: "none" })
-    const b = await cached(chafa, IMG, S0, 16, { ...defaults(chafa), symbols: "block", flip: "h" })
+    const a = await cached(chafa, IMG, S0, T0, 16, { ...defaults(chafa), symbols: "block" })
+    const b = await cached(chafa, IMG, S0, { contrast: 1, flip: "h" }, 16, { ...defaults(chafa), symbols: "block" })
     if ("err" in a || "err" in b) throw new Error("render err")
     // Horizontal flip of a left/right step swaps where the █ run sits.
     const ar = a.frames[0]![H >> 1]!, br = b.frames[0]![H >> 1]!
@@ -128,10 +127,22 @@ describe("eikon-render", () => {
     expect(ar).not.toBe(br)
   })
 
+  test("tone: mean-centered contrast responds on off-mean sources", () => {
+    // 64 px all at 200 except 4 px at 40 → mean ≈ 190. A 128-pivot
+    // multiply would barely change anything; mean-centered pushes
+    // the 200s up and the 40s down.
+    const g = new Uint8Array(64).fill(200)
+    g[0] = g[1] = g[2] = g[3] = 40
+    const win = windowOf(new Uint8Array(g), 8, 8)
+    tone(win, { contrast: 2, flip: "none" })
+    expect(win.gray[10]).toBeGreaterThan(200)
+    expect(win.gray[0]).toBeLessThan(40)
+  })
+
   runc("chafa: symbol classes incl. non-BMP (sextant/wedge) accepted, no U+FFFD", async () => {
     resetCache()
     for (const sym of ["quad", "half", "wedge", "sextant"]) {
-      const out = await cached(chafa, IMG, S0, 16, { ...defaults(chafa), symbols: sym })
+      const out = await cached(chafa, IMG, S0, T0, 16, { ...defaults(chafa), symbols: sym })
       if ("err" in out) throw new Error(`${sym}: ${out.err}`)
       for (const row of out.frames[0]!) {
         expect(Array.from(row).length).toBe(W)
@@ -155,13 +166,13 @@ describe("eikon-render", () => {
     // 1s of animated testsrc at 24fps.
     spawnSync("ffmpeg", ["-hide_banner","-loglevel","error","-f","lavfi",
       "-i","testsrc=s=128x128:r=24:d=1","-pix_fmt","yuv420p","-y",V])
-    const out = await cached(native, V, S0, 12, defaults(native))
+    const out = await cached(native, V, S0, T0, 12, defaults(native))
     if ("err" in out) throw new Error(out.err)
     // 1s @ 12fps → 12 frames.
     expect(out.frames.length).toBe(12)
     expect(out.frames[0]!.join("")).not.toBe(out.frames[6]!.join(""))
     // fps change = different clip key → re-decode, different count.
-    const out8 = await cached(native, V, S0, 8, defaults(native))
+    const out8 = await cached(native, V, S0, T0, 8, defaults(native))
     if ("err" in out8) throw new Error(out8.err)
     expect(out8.frames.length).toBe(8)
   })
@@ -169,7 +180,7 @@ describe("eikon-render", () => {
   runc("chafa filmstrip: N-frame video → N padded frames, no U+FFFD", async () => {
     resetCache()
     const V = "/tmp/eikon-vid.mp4"
-    const out = await cached(chafa, V, S0, 8, { ...defaults(chafa), symbols: "sextant" })
+    const out = await cached(chafa, V, S0, T0, 8, { ...defaults(chafa), symbols: "sextant" })
     if ("err" in out) throw new Error(out.err)
     expect(out.frames.length).toBe(8)
     for (const f of out.frames) {

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -104,6 +104,45 @@ describe("EikonStudio tab", () => {
     await until(t, () => !t.frame().includes("● unsaved"))
     un()
   })
+
+  run("Enter on source row → menu with Local file…; pick + path + Enter adopts source", async () => {
+    const un = eikon.register(stub)
+    seed("fox")
+    prefs.set("eikon", "fox")
+    // Pre-create a file we can adopt.
+    const extPath = join(HH, "extra.png")
+    writeFileSync(extPath, PX)
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+      { width: 160, height: 48 },
+    )
+    await until(t, () => t.frame().includes("rasterizer"))
+
+    // Nav from rasterizer (0) → source (1).
+    act(() => t.keys.pressArrow("down"))
+    await until(t, () => /▸ source/.test(t.frame()))
+
+    // Enter → source-actions menu.
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Local file"))
+    expect(t.frame()).toContain("Source for 'idle'")
+
+    // Pick "Local file…" (first/only-when-empty option).
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Tab complete"))
+
+    // Type the path + Enter.
+    await act(async () => { await t.keys.typeText(extPath) })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("● unsaved"))
+
+    // Adopted file landed in the eikon's source dir as <role>.png.
+    const adoptedDir = eikon.ensure("fox").source
+    const f = Bun.file(join(adoptedDir, "idle.png"))
+    expect(await f.exists()).toBe(true)
+    un()
+  })
 })
 
 describe("EikonGallery tab", () => {

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -2,8 +2,9 @@ import { describe, expect, test } from "bun:test"
 import { act } from "react"
 import { mkdirSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import { mountNode, until } from "./harness"
+import { mountNode, until, MockGateway } from "./harness"
 import { EikonGroup } from "../src/tabs/EikonGroup"
+import { resetToolsetsCache } from "../src/tabs/EikonStudio"
 import { eikon } from "../src/service/eikon"
 import { native, caps, type Rasterizer } from "../src/utils/eikon-render"
 import * as prefs from "../src/context/preferences"
@@ -141,6 +142,87 @@ describe("EikonStudio tab", () => {
     const adoptedDir = eikon.ensure("fox").source
     const f = Bun.file(join(adoptedDir, "idle.png"))
     expect(await f.exists()).toBe(true)
+    un()
+  })
+
+  run("Generate image… row appears when image_gen toolset enabled; submit adopts + persists prompt", async () => {
+    const un = eikon.register(stub)
+    seed("owlgen")
+    prefs.set("eikon", "owlgen")
+    // Pre-stage the path the mock RPC will return.
+    const genPath = join(HH, "generated.png")
+    writeFileSync(genPath, PX)
+    resetToolsetsCache()
+    const gw = new MockGateway({
+      "toolsets.list": () => ({ toolsets: [
+        { name: "image_gen", description: "", tool_count: 1, enabled: true },
+      ]}),
+      "eikon.generate": p => {
+        expect(p.kind).toBe("image")
+        expect(typeof p.prompt).toBe("string")
+        return { path: genPath }
+      },
+    })
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+      { width: 160, height: 60, gw },
+    )
+    await until(t, () => t.frame().includes("rasterizer"))
+
+    // Nav to source row → open menu.
+    act(() => t.keys.pressArrow("down"))
+    await until(t, () => /▸ source/.test(t.frame()))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Local file"))
+    expect(t.frame()).toContain("Generate image")
+    // video_gen not enabled → row hidden.
+    expect(t.frame()).not.toContain("Generate video")
+
+    // Move to "Generate image…" (row 2 — Local file is 0, Generate image is 1).
+    act(() => t.keys.pressArrow("down"))
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Generate image"))
+    // Type into the textarea (prompt field is focused by default).
+    await act(async () => { await t.keys.typeText("a wise owl") })
+    // Tab to the submit field; the form has prompt → seed → submit
+    // (base.png is auto-detected because we seeded sources.base).
+    act(() => t.keys.pressTab())
+    await t.settle()
+    act(() => t.keys.pressTab())
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    // Adoption lands in source/idle.png (st='idle' and base exists so role='idle').
+    await until(t, () => {
+      const f = Bun.file(join(eikon.ensure("owlgen").source, "idle.png"))
+      return f.size > 0
+    })
+    expect(t.frame()).toContain("● unsaved")
+    // RPC was called with the typed prompt.
+    const call = gw.last("eikon.generate")
+    expect(call?.params.prompt).toBe("a wise owl")
+    un()
+  })
+
+  run("Generate rows hidden when toolsets.list returns []", async () => {
+    const un = eikon.register(stub)
+    seed("nogen")
+    prefs.set("eikon", "nogen")
+    resetToolsetsCache()
+    const gw = new MockGateway({ "toolsets.list": () => ({ toolsets: [] }) })
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+      { width: 160, height: 48, gw },
+    )
+    await until(t, () => t.frame().includes("rasterizer"))
+    act(() => t.keys.pressArrow("down"))
+    await until(t, () => /▸ source/.test(t.frame()))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Local file"))
+    expect(t.frame()).not.toContain("Generate image")
+    expect(t.frame()).not.toContain("Generate video")
     un()
   })
 })

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -336,11 +336,12 @@ describe("EikonStudio tab", () => {
     // Prompt textarea is pre-filled with style hints on line 2+ and
     // the cursor is parked at (0,0). Type the subject on line 1.
     await act(async () => { await t.keys.typeText("a wise owl") })
-    // Tab to the submit field; the form has prompt → seed → submit
-    // (base.png is auto-detected because we seeded sources.base).
-    act(() => t.keys.pressTab())
+    // Enter on the textarea advances to the next field (BINDS maps
+    // return→submit); the form is prompt → seed → submit since
+    // base.png is auto-detected. Enter×3 walks through and fires.
+    act(() => t.keys.pressEnter())
     await t.settle()
-    act(() => t.keys.pressTab())
+    act(() => t.keys.pressEnter())
     await t.settle()
     act(() => t.keys.pressEnter())
     // Adoption lands in source/idle.png (st='idle' and base exists so role='idle').
@@ -351,7 +352,7 @@ describe("EikonStudio tab", () => {
     expect(t.frame()).toContain("● unsaved")
     // Gen fn was called with subject + the pre-filled style hints.
     expect(got?.kind).toBe("image")
-    expect(got?.prompt).toMatch(/^a wise owl\nhigh contrast, light subject on solid black background/)
+    expect(got?.prompt).toMatch(/^a wise owl\nhigh contrast, light subject on dark, black background$/)
     gen.setImpl(null); gen.setProbe(null)
     un()
   })
@@ -398,6 +399,9 @@ describe("EikonStudio tab", () => {
     // ↓ to source.
     act(() => t.keys.pressArrow("down")); await t.settle()
     expect(t.frame()).toContain("image or video file the avatar is rendered from")
+    // Bold /eikon-create recommendation may hyphen-wrap; match a run
+    // that's guaranteed contiguous.
+    expect(t.frame()).toContain("interactively (recommended)")
     // ↓↓↓ → contrast (studio-owned tone row, has a KnobDef.hint).
     for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     expect(t.frame()).toContain("Spread pixel values around their mean")

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -30,7 +30,7 @@ function seed(name: string) {
   const p = eikon.ensure(name)
   writeFileSync(join(p.source, "base.png"), PX)
   writeFileSync(eikon.file(name), JSON.stringify({ eikon: 1, name, width: 48, height: 24 }) + "\n")
-  eikon.writeStudio(name, { rasterizer: "stub", spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+  eikon.writeStudio(name, { rasterizer: "stub", spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, invert: true, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
 }
 
 describe("EikonStudio tab", () => {
@@ -60,10 +60,10 @@ describe("EikonStudio tab", () => {
     // Knobs hint uses "edit", not "open".
     expect(t.frame()).toContain("[Enter] edit")
 
-    // Nav to first rasterizer knob (stub's 'tone') — HEAD has 7 nav
+    // Nav to first rasterizer knob (stub's 'tone') — HEAD has 8 nav
     // rows when not dirty (open, rasterizer, source, knobsfor, reset,
-    // contrast, flip), so stub.tone is at index 7.
-    for (let i = 0; i < 7; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    // contrast, invert, flip), so stub.tone is at index 8.
+    for (let i = 0; i < 8; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     await until(t, () => /▸ tone/.test(t.frame()))
     act(() => t.keys.pressArrow("right"))
     await until(t, () => t.frame().includes("◂ hi ▸"))
@@ -333,7 +333,8 @@ describe("EikonStudio tab", () => {
     await t.settle()
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Generate image"))
-    // Type into the textarea (prompt field is focused by default).
+    // Prompt textarea is pre-filled with style hints on line 2+ and
+    // the cursor is parked at (0,0). Type the subject on line 1.
     await act(async () => { await t.keys.typeText("a wise owl") })
     // Tab to the submit field; the form has prompt → seed → submit
     // (base.png is auto-detected because we seeded sources.base).
@@ -348,9 +349,9 @@ describe("EikonStudio tab", () => {
       return f.size > 0
     })
     expect(t.frame()).toContain("● unsaved")
-    // Gen fn was called with the typed prompt.
+    // Gen fn was called with subject + the pre-filled style hints.
     expect(got?.kind).toBe("image")
-    expect(got?.prompt).toBe("a wise owl")
+    expect(got?.prompt).toMatch(/^a wise owl\nhigh contrast, light subject on solid black background/)
     gen.setImpl(null); gen.setProbe(null)
     un()
   })
@@ -400,9 +401,9 @@ describe("EikonStudio tab", () => {
     // ↓↓↓ → contrast (studio-owned tone row, has a KnobDef.hint).
     for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     expect(t.frame()).toContain("Spread pixel values around their mean")
-    // ↓↓ past flip → first rasterizer knob (stub's 'tone' has no
-    // declared hint, so the generic cycle text renders).
-    for (let i = 0; i < 2; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    // ↓↓↓ past invert/flip → first rasterizer knob (stub's 'tone' has
+    // no declared hint, so the generic cycle text renders).
+    for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     expect(t.frame()).toMatch(/←→ or Enter cycles: lo · hi/)
     un()
   })
@@ -411,7 +412,7 @@ describe("EikonStudio tab", () => {
     const un = eikon.register(stub)
     seed("wheelt")
     // Start at zoom 0.5 so pan has room and the vbar thumb is ~half.
-    eikon.writeStudio("wheelt", { rasterizer: "stub", spatial: { zoom: 0.5, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+    eikon.writeStudio("wheelt", { rasterizer: "stub", spatial: { zoom: 0.5, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, invert: true, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
     prefs.set("eikon", "wheelt")
     await using t = await mountNode(
       <EikonGroup focused sub={0} setSub={() => {}} />,

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { mkdirSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { mountNode, until } from "./harness"
 import { EikonGroup } from "../src/tabs/EikonGroup"
+import { EikonStudio } from "../src/tabs/EikonStudio"
 import { eikon } from "../src/service/eikon"
 import { native, caps, type Rasterizer } from "../src/utils/eikon-render"
 import * as prefs from "../src/context/preferences"
@@ -99,6 +100,52 @@ describe("EikonStudio tab", () => {
     act(() => t.keys.pressArrow("right"))
     await until(t, () => t.frame().includes("● unsaved"))
     act(() => t.keys.pressEscape())
+    await until(t, () => t.frame().includes("Discard unsaved"))
+    act(() => t.keys.pressKey("y"))
+    await until(t, () => !t.frame().includes("● unsaved"))
+    un()
+  })
+
+  run("cold start: Enter seeds a fresh session and renders rows", async () => {
+    const un = eikon.register(stub)
+    prefs.set("eikonRasterizer", "stub")
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+      { width: 160, height: 48 },
+    )
+    await until(t, () => t.frame().includes("No eikon open"))
+    expect(t.frame()).toContain("[Enter] new eikon")
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("rasterizer"))
+    expect(t.frame()).toContain("name")
+    un()
+  })
+
+  run("dirty session survives name prop change until confirm", async () => {
+    const un = eikon.register(stub)
+    seed("alpha")
+    seed("beta")
+    prefs.set("eikon", "alpha")
+    let set: ((n: string) => void) | undefined
+    function Wrap() {
+      const [n, sn] = useState<string | undefined>(undefined)
+      set = sn
+      return <EikonStudio focused name={n} />
+    }
+    await using t = await mountNode(<Wrap />, { width: 160, height: 48 })
+    await until(t, () => t.frame().includes("rasterizer"))
+    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    act(() => t.keys.pressArrow("right"))
+    await until(t, () => t.frame().includes("● unsaved"))
+    act(() => set!("beta"))
+    await until(t, () => t.frame().includes("Discard unsaved"))
+    expect(t.frame()).toContain("● unsaved")
+    act(() => t.keys.pressEscape())
+    await until(t, () => !t.frame().includes("Discard unsaved"))
+    expect(t.frame()).toContain("● unsaved")
+    act(() => set!("beta-x"))
+    act(() => set!("beta"))
     await until(t, () => t.frame().includes("Discard unsaved"))
     act(() => t.keys.pressKey("y"))
     await until(t, () => !t.frame().includes("● unsaved"))

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -2,9 +2,10 @@ import { describe, expect, test } from "bun:test"
 import { act, useState } from "react"
 import { mkdirSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import { mountNode, until, MockGateway } from "./harness"
+import { mountNode, until } from "./harness"
 import { EikonGroup } from "../src/tabs/EikonGroup"
 import { EikonStudio, resetToolsetsCache } from "../src/tabs/EikonStudio"
+import { gen } from "../src/service/eikon-gen"
 import { eikon } from "../src/service/eikon"
 import { native, caps, type Rasterizer } from "../src/utils/eikon-render"
 import * as prefs from "../src/context/preferences"
@@ -300,28 +301,21 @@ describe("EikonStudio tab", () => {
     un()
   })
 
-  run("Generate image… row appears when image_gen toolset enabled; submit adopts + persists prompt", async () => {
+  run("Generate image… row appears when backend available; submit adopts + persists prompt", async () => {
     const un = eikon.register(stub)
     seed("owlgen")
     prefs.set("eikon", "owlgen")
-    // Pre-stage the path the mock RPC will return.
+    // Pre-stage the path the mock gen will return.
     const genPath = join(HH, "generated.png")
     writeFileSync(genPath, PX)
     resetToolsetsCache()
-    const gw = new MockGateway({
-      "toolsets.list": () => ({ toolsets: [
-        { name: "image_gen", description: "", tool_count: 1, enabled: true },
-      ]}),
-      "eikon.generate": p => {
-        expect(p.kind).toBe("image")
-        expect(typeof p.prompt).toBe("string")
-        return { path: genPath }
-      },
-    })
+    gen.setProbe(async () => ({ image: true, video: false }))
+    let got: { kind: string; prompt: string } | undefined
+    gen.setImpl(async (kind, prompt) => { got = { kind, prompt }; return { path: genPath } })
     let sub = 0
     await using t = await mountNode(
       <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
-      { width: 160, height: 60, gw },
+      { width: 160, height: 60 },
     )
     await until(t, () => t.frame().includes("rasterizer"))
 
@@ -355,22 +349,23 @@ describe("EikonStudio tab", () => {
       return f.size > 0
     })
     expect(t.frame()).toContain("● unsaved")
-    // RPC was called with the typed prompt.
-    const call = gw.last("eikon.generate")
-    expect(call?.params.prompt).toBe("a wise owl")
+    // Gen fn was called with the typed prompt.
+    expect(got?.kind).toBe("image")
+    expect(got?.prompt).toBe("a wise owl")
+    gen.setImpl(null); gen.setProbe(null)
     un()
   })
 
-  run("Generate rows hidden when toolsets.list returns []", async () => {
+  run("Generate rows hidden when no gen backend configured", async () => {
     const un = eikon.register(stub)
     seed("nogen")
     prefs.set("eikon", "nogen")
     resetToolsetsCache()
-    const gw = new MockGateway({ "toolsets.list": () => ({ toolsets: [] }) })
+    gen.setProbe(async () => ({ image: false, video: false }))
     let sub = 0
     await using t = await mountNode(
       <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
-      { width: 160, height: 48, gw },
+      { width: 160, height: 48 },
     )
     await until(t, () => t.frame().includes("rasterizer"))
     act(() => t.keys.pressArrow("down"))
@@ -380,6 +375,7 @@ describe("EikonStudio tab", () => {
     await until(t, () => t.frame().includes("Local file"))
     expect(t.frame()).not.toContain("Generate image")
     expect(t.frame()).not.toContain("Generate video")
+    gen.setProbe(null)
     un()
   })
 })

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -30,7 +30,7 @@ function seed(name: string) {
   const p = eikon.ensure(name)
   writeFileSync(join(p.source, "base.png"), PX)
   writeFileSync(eikon.file(name), JSON.stringify({ eikon: 1, name, width: 48, height: 24 }) + "\n")
-  eikon.writeStudio(name, { rasterizer: "stub", spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+  eikon.writeStudio(name, { rasterizer: "stub", spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
 }
 
 describe("EikonStudio tab", () => {
@@ -60,11 +60,10 @@ describe("EikonStudio tab", () => {
     // Knobs hint uses "edit", not "open".
     expect(t.frame()).toContain("[Enter] edit")
 
-    // Nav to first tonal knob (tone) — HEAD has 5 nav rows when no
-    // fetch is shown (rasterizer, source, knobsfor, reset), so tone
-    // is at index 5 (open=0, rasterizer=1, source=2, knobsfor=3,
-    // reset=4, tone=5).
-    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    // Nav to first rasterizer knob (stub's 'tone') — HEAD has 7 nav
+    // rows when not dirty (open, rasterizer, source, knobsfor, reset,
+    // contrast, flip), so stub.tone is at index 7.
+    for (let i = 0; i < 7; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     await until(t, () => /▸ tone/.test(t.frame()))
     act(() => t.keys.pressArrow("right"))
     await until(t, () => t.frame().includes("◂ hi ▸"))
@@ -398,9 +397,12 @@ describe("EikonStudio tab", () => {
     // ↓ to source.
     act(() => t.keys.pressArrow("down")); await t.settle()
     expect(t.frame()).toContain("image or video file the avatar is rendered from")
-    // ↓↓↓ past divider+knobsfor+reset → first rasterizer knob (stub's
-    // 'tone' has no declared hint, so the generic cycle text renders).
+    // ↓↓↓ → contrast (studio-owned tone row, has a KnobDef.hint).
     for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    expect(t.frame()).toContain("Spread pixel values around their mean")
+    // ↓↓ past flip → first rasterizer knob (stub's 'tone' has no
+    // declared hint, so the generic cycle text renders).
+    for (let i = 0; i < 2; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     expect(t.frame()).toMatch(/←→ or Enter cycles: lo · hi/)
     un()
   })
@@ -409,7 +411,7 @@ describe("EikonStudio tab", () => {
     const un = eikon.register(stub)
     seed("wheelt")
     // Start at zoom 0.5 so pan has room and the vbar thumb is ~half.
-    eikon.writeStudio("wheelt", { rasterizer: "stub", spatial: { zoom: 0.5, ox: 0.5, oy: 0.5 }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+    eikon.writeStudio("wheelt", { rasterizer: "stub", spatial: { zoom: 0.5, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
     prefs.set("eikon", "wheelt")
     await using t = await mountNode(
       <EikonGroup focused sub={0} setSub={() => {}} />,

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -123,7 +123,7 @@ describe("EikonStudio tab", () => {
     expect(t.frame()).toContain("chafa")
     expect(t.frame()).toContain("native")
     act(() => t.keys.pressEscape())
-    await until(t, () => !t.frame().includes("● stub") || t.frame().includes("Knobs"))
+    await until(t, () => !t.frame().includes("● stub") || t.frame().includes("Settings"))
     un()
   })
 
@@ -376,6 +376,74 @@ describe("EikonStudio tab", () => {
     expect(t.frame()).not.toContain("Generate image")
     expect(t.frame()).not.toContain("Generate video")
     gen.setProbe(null)
+    un()
+  })
+
+  run("Settings help footer follows selection", async () => {
+    const un = eikon.register(stub)
+    seed("helpt")
+    prefs.set("eikon", "helpt")
+    await using t = await mountNode(
+      <EikonGroup focused sub={0} setSub={() => {}} />,
+      { width: 160, height: 48 },
+    )
+    await until(t, () => t.frame().includes("rasterizer"))
+    // Pane is titled Settings now.
+    expect(t.frame()).toContain("Settings — helpt")
+    // Row 0 (eikon) → open help.
+    expect(t.frame()).toContain("Which eikon you're editing")
+    // ↓ to rasterizer.
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    expect(t.frame()).toContain("engine that turns your source")
+    // ↓ to source.
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    expect(t.frame()).toContain("image or video file the avatar is rendered from")
+    // ↓↓↓ past divider+knobsfor+reset → first rasterizer knob (stub's
+    // 'tone' has no declared hint, so the generic cycle text renders).
+    for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    expect(t.frame()).toMatch(/←→ or Enter cycles: lo · hi/)
+    un()
+  })
+
+  run("preview wheel: stops scrollbox propagation; ctrl=zoom, shift=pan-x, bare=pan-y", async () => {
+    const un = eikon.register(stub)
+    seed("wheelt")
+    // Start at zoom 0.5 so pan has room and the vbar thumb is ~half.
+    eikon.writeStudio("wheelt", { rasterizer: "stub", spatial: { zoom: 0.5, ox: 0.5, oy: 0.5 }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+    prefs.set("eikon", "wheelt")
+    await using t = await mountNode(
+      <EikonGroup focused sub={0} setSub={() => {}} />,
+      { width: 180, height: 30 },  // short → outer scrollbox is scrollable
+    )
+    await until(t, () => t.frame().includes("STUB-ROW"))
+    const lines = () => t.frame().split("\n")
+    // A cell inside the preview body.
+    const y = lines().findIndex(l => l.includes("STUB-ROW"))
+    const x = lines()[y]!.indexOf("STUB-ROW") + 2
+    const top0 = lines()[0]
+    // pan-y vbar = rows where the body line ends in ██ flank.
+    const vrows = () => lines().filter(l => /STUB-ROW.*██/.test(l))
+    const vtop = () => lines().findIndex(l => /STUB-ROW.*██/.test(l))
+    const v0 = vtop(), vlen0 = vrows().length
+    expect(vlen0).toBeGreaterThan(2)
+    // Bare wheel down → pan-y: thumb moves down, outer viewport doesn't.
+    for (let i = 0; i < 3; i++) {
+      await act(async () => { await t.mouse.scroll(x, y, "down") }); await t.settle()
+    }
+    expect(vtop()).toBeGreaterThan(v0)
+    expect(lines()[0]).toBe(top0)
+    // Ctrl+wheel → zoom (vbar thumb length changes); outer unchanged.
+    for (let i = 0; i < 3; i++) {
+      await act(async () => { await t.mouse.scroll(x, y, "up", { modifiers: { ctrl: true } }) }); await t.settle()
+    }
+    expect(vrows().length).not.toBe(vlen0)
+    expect(lines()[0]).toBe(top0)
+    // Shift+wheel → pan-x is asserted via the sidebar pan-x hbar
+    // in the full layout test; at height=30 it's clipped, so just
+    // confirm dirty flipped and the outer viewport still hasn't moved.
+    await act(async () => { await t.mouse.scroll(x, y, "down", { modifiers: { shift: true } }) }); await t.settle()
+    expect(t.frame()).toContain("● unsaved")
+    expect(lines()[0]).toBe(top0)
     un()
   })
 })

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -52,7 +52,7 @@ describe("EikonStudio tab", () => {
     // Source row shows basename · dims · size.
     expect(t.frame()).toMatch(/base\.png · 1×1 · \d+\s*B/)
     // knobs-for cycle row.
-    expect(t.frame()).toContain("knobs for")
+    expect(t.frame()).toContain("tune")
     expect(t.frame()).toContain("◂ all states ▸")
     expect(t.frame()).not.toContain("fork state")
     // Strip labels carry no glyphs.
@@ -78,7 +78,7 @@ describe("EikonStudio tab", () => {
     un()
   })
 
-  run("knobs for: ←→ forks current state and toggles back", async () => {
+  run("tune: ←→ forks current state and toggles back", async () => {
     const un = eikon.register(stub)
     seed("knb")
     prefs.set("eikon", "knb")
@@ -87,11 +87,11 @@ describe("EikonStudio tab", () => {
       <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
       { width: 160, height: 60 },
     )
-    await until(t, () => t.frame().includes("knobs for"))
+    await until(t, () => t.frame().includes("tune"))
     expect(t.frame()).toContain("◂ all states ▸")
     // Land on knobs-for row (open=0, rasterizer=1, source=2, knobsfor=3).
     for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
-    await until(t, () => /▸ knobs for/.test(t.frame()))
+    await until(t, () => /▸ tune/.test(t.frame()))
     act(() => t.keys.pressArrow("right"))
     await until(t, () => t.frame().includes("◂ idle only ▸"))
     expect(t.frame()).toContain("● unsaved")

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -48,9 +48,21 @@ describe("EikonStudio tab", () => {
     // Preview frame arrives after async decode+rasterize.
     await until(t, () => t.frame().includes("STUB-ROW"))
 
+    // Source row shows basename · dims · size.
+    expect(t.frame()).toMatch(/base\.png · 1×1 · \d+\s*B/)
+    // knobs-for cycle row.
+    expect(t.frame()).toContain("knobs for")
+    expect(t.frame()).toContain("◂ all states ▸")
+    expect(t.frame()).not.toContain("fork state")
+    // Strip labels carry no glyphs.
+    expect(t.frame()).not.toContain("📎")
+    // Knobs hint uses "edit", not "open".
+    expect(t.frame()).toContain("[Enter] edit")
+
     // Nav to first tonal knob (tone) — HEAD has 5 nav rows when no
-    // fetch is shown (rasterizer, source, name, fork, reset), so
-    // tone is at index 5.
+    // fetch is shown (rasterizer, source, knobsfor, reset), so tone
+    // is at index 5 (open=0, rasterizer=1, source=2, knobsfor=3,
+    // reset=4, tone=5).
     for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     await until(t, () => /▸ tone/.test(t.frame()))
     act(() => t.keys.pressArrow("right"))
@@ -64,6 +76,32 @@ describe("EikonStudio tab", () => {
     await until(t, () => t.frame().includes("state") && t.frame().includes("actions"))
     un()
   })
+
+  run("knobs for: ←→ forks current state and toggles back", async () => {
+    const un = eikon.register(stub)
+    seed("knb")
+    prefs.set("eikon", "knb")
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+      { width: 160, height: 60 },
+    )
+    await until(t, () => t.frame().includes("knobs for"))
+    expect(t.frame()).toContain("◂ all states ▸")
+    // Land on knobs-for row (open=0, rasterizer=1, source=2, knobsfor=3).
+    for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    await until(t, () => /▸ knobs for/.test(t.frame()))
+    act(() => t.keys.pressArrow("right"))
+    await until(t, () => t.frame().includes("◂ idle only ▸"))
+    expect(t.frame()).toContain("● unsaved")
+    // Strip label for idle reads "forked" once per[idle] is set.
+    expect(t.frame()).toContain("forked")
+    // Toggle back.
+    act(() => t.keys.pressArrow("left"))
+    await until(t, () => t.frame().includes("◂ all states ▸"))
+    un()
+  })
+
 
   run("Enter on rasterizer row opens DialogSelect; unavailable shows reason", async () => {
     const un = eikon.register(stub)

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -86,7 +86,7 @@ describe("EikonStudio tab", () => {
     un()
   })
 
-  run("dirty Esc → openConfirm; y reloads from disk", async () => {
+  run("dirty Esc → three-way save/discard; [d] reloads from disk", async () => {
     const un = eikon.register(stub)
     seed("dog")
     prefs.set("eikon", "dog")
@@ -100,9 +100,46 @@ describe("EikonStudio tab", () => {
     act(() => t.keys.pressArrow("right"))
     await until(t, () => t.frame().includes("● unsaved"))
     act(() => t.keys.pressEscape())
-    await until(t, () => t.frame().includes("Discard unsaved"))
-    act(() => t.keys.pressKey("y"))
+    await until(t, () => t.frame().includes("Unsaved edits") && t.frame().includes("[D] discard"))
+    act(() => t.keys.pressKey("d"))
     await until(t, () => !t.frame().includes("● unsaved"))
+    un()
+  })
+
+  run("dirty Esc → [s] saves and drops dirty", async () => {
+    const un = eikon.register(stub)
+    seed("cow")
+    prefs.set("eikon", "cow")
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+    )
+    await until(t, () => t.frame().includes("rasterizer"))
+    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    act(() => t.keys.pressArrow("right"))
+    await until(t, () => t.frame().includes("● unsaved"))
+    act(() => t.keys.pressEscape())
+    await until(t, () => t.frame().includes("Unsaved edits"))
+    act(() => t.keys.pressKey("s"))
+    await until(t, () => t.frame().includes("Saved →"))
+    await until(t, () => !t.frame().includes("● unsaved"))
+    un()
+  })
+
+  run("revert row appears when dirty and routes through three-way", async () => {
+    const un = eikon.register(stub)
+    seed("fox")
+    prefs.set("eikon", "fox")
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+    )
+    await until(t, () => t.frame().includes("rasterizer"))
+    expect(t.frame()).not.toContain("revert")
+    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    act(() => t.keys.pressArrow("right"))
+    await until(t, () => t.frame().includes("revert"))
+    expect(t.frame()).toContain("▸ reload from disk")
     un()
   })
 

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -74,7 +74,9 @@ describe("EikonStudio tab", () => {
       { width: 160, height: 48 },
     )
     await until(t, () => t.frame().includes("rasterizer"))
-    // Selection starts on row 0 (rasterizer). Enter → dialog.
+    // Selection starts on row 0 (eikon picker). Move down once to land on
+    // the rasterizer row, then Enter → dialog.
+    act(() => t.keys.pressArrow("down")); await t.settle()
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Rasterizer") && t.frame().includes("● stub"))
     // chafa + native also listed; one may show an install hint.
@@ -82,6 +84,34 @@ describe("EikonStudio tab", () => {
     expect(t.frame()).toContain("native")
     act(() => t.keys.pressEscape())
     await until(t, () => !t.frame().includes("● stub") || t.frame().includes("Knobs"))
+    un()
+  })
+
+  run("Enter on eikon row opens picker with seeded eikon + New…; New creates and opens", async () => {
+    const un = eikon.register(stub)
+    seed("alpha")
+    prefs.set("eikon", "alpha")
+    let sub = 0
+    await using t = await mountNode(
+      <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
+      { width: 160, height: 48 },
+    )
+    await until(t, () => t.frame().includes("rasterizer"))
+    // Row 0 = eikon picker. Enter opens it; "alpha" appears as the
+    // current selection. The trailers (+ New, + Install) may be below
+    // the viewport in a populated sandbox, so filter down to "new" to
+    // bring + New into view, then Enter selects it.
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Open eikon"))
+    expect(t.frame()).toContain("alpha")
+    await act(async () => { await t.keys.typeText("new") })
+    await until(t, () => t.frame().includes("+ New"))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("New eikon"))
+    // Type a fresh name; default `from` is blank, so Enter resolves.
+    await act(async () => { await t.keys.typeText("beta") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("beta ▸"))
     un()
   })
 

--- a/test/eikon-swap.test.tsx
+++ b/test/eikon-swap.test.tsx
@@ -22,7 +22,8 @@ function seed(name: string, r: string) {
 
 /** DialogSelect filterable=false; registry order [chafa, native]. */
 async function pickIdx(t: Harness, idx: number) {
-  act(() => t.keys.pressKey("HOME")); await t.settle()  // sel → row 0 (rasterizer)
+  act(() => t.keys.pressKey("HOME")); await t.settle()  // sel → row 0 (eikon)
+  act(() => t.keys.pressArrow("down")); await t.settle()  // → row 1 (rasterizer)
   act(() => t.keys.pressEnter())
   await until(t, () => t.frame().includes("Rasterizer"))
   act(() => t.keys.pressKey("HOME")); await t.settle()
@@ -80,12 +81,12 @@ run("Esc in a prompt dialog does NOT fall through to discard()", async () => {
   act(() => t.keys.pressArrow("right")); await t.settle()
   await until(t, () => t.frame().includes("● unsaved"))
 
-  // Open 'name' prompt → Esc closes it, no discard confirm.
-  await navTo(t, "name")
+  // Open 'source' prompt → Esc closes it, no discard confirm.
+  await navTo(t, "source")
   act(() => t.keys.pressEnter())
-  await until(t, () => t.frame().includes("Name") && t.frame().includes("Enter confirm"))
+  await until(t, () => t.frame().includes("Source image"))
   act(() => t.keys.pressEscape()); await t.settle(); await t.settle()
-  expect(t.frame()).not.toContain("Enter confirm")
+  expect(t.frame()).not.toContain("Source image")
   expect(t.frame()).not.toContain("Discard unsaved")
   expect(t.frame()).toContain("● unsaved")  // dirty retained
 

--- a/test/eikon-swap.test.tsx
+++ b/test/eikon-swap.test.tsx
@@ -17,7 +17,7 @@ function seed(name: string, r: string) {
   spawnSync("ffmpeg", ["-hide_banner", "-loglevel", "error", "-f", "lavfi",
     "-i", "color=gray:s=32x32", "-frames:v", "1", "-y", join(p.source, "base.png")])
   writeFileSync(eikon.file(name), JSON.stringify({ eikon: 1, name }) + "\n")
-  eikon.writeStudio(name, { rasterizer: r, spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+  eikon.writeStudio(name, { rasterizer: r, spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
 }
 
 /** DialogSelect filterable=false; registry order [chafa, native]. */
@@ -49,25 +49,30 @@ async function navTo(t: Harness, name: string) {
   throw new Error(`never reached row '${name}'\n${t.frame()}`)
 }
 
-run("chafa↔native: flip row appears/disappears immediately on swap", async () => {
+run("chafa↔native: chafa-only rows appear/disappear immediately on swap", async () => {
   seed("swap", "native")
   prefs.set("eikon", "swap")
   prefs.set("eikonRasterizer", "native")
   await using t = await mountNode(<EikonGroup focused sub={0} setSub={() => {}} />, { width: 180, height: 60 })
   await until(t, () => t.frame().includes("native ▸"))
-  expect(t.frame()).not.toContain("flip")
+  // fill/dither are chafa-only; flip/contrast are now studio-owned
+  // HEAD rows so they're always present.
+  expect(t.frame()).toContain("flip")
+  expect(t.frame()).toContain("contrast")
+  expect(t.frame()).not.toContain("dither")
 
   await pickIdx(t, 0)
   await until(t, () => t.frame().includes("chafa ▸"))
-  expect(t.frame()).toContain("flip")
+  expect(t.frame()).toContain("dither")
+  expect(t.frame()).toContain("fill")
 
   await pickIdx(t, 1)
   await until(t, () => t.frame().includes("native ▸"))
-  expect(t.frame()).not.toContain("flip")
+  expect(t.frame()).not.toContain("dither")
 
   await pickIdx(t, 0)
   await until(t, () => t.frame().includes("chafa ▸"))
-  expect(t.frame()).toContain("flip")
+  expect(t.frame()).toContain("dither")
 })
 
 run("Esc in a prompt dialog does NOT fall through to discard()", async () => {

--- a/test/eikon-swap.test.tsx
+++ b/test/eikon-swap.test.tsx
@@ -129,9 +129,9 @@ run("knob rows: Space and Enter both act per nav.md; click = activate", async ()
   // action/reset: Space is inert (high-commitment); Enter opens confirm.
   await navTo(t, "reset")
   act(() => t.keys.pressKey(" ")); await t.settle(); await t.settle()
-  expect(t.frame()).not.toContain("Reset knobs?")
+  expect(t.frame()).not.toContain("Reset settings?")
   act(() => t.keys.pressEnter())
-  await until(t, () => t.frame().includes("Reset knobs?"))
+  await until(t, () => t.frame().includes("Reset settings?"))
   act(() => t.keys.pressKey("n")); await t.settle()
 
   // slider: Space/Enter inert (no value change).

--- a/test/eikon-swap.test.tsx
+++ b/test/eikon-swap.test.tsx
@@ -17,7 +17,7 @@ function seed(name: string, r: string) {
   spawnSync("ffmpeg", ["-hide_banner", "-loglevel", "error", "-f", "lavfi",
     "-i", "color=gray:s=32x32", "-frames:v", "1", "-y", join(p.source, "base.png")])
   writeFileSync(eikon.file(name), JSON.stringify({ eikon: 1, name }) + "\n")
-  eikon.writeStudio(name, { rasterizer: r, spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
+  eikon.writeStudio(name, { rasterizer: r, spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, invert: true, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: { base: "base.png" } })
 }
 
 /** DialogSelect filterable=false; registry order [chafa, native]. */


### PR DESCRIPTION
Six kanban-built cards merged narrow-first into this integration branch, plus post-integration polish on top. 945 pass, tsc clean.

## What changed

**Entry / selection (`t_e12db8c1`, `t_08d51a49`)**
- Fixed cold-start dead Enter, Gallery '0 states', label clip, dirty-loss on Gallery→Studio handover, clean-save no-op.
- New top Settings row `eikon  <name> ▸` opens a unified picker (installed + bundled + `+ New…` / `+ Install…`). One `openNewEikon` dialog (name + blank/local/install) used by Studio `n`, Gallery `n`, and cold-start Enter.

**Source acquisition (`t_8a9b4842`, `t_b182c1b3`, `9b3526e`)**
- Enter on `source` (or a strip cell) opens a menu: Local file… / Generate image… / Generate video… / Same as base / Remove.
- New `openPathPrompt` primitive: Tab-completes via the existing `complete.path` RPC.
- New `service/eikon-gen.ts`: spawns the installed hermes-agent venv's python and calls `_handle_image_generate` / `_handle_video_generate` (plugin-aware dispatch). `~/.hermes/.env` keys are forwarded into the child. `probe()` checks actual provider availability via `check_*_requirements()`, so Generate rows hide when nothing's configured. No gateway RPC.
- `openGenerate` dialog: prompt textarea pre-filled with minimal style hints on line 2 and the cursor parked on blank line 1. Enter advances field focus, Shift+Enter inserts newline, Enter×N walks to submit. Optional base.png seed toggle, 1-4s slider for video. Errors dump raw.

**Save / discard (`t_d77b4fd4`)**
- New `openSaveDiscard`: `[S] save [D] discard [Esc] keep editing`. Esc on a dirty session routes here; so does the new `revert` action row. `● saving…` hint suffix while Ctrl+S bakes.

**Settings pane (`3596ce5`, `74c034d`, `b60e5c2`)**
- Pane titled `Settings`, word "knobs" removed from all UI.
- 4-row help footer below the rows, driven by `KnobDef.hint` on selection. Source hint adds a bold `Use /eikon-create to generate source files interactively (recommended).`
- Wheel capture on preview: bare=pan-y, Shift=pan-x, Ctrl=zoom. Slider rows also eat wheel while selected.

**Tone layer (`6dd1942`, `dae10ac`, `d713da4`)**
- New `Tone = {contrast, invert, flip}` owned by the studio and applied to the gray Window before any rasterizer sees it. Rasterizers drop their contrast/invert/flip knobs; chafa runs with `--preprocess off` and no `--invert`.
- Contrast is mean-centered (`(g-m)*con+m`, per-plane mean) so the slider bites on off-mean photographic sources. Range 0.25-4.0, shown as `×N.NN`. Invert defaults true (dark terminal bg).
- Section headers (`input` / `<rasterizer>`) disambiguate the two knob groups; React keys/ids/nav anchor namespaced on `(kind, id)` so a plugin rasterizer can still declare its own `contrast`.
- `fresh()` merges `{...T0, ...seed.tone}` so older `studio.json` files back-fill missing fields.

**Polish (`t_9e146cdd`)**
- `source` row shows `basename · w×h · size`. `tune  ◂ all states / <state> only ▸` replaces the fork-state action. Strip labels are two-line text, glyphs gone. Baked-mode note under the preview. Rasterizer row surfaces ⚠ unavailable reason. Hint verb `open` → `edit`.

## New files
`src/dialogs/new-eikon.tsx` `src/dialogs/path-prompt.tsx` `src/dialogs/eikon-generate.tsx` `src/service/eikon-gen.ts` `test/eikon-gen.test.ts`