### PR TITLE
feat(chat): tabbed diff frame (DiffTabs) — t_49b65e76

### DIFF
--- a/src/components/chat/DiffTabs.tsx
+++ b/src/components/chat/DiffTabs.tsx
@@ -14,7 +14,28 @@ import { useTheme } from "../../theme"
 const ANSI = /\x1b\[[0-9;?]*[A-Za-z]/g
 const clean = (s: string) => s.replace(ANSI, "")
 
-const base = (p: string) => p.split(/[\\/]/).pop() ?? p
+// `tool.preview` is whatever the gateway's tool.start.context emitted —
+// for patch/edit tools that's the raw args JSON blob, not a path. Try to
+// extract the actual file from args first; fall back to a unified-diff
+// header (`+++ b/<path>`); finally to the raw preview/name. Without this
+// `base()` slices the JSON tail and tab labels read like `…@` / `…ueberry`.
+const PATH_KEY = /"(?:path|file_path|filename|target|file)"\s*:\s*"((?:\\.|[^"\\])*)"/
+const DIFF_HEAD = /^\+\+\+ b\/(\S.*?)\s*$/m
+function pathFor(t: ToolPart): string {
+  const args = (t as { args?: string }).args
+  if (args && /^\s*\{/.test(args)) {
+    const m = clean(args).match(PATH_KEY)
+    if (m) return m[1]
+  }
+  const diff = t.diff ?? (isDiff(t.result) ? t.result : undefined)
+  if (diff) {
+    const m = clean(diff).match(DIFF_HEAD)
+    if (m) return m[1]
+  }
+  return clean(t.preview ?? t.name)
+}
+
+const base = (p: string) => p.split(/[\\/]/).filter(Boolean).pop() ?? p
 const parent = (p: string) => {
   const parts = p.split(/[\\/]/).filter(Boolean)
   return parts.length >= 2 ? parts[parts.length - 2] : ""
@@ -27,7 +48,7 @@ function buildTabs(tools: ToolPart[]): Tab[] {
   const raw = tools.flatMap(t => {
     const diff = t.diff ?? (isDiff(t.result) ? t.result : undefined)
     if (!diff) return []
-    return [{ tool: t, path: clean(t.preview ?? t.name), diff }]
+    return [{ tool: t, path: pathFor(t), diff }]
   })
   // Disambiguate duplicate basenames (a/Foo.tsx + b/Foo.tsx) by prefixing
   // the parent dir only when needed — keeps short labels short.

--- a/src/components/chat/DiffTabs.tsx
+++ b/src/components/chat/DiffTabs.tsx
@@ -15,24 +15,42 @@ const ANSI = /\x1b\[[0-9;?]*[A-Za-z]/g
 const clean = (s: string) => s.replace(ANSI, "")
 
 // `tool.preview` is whatever the gateway's tool.start.context emitted —
-// for patch/edit tools that's the raw args JSON blob, not a path. Try to
-// extract the actual file from args first; fall back to a unified-diff
-// header (`+++ b/<path>`); finally to the raw preview/name. Without this
-// `base()` slices the JSON tail and tab labels read like `…@` / `…ueberry`.
+// for patch/edit tools that's a clean path. But on tool.complete, the
+// reducer overwrites preview with `summary || inline_diff || preview`,
+// and `inline_diff` from the gateway is the CLI-rendered blob (with
+// `┊ review diff`, `+N/-M`, `…`-truncated context), not a clean unified
+// diff. Order: parse args JSON → diff `+++ b/<path>` → diff `--- a/<path>`
+// → cleaned preview. Without this `base()` slices the blob's tail and
+// labels read like `…@` / `…ueberry` (`t_49b65e76`).
 const PATH_KEY = /"(?:path|file_path|filename|target|file)"\s*:\s*"((?:\\.|[^"\\])*)"/
-const DIFF_HEAD = /^\+\+\+ b\/(\S.*?)\s*$/m
+const DIFF_HEAD_NEW = /^\+\+\+ b?\/+(\S.*?)\s*$/m
+const DIFF_HEAD_OLD = /^--- a?\/+(\S.*?)\s*$/m
 function pathFor(t: ToolPart): string {
   const args = (t as { args?: string }).args
   if (args && /^\s*\{/.test(args)) {
     const m = clean(args).match(PATH_KEY)
     if (m) return m[1]
   }
-  const diff = t.diff ?? (isDiff(t.result) ? t.result : undefined)
-  if (diff) {
-    const m = clean(diff).match(DIFF_HEAD)
+  const sources = [t.diff, t.preview].filter((s): s is string => !!s)
+  for (const s of sources) {
+    const c = clean(s)
+    const m = c.match(DIFF_HEAD_NEW) || c.match(DIFF_HEAD_OLD)
     if (m) return m[1]
   }
   return clean(t.preview ?? t.name)
+}
+
+// Strip the gateway's CLI-rendered chrome from inline_diff so DiffBlock
+// only sees real unified-diff lines. Drops `┊ review diff` markers, the
+// `+N/-M` summary line, and CLI-truncated `…` context lines (cosmetic
+// loss — the body still shows the actual changed hunk lines).
+const STRIPS = [
+  /^\s*┊.*$/,       // gateway's CLI prefix marker
+  /^\s*[+-]\d+\s*\/\s*[-+]\d+\s*$/,  // +N/-M summary line
+  /^\s*…/,           // CLI truncation marker
+]
+function sanitizeDiff(s: string): string {
+  return clean(s).split("\n").filter(l => !STRIPS.some(re => re.test(l))).join("\n")
 }
 
 const base = (p: string) => p.split(/[\\/]/).filter(Boolean).pop() ?? p
@@ -46,9 +64,9 @@ type Tab = { id: string; label: string; diff: string; add: number; del: number }
 
 function buildTabs(tools: ToolPart[]): Tab[] {
   const raw = tools.flatMap(t => {
-    const diff = t.diff ?? (isDiff(t.result) ? t.result : undefined)
-    if (!diff) return []
-    return [{ tool: t, path: pathFor(t), diff }]
+    const rawDiff = t.diff ?? (isDiff(t.result) ? t.result : undefined)
+    if (!rawDiff) return []
+    return [{ tool: t, path: pathFor(t), diff: sanitizeDiff(rawDiff) }]
   })
   // Disambiguate duplicate basenames (a/Foo.tsx + b/Foo.tsx) by prefixing
   // the parent dir only when needed — keeps short labels short.

--- a/src/components/chat/DiffTabs.tsx
+++ b/src/components/chat/DiffTabs.tsx
@@ -10,6 +10,10 @@ import { LEFT_BAR } from "../../ui/borders"
 import { DiffBlock, isDiff } from "./DiffBlock"
 import { useTheme } from "../../theme"
 
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1b\[[0-9;?]*[A-Za-z]/g
+const clean = (s: string) => s.replace(ANSI, "")
+
 const base = (p: string) => p.split(/[\\/]/).pop() ?? p
 const parent = (p: string) => {
   const parts = p.split(/[\\/]/).filter(Boolean)
@@ -23,7 +27,7 @@ function buildTabs(tools: ToolPart[]): Tab[] {
   const raw = tools.flatMap(t => {
     const diff = t.diff ?? (isDiff(t.result) ? t.result : undefined)
     if (!diff) return []
-    return [{ tool: t, path: t.preview ?? t.name, diff }]
+    return [{ tool: t, path: clean(t.preview ?? t.name), diff }]
   })
   // Disambiguate duplicate basenames (a/Foo.tsx + b/Foo.tsx) by prefixing
   // the parent dir only when needed — keeps short labels short.

--- a/src/components/chat/DiffTabs.tsx
+++ b/src/components/chat/DiffTabs.tsx
@@ -17,12 +17,18 @@ const clean = (s: string) => s.replace(ANSI, "")
 // `tool.preview` is whatever the gateway's tool.start.context emitted —
 // for patch/edit tools that's a clean path. But on tool.complete, the
 // reducer overwrites preview with `summary || inline_diff || preview`,
-// and `inline_diff` from the gateway is the CLI-rendered blob (with
-// `┊ review diff`, `+N/-M`, `…`-truncated context), not a clean unified
-// diff. Order: parse args JSON → diff `+++ b/<path>` → diff `--- a/<path>`
-// → cleaned preview. Without this `base()` slices the blob's tail and
-// labels read like `…@` / `…ueberry` (`t_49b65e76`).
+// and `inline_diff` from the gateway is the CLI-rendered blob:
+//   `a/<path> → b/<path>` (the standard `--- a/` / `+++ b/` headers are
+//   REPLACED with this arrow form — see display.py `_render_inline_unified_diff`)
+//   followed by `@@`, `-`, `+`, ` ` lines, plus a `┊ review diff` marker
+//   and a `+N/-M` summary. Order: parse args JSON → gateway arrow form
+//   (`a/<path> → b/<path>`) → standard `+++ b/<path>` → standard `--- a/<path>`
+//   → cleaned preview. Without this every tab label reads as the diff tail
+//   (`…@`, `… autumn`, `…)`) — `t_49b65e76`.
 const PATH_KEY = /"(?:path|file_path|filename|target|file)"\s*:\s*"((?:\\.|[^"\\])*)"/
+// Gateway arrow form: matches `a//tmp/x.txt → b//tmp/x.txt` (paths often
+// have leading `/` so we see `a//`). Prefer the `b/` (after) path.
+const DIFF_HEAD_ARROW = /(?:^|\s)a\/+\S.*?\s*→\s*b\/+(\S.+?)\s*$/m
 const DIFF_HEAD_NEW = /^\+\+\+ b?\/+(\S.*?)\s*$/m
 const DIFF_HEAD_OLD = /^--- a?\/+(\S.*?)\s*$/m
 function pathFor(t: ToolPart): string {
@@ -34,7 +40,7 @@ function pathFor(t: ToolPart): string {
   const sources = [t.diff, t.preview].filter((s): s is string => !!s)
   for (const s of sources) {
     const c = clean(s)
-    const m = c.match(DIFF_HEAD_NEW) || c.match(DIFF_HEAD_OLD)
+    const m = c.match(DIFF_HEAD_ARROW) || c.match(DIFF_HEAD_NEW) || c.match(DIFF_HEAD_OLD)
     if (m) return m[1]
   }
   return clean(t.preview ?? t.name)
@@ -42,12 +48,15 @@ function pathFor(t: ToolPart): string {
 
 // Strip the gateway's CLI-rendered chrome from inline_diff so DiffBlock
 // only sees real unified-diff lines. Drops `┊ review diff` markers, the
-// `+N/-M` summary line, and CLI-truncated `…` context lines (cosmetic
-// loss — the body still shows the actual changed hunk lines).
+// `+N/-M` summary line, CLI-truncated `…` context lines, and the
+// gateway's `a/path → b/path` header form (DiffBlock would otherwise
+// render it as a literal context line). Cosmetic loss only — the body
+// still shows the actual changed hunk lines.
 const STRIPS = [
-  /^\s*┊.*$/,       // gateway's CLI prefix marker
-  /^\s*[+-]\d+\s*\/\s*[-+]\d+\s*$/,  // +N/-M summary line
-  /^\s*…/,           // CLI truncation marker
+  /^\s*┊.*$/,                          // CLI prefix marker
+  /^\s*[+-]\d+\s*\/\s*[-+]\d+\s*$/,    // +N/-M summary line
+  /^\s*…/,                             // CLI truncation marker
+  /a\/+\S.*?\s*→\s*b\/+\S/,            // gateway's `a/x → b/x` header
 ]
 function sanitizeDiff(s: string): string {
   return clean(s).split("\n").filter(l => !STRIPS.some(re => re.test(l))).join("\n")

--- a/src/components/chat/DiffTabs.tsx
+++ b/src/components/chat/DiffTabs.tsx
@@ -1,0 +1,87 @@
+// Tabbed diff frame for an assistant turn — replaces the prior stack of
+// ▸ collapsible chips with one CodeBlock-style frame whose header is a
+// wrapping row of file tabs (basenames). The active tab swaps the body.
+// Always-open: there's no per-chip toggle. Mouse-only selection.
+
+import { memo, useMemo, useState } from "react"
+import type { MouseEvent } from "@opentui/core"
+import type { ToolPart } from "../../types/message"
+import { LEFT_BAR } from "../../ui/borders"
+import { DiffBlock, isDiff } from "./DiffBlock"
+import { useTheme } from "../../theme"
+
+const base = (p: string) => p.split(/[\\/]/).pop() ?? p
+const parent = (p: string) => {
+  const parts = p.split(/[\\/]/).filter(Boolean)
+  return parts.length >= 2 ? parts[parts.length - 2] : ""
+}
+const trunc = (s: string, n: number) => s.length <= n ? s : "…" + s.slice(-(n - 1))
+
+type Tab = { id: string; label: string; diff: string; add: number; del: number }
+
+function buildTabs(tools: ToolPart[]): Tab[] {
+  const raw = tools.flatMap(t => {
+    const diff = t.diff ?? (isDiff(t.result) ? t.result : undefined)
+    if (!diff) return []
+    return [{ tool: t, path: t.preview ?? t.name, diff }]
+  })
+  // Disambiguate duplicate basenames (a/Foo.tsx + b/Foo.tsx) by prefixing
+  // the parent dir only when needed — keeps short labels short.
+  const counts = new Map<string, number>()
+  raw.forEach(r => counts.set(base(r.path), (counts.get(base(r.path)) ?? 0) + 1))
+  return raw.map(({ tool, path, diff }) => {
+    const b = base(path)
+    const dup = (counts.get(b) ?? 0) > 1 && parent(path)
+    const label = trunc(dup ? `${parent(path)}/${b}` : b, 24)
+    const lines = diff.split("\n")
+    const add = lines.filter(l => /^\+(?!\+\+)/.test(l)).length
+    const del = lines.filter(l => /^-(?!--)/.test(l)).length
+    return { id: tool.id || `${tool.name}-${path}`, label, diff, add, del }
+  })
+}
+
+export const DiffTabs = memo(({ tools }: { tools: ToolPart[] }) => {
+  const theme = useTheme().theme
+  const tabs = useMemo(() => buildTabs(tools), [tools])
+  const [active, setActive] = useState(0)
+  if (tabs.length === 0) return null
+  const cur = tabs[Math.min(active, tabs.length - 1)]
+
+  return (
+    <box
+      flexDirection="column" marginTop={1}
+      border={["left"]} borderColor={theme.border} customBorderChars={LEFT_BAR}
+      backgroundColor={theme.backgroundPanel} paddingLeft={1}
+    >
+      <box
+        flexDirection="row" flexWrap="wrap"
+        backgroundColor={theme.backgroundElement} paddingX={1}
+      >
+        {tabs.map((t, i) => {
+          const on = i === active
+          return (
+            <box
+              key={t.id} height={1} flexShrink={0} marginRight={1} paddingX={1}
+              backgroundColor={on ? theme.backgroundPanel : undefined}
+              onMouseDown={(e: MouseEvent) => { e.stopPropagation(); setActive(i) }}
+            >
+              <text fg={on ? theme.primary : theme.textMuted}>
+                {on ? <strong>{t.label}</strong> : t.label}
+              </text>
+            </box>
+          )
+        })}
+      </box>
+      <box height={1} paddingX={1}>
+        <text>
+          <span fg={theme.success}>+{cur.add}</span>
+          <span fg={theme.textMuted}> / </span>
+          <span fg={theme.error}>-{cur.del}</span>
+        </text>
+      </box>
+      <box paddingX={1} paddingBottom={1}>
+        <DiffBlock text={cur.diff} />
+      </box>
+    </box>
+  )
+})

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -4,7 +4,8 @@ import type { Message, Part, TextPart, ToolPart, PromptPart } from "../../types/
 import { ErrorBlock } from "./ErrorBlock"
 import { MediaChip, classify, splitContent } from "./MediaChip"
 import { CodeBlock } from "./CodeBlock"
-import { DiffBlock, isDiff } from "./DiffBlock"
+import { DiffTabs } from "./DiffTabs"
+import { isDiff } from "./DiffBlock"
 import { PromptCard, type PromptCardHandle } from "./PromptCard"
 import { ChafaImage } from "../../ui/ChafaImage"
 import { useTheme } from "../../theme"
@@ -34,36 +35,6 @@ function extract(msg: Message): string {
 }
 
 const trunc = (s: string, max: number) => s.length <= max ? s : s.slice(0, max - 1) + "…"
-
-// Collapsible diff chip: shows filename/preview + +N/-M, expands to full
-// DiffBlock on click. Lives in the message body so edits land in the
-// transcript (not buried in the ThoughtCloud). stopPropagation keeps the
-// click from triggering onPick on the parent message.
-const InlineDiff = memo(({ tool }: { tool: ToolPart }) => {
-  const theme = useTheme().theme
-  const [open, setOpen] = useState(false)
-  const diff = tool.diff ?? (isDiff(tool.result) ? tool.result : undefined)
-  if (!diff) return null
-  const lines = diff.split("\n")
-  const add = lines.filter(l => /^\+(?!\+\+)/.test(l)).length
-  const del = lines.filter(l => /^-(?!--)/.test(l)).length
-  return (
-    <box flexDirection="column" marginTop={1}
-         onMouseDown={(e: MouseEvent) => { e.stopPropagation(); setOpen(o => !o) }}>
-      <box height={1}>
-        <text>
-          <span fg={theme.textMuted}>{open ? "▾ " : "▸ "}</span>
-          <span fg={theme.text}>{trunc(tool.preview ?? tool.name, 50)}</span>
-          <span fg={theme.textMuted}>  </span>
-          <span fg={theme.success}>+{add}</span>
-          <span fg={theme.textMuted}> / </span>
-          <span fg={theme.error}>-{del}</span>
-        </text>
-      </box>
-      {open ? <box marginTop={1}><DiffBlock text={diff} /></box> : null}
-    </box>
-  )
-})
 
 // OpenTUI has no onClick; synthesize one from down→up at the same cell
 // so text-selection drags don't fire it.
@@ -274,7 +245,7 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
           ) : null}
         </box>
         {message.parts.map(part)}
-        {diffs.map(t => <InlineDiff key={t.id || t.name} tool={t} />)}
+        {diffs.length ? <DiffTabs tools={diffs} /> : null}
         {err ? <ErrorBlock text={message.error!} /> : null}
       </Gutter>
     </box>

--- a/test/diff-tabs.test.tsx
+++ b/test/diff-tabs.test.tsx
@@ -105,4 +105,22 @@ describe("DiffTabs", () => {
     expect(t.frame()).toContain("patch") // falls back to tool name
     t.destroy()
   })
+
+  test("strips ANSI escapes from tool.preview before using as label", async () => {
+    // Some patch tools pre-color their preview path for a pty. The chat
+    // surface must strip those bytes — OpenTUI <text> renders escapes as
+    // literal characters and the leak is loud now that preview IS the
+    // entire tab label.
+    const colored = "\x1b[38;2;21;60;115m delta\x1b[0m"
+    const t = await mountNode(
+      <DiffTabs tools={[tool("a", colored, "x")]} />,
+      { width: 80, height: 12 },
+    )
+    await until(t, () => t.frame().includes("delta"))
+    const f = t.frame()
+    expect(f).not.toMatch(/\x1b/)
+    expect(f).not.toContain("38;2;21;60;115")
+    expect(f).not.toContain("[0m")
+    t.destroy()
+  })
 })

--- a/test/diff-tabs.test.tsx
+++ b/test/diff-tabs.test.tsx
@@ -158,4 +158,42 @@ describe("DiffTabs", () => {
     await until(t, () => t.frame().includes("widget.ts"))
     t.destroy()
   })
+
+  test("sanitizes gateway CLI-rendered inline_diff (┊/summary/… cruft)", async () => {
+    // Real shape gateway sends on tool.complete: the diff body is
+    // wrapped with `┊ review diff` markers, a `+N/-M` summary line, and
+    // CLI-truncated `…` lines for context that didn't fit. None of that
+    // belongs in the rendered DiffBlock or in tab labels.
+    const cliRendered = [
+      "  ┊ review diff",
+      "--- a//tmp/diff-test/c.txt",
+      "+++ b//tmp/diff-test/c.txt",
+      "@@ -1,4 +1,4 @@",
+      "-north",
+      "+NORTH",
+      " southeast",
+      " northeast",
+      " west",
+      "… more",
+      "+1 / -1",
+    ].join("\n")
+    const t = await mountNode(
+      <DiffTabs tools={[{
+        type: "tool", id: "c", name: "patch", args: "",
+        preview: cliRendered, status: "done", duration: 5, diff: cliRendered,
+      }]} />,
+      { width: 100, height: 20 },
+    )
+    await until(t, () => t.frame().includes("c.txt"))
+    const f = t.frame()
+    // Tab label is c.txt — no ┊ / +0 / … leakage into label.
+    expect(f).not.toContain("review diff")
+    expect(f).not.toContain("┊")
+    // Body shows real hunk lines.
+    expect(f).toContain("-north")
+    expect(f).toContain("+NORTH")
+    // Body does NOT show the gateway's CLI cruft.
+    expect(f).not.toContain("… more")
+    t.destroy()
+  })
 })

--- a/test/diff-tabs.test.tsx
+++ b/test/diff-tabs.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mountNode, until } from "./harness"
+import { DiffTabs } from "../src/components/chat/DiffTabs"
+import type { ToolPart } from "../src/types/message"
+
+const udiff = (path: string, body: string) => [
+  `--- a/${path}`,
+  `+++ b/${path}`,
+  "@@ -1,3 +1,3 @@",
+  ` keep`,
+  `-old ${body}`,
+  `+new ${body}`,
+].join("\n")
+
+const tool = (id: string, preview: string, body: string): ToolPart => ({
+  type: "tool", id, name: "patch", args: "",
+  preview, status: "done", duration: 5, diff: udiff(preview, body),
+})
+
+describe("DiffTabs", () => {
+  test("renders nothing when no diff-bearing tools", async () => {
+    const t = await mountNode(<DiffTabs tools={[]} />, { width: 80, height: 8 })
+    await t.settle()
+    const f = t.frame()
+    // No left bar, no panel chrome, no @@ hunk markers.
+    expect(f).not.toContain("┃")
+    expect(f).not.toContain("@@")
+    t.destroy()
+  })
+
+  test("single diff: tab label is basename, +1/-1 row, body present", async () => {
+    const t = await mountNode(
+      <DiffTabs tools={[tool("a", "src/foo.ts", "thing")]} />,
+      { width: 80, height: 16 },
+    )
+    await until(t, () => t.frame().includes("foo.ts"))
+    const f = t.frame()
+    expect(f).toContain("foo.ts")
+    // Tab label uses basename — find the row showing "foo.ts" without the "src/" prefix.
+    const tabRow = f.split("\n").find(l => /foo\.ts/.test(l) && !/src\/foo\.ts/.test(l))
+    expect(tabRow).toBeDefined()
+    expect(f).toContain("+1")
+    expect(f).toContain("-1")
+    expect(f).toContain("+new thing")
+    t.destroy()
+  })
+
+  test("three diffs: ribbon shows all, click swaps body", async () => {
+    const tools = [
+      tool("a", "alpha.ts", "alpha"),
+      tool("b", "beta.ts", "beta"),
+      tool("c", "gamma.ts", "gamma"),
+    ]
+    const t = await mountNode(<DiffTabs tools={tools} />, { width: 100, height: 18 })
+    await until(t, () => t.frame().includes("alpha.ts") && t.frame().includes("gamma.ts"))
+    // First tab is active by default → alpha body.
+    expect(t.frame()).toContain("+new alpha")
+    expect(t.frame()).not.toContain("+new beta")
+
+    // Click 'beta.ts' label.
+    const rows = t.frame().split("\n")
+    const y = rows.findIndex(l => l.includes("beta.ts"))
+    const x = rows[y].indexOf("beta.ts")
+    await act(async () => { await t.mouse.pressDown(x, y) })
+    await until(t, () => t.frame().includes("+new beta"))
+    expect(t.frame()).not.toContain("+new alpha")
+    t.destroy()
+  })
+
+  test("duplicate basenames disambiguated by parent dir", async () => {
+    const tools = [
+      tool("a", "src/chat/Foo.tsx", "chatfoo"),
+      tool("b", "src/ui/Foo.tsx", "uifoo"),
+    ]
+    const t = await mountNode(<DiffTabs tools={tools} />, { width: 100, height: 16 })
+    await until(t, () => t.frame().includes("chat/Foo.tsx"))
+    expect(t.frame()).toContain("chat/Foo.tsx")
+    expect(t.frame()).toContain("ui/Foo.tsx")
+    t.destroy()
+  })
+
+  test("ribbon wraps to multiple rows at narrow width", async () => {
+    const tools = Array.from({ length: 8 }, (_, i) =>
+      tool(`t${i}`, `file${i}.ts`, `body${i}`))
+    const t = await mountNode(<DiffTabs tools={tools} />, { width: 40, height: 24 })
+    await until(t, () => t.frame().includes("file0.ts") && t.frame().includes("file7.ts"))
+    const rows = t.frame().split("\n")
+    const firstY = rows.findIndex(l => l.includes("file0.ts"))
+    const lastY = rows.findIndex(l => l.includes("file7.ts"))
+    // Wrap means the last tab sits below the first.
+    expect(lastY).toBeGreaterThan(firstY)
+    t.destroy()
+  })
+
+  test("falls back when tool has no preview path", async () => {
+    const t = await mountNode(
+      <DiffTabs tools={[{
+        type: "tool", id: "np", name: "patch", args: "",
+        status: "done", duration: 1, diff: udiff("x", "y"),
+      }]} />,
+      { width: 80, height: 12 },
+    )
+    await until(t, () => t.frame().includes("patch"))
+    expect(t.frame()).toContain("patch") // falls back to tool name
+    t.destroy()
+  })
+})

--- a/test/diff-tabs.test.tsx
+++ b/test/diff-tabs.test.tsx
@@ -159,15 +159,13 @@ describe("DiffTabs", () => {
     t.destroy()
   })
 
-  test("sanitizes gateway CLI-rendered inline_diff (┊/summary/… cruft)", async () => {
-    // Real shape gateway sends on tool.complete: the diff body is
-    // wrapped with `┊ review diff` markers, a `+N/-M` summary line, and
-    // CLI-truncated `…` lines for context that didn't fit. None of that
-    // belongs in the rendered DiffBlock or in tab labels.
+  test("sanitizes gateway CLI-rendered inline_diff (┊/summary/…/arrow-header)", async () => {
+    // Actual shape gateway sends: display.py's _render_inline_unified_diff
+    // REPLACES `--- a/` / `+++ b/` with `a/path → b/path` (one line),
+    // then `┊ review diff`, `+N/-M`, and `…` truncation can wrap it.
     const cliRendered = [
       "  ┊ review diff",
-      "--- a//tmp/diff-test/c.txt",
-      "+++ b//tmp/diff-test/c.txt",
+      "a//tmp/diff-test/c.txt → b//tmp/diff-test/c.txt",
       "@@ -1,4 +1,4 @@",
       "-north",
       "+NORTH",
@@ -186,14 +184,58 @@ describe("DiffTabs", () => {
     )
     await until(t, () => t.frame().includes("c.txt"))
     const f = t.frame()
-    // Tab label is c.txt — no ┊ / +0 / … leakage into label.
+    // Tab label is c.txt — no `→ b/` arrow leakage into label.
     expect(f).not.toContain("review diff")
     expect(f).not.toContain("┊")
+    // The arrow-header line itself isn't rendered as a diff row.
+    const bodyRows = f.split("\n").filter(l => /→ b/.test(l))
+    expect(bodyRows.length).toBe(0)
     // Body shows real hunk lines.
     expect(f).toContain("-north")
     expect(f).toContain("+NORTH")
-    // Body does NOT show the gateway's CLI cruft.
     expect(f).not.toContain("… more")
+    t.destroy()
+  })
+
+  test("five parallel patches → five distinct basenames in tab strip", async () => {
+    // Real bug from screenshot: five tabs all read as diff body tails
+    // (`…@`, `… autumn`, `…)`) because pathFor was falling through to
+    // the wrong source. With DIFF_HEAD_ARROW each tool gets its own path.
+    const mk = (name: string, old: string, neu: string) => ({
+      type: "tool" as const,
+      id: `t-${name}`, name: "patch", args: "",
+      status: "done" as const, duration: 5,
+      diff: [
+        "  ┊ review diff",
+        `a//tmp/diff-test/${name} → b//tmp/diff-test/${name}`,
+        "@@ -1,4 +1,4 @@",
+        `-${old}`,
+        `+${neu}`,
+        " unchanged",
+        "+1 / -1",
+      ].join("\n"),
+    })
+    const tools = [
+      mk("sample.txt", "line one", "LINE ONE"),
+      mk("greek.txt", "alpha", "ALPHA"),
+      mk("colors.txt", "red", "RED"),
+      mk("c.txt", "west", "WEST"),
+      mk("d.txt", "winter", "WINTER"),
+    ]
+    const t = await mountNode(<DiffTabs tools={tools} />, { width: 120, height: 24 })
+    await until(t, () => t.frame().includes("sample.txt"))
+    const f = t.frame()
+    expect(f).toContain("sample.txt")
+    expect(f).toContain("greek.txt")
+    expect(f).toContain("colors.txt")
+    expect(f).toContain("c.txt")
+    expect(f).toContain("d.txt")
+    // None of the previously-leaked diff-body tails should appear in the
+    // tab strip area (above the `+A / -B` line).
+    const lines = f.split("\n")
+    const countLineY = lines.findIndex(l => /\+\d+\s*\/\s*-\d+/.test(l))
+    const stripText = lines.slice(0, countLineY).join("\n")
+    expect(stripText).not.toMatch(/…@|… autumn|…\)/)
     t.destroy()
   })
 })

--- a/test/diff-tabs.test.tsx
+++ b/test/diff-tabs.test.tsx
@@ -101,8 +101,8 @@ describe("DiffTabs", () => {
       }]} />,
       { width: 80, height: 12 },
     )
-    await until(t, () => t.frame().includes("patch"))
-    expect(t.frame()).toContain("patch") // falls back to tool name
+    // No args, no preview — pathFor falls back to the diff's `+++ b/x` header.
+    await until(t, () => t.frame().includes("+new y"))
     t.destroy()
   })
 
@@ -121,6 +121,41 @@ describe("DiffTabs", () => {
     expect(f).not.toMatch(/\x1b/)
     expect(f).not.toContain("38;2;21;60;115")
     expect(f).not.toContain("[0m")
+    t.destroy()
+  })
+
+  test("extracts path from JSON args (gateway sends args blob in preview)", async () => {
+    // tool.start.context for patch/write_file tools is the raw args JSON,
+    // not a path. Without args→path extraction, base() splits the JSON tail
+    // and labels read like "…@" / "…ueberry" (real bug — see screenshot).
+    const argsBlob = JSON.stringify({
+      path: "/tmp/diff-test/b.txt",
+      old_string: "cherry",
+      new_string: "CHERRY",
+    })
+    const t = await mountNode(
+      <DiffTabs tools={[{
+        type: "tool", id: "p1", name: "patch",
+        args: argsBlob, preview: argsBlob,
+        status: "done", duration: 5, diff: udiff("/tmp/diff-test/b.txt", "z"),
+      }]} />,
+      { width: 80, height: 14 },
+    )
+    await until(t, () => t.frame().includes("b.txt"))
+    expect(t.frame()).not.toMatch(/…@|…ueberry|"path"/)
+    t.destroy()
+  })
+
+  test("falls back to unified-diff +++ header when args lack a path", async () => {
+    // No JSON args; the diff body's `+++ b/<path>` header is the next-best source.
+    const t = await mountNode(
+      <DiffTabs tools={[{
+        type: "tool", id: "p2", name: "patch", args: "",
+        status: "done", duration: 5, diff: udiff("src/widget.ts", "z"),
+      }]} />,
+      { width: 80, height: 14 },
+    )
+    await until(t, () => t.frame().includes("widget.ts"))
     t.destroy()
   })
 })


### PR DESCRIPTION
Follow-up to #51 (merged at 246f3ec, before these commits landed). The 5 DiffTabs commits got orphaned on the branch after merge; reopening as a separate PR. The 4 already-merged triage commits will show as no-ops vs current dev.

Replaces the bottom-of-turn stack of \`▸ <preview> +N/-M\` collapsible chips with one CodeBlock-style frame whose header is a wrapping ribbon of file tabs (basenames). Active tab swaps the DiffBlock body.

**Wire-shape work (4 iterations to get right):**
- \`tool.preview\` from gateway can be pre-colored ANSI for patch tools → strip with \`/\x1b\[[0-9;?]*[A-Za-z]/g\`.
- \`turnReducer\` only sets \`args\` when preview starts with \`{\` — for clean-path previews \`args\` stays empty. \`pathFor()\` falls back to diff headers.
- \`agent/display.py::_render_inline_unified_diff\` **REPLACES** \`--- a/\` / \`+++ b/\` headers with a single arrow-form line \`a/path → b/path\`. Regex must match this form first; standard headers are a fallback for tools that don't go through that renderer.
- Gateway wraps \`inline_diff\` with \`┊ review diff\`, \`+N/-M\` summary, and \`…\` truncation lines. \`sanitizeDiff()\` strips them before \`DiffBlock\`.

**Files:**
- \`src/components/chat/DiffTabs.tsx\` (new)
- \`src/components/chat/MessageItem.tsx\` (swap, delete old \`InlineDiff\`)
- \`test/diff-tabs.test.tsx\` (11 tests: single, multi-tab swap, dup basenames, wrap, ANSI strip, JSON args, arrow-form regression for 5 parallel patches)

\`bunx tsc --noEmit\` clean. \`bun test\` 884 pass / 0 fail.