### PR TITLE
fix: resolve agent root from HERMES_HOME

### DIFF
--- a/src/context/gateway-client.ts
+++ b/src/context/gateway-client.ts
@@ -13,12 +13,14 @@ const STARTUP_MS = 15_000
 const REQUEST_MS = 120_000
 
 /** Locate the hermes-agent source tree (gateway + hermes_cli live here).
- *  Default: ~/.hermes/hermes-agent (where `hermes update` installs it).
- *  Override with HERMES_AGENT_ROOT for dev clones / exotic layouts. */
+ *  HERMES_AGENT_ROOT is the explicit override for dev clones / exotic layouts.
+ *  Otherwise, follow HERMES_HOME when set and fall back to ~/.hermes. */
 export function hermesAgentRoot(): string {
   if (process.env.HERMES_AGENT_ROOT) return process.env.HERMES_AGENT_ROOT
+  const hermesHome = process.env.HERMES_HOME?.trim()
+  if (hermesHome) return resolve(hermesHome, "hermes-agent")
   const home = process.env.HOME || homedir()
-  return `${home}/.hermes/hermes-agent`
+  return resolve(home, ".hermes", "hermes-agent")
 }
 
 type Pending = {

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { join, resolve } from "path"
 import { tmpdir } from "os"
-import { python } from "../src/context/gateway-client"
+import { hermesAgentRoot, python } from "../src/context/gateway-client"
 
 const withEnv = <T>(key: string, value: string | undefined, fn: () => T): T => {
   const prev = process.env[key]
@@ -16,6 +16,34 @@ const withEnv = <T>(key: string, value: string | undefined, fn: () => T): T => {
 }
 
 const tmp = () => mkdtempSync(join(tmpdir(), "herm-gateway-"))
+
+describe("hermesAgentRoot", () => {
+  test("uses HERMES_AGENT_ROOT when set", () => {
+    withEnv("HERMES_AGENT_ROOT", resolve("custom", "agent"), () => {
+      withEnv("HERMES_HOME", resolve("custom", "home"), () => {
+        expect(hermesAgentRoot()).toBe(resolve("custom", "agent"))
+      })
+    })
+  })
+
+  test("falls back to HERMES_HOME/hermes-agent", () => {
+    withEnv("HERMES_AGENT_ROOT", undefined, () => {
+      withEnv("HERMES_HOME", resolve("custom", "home"), () => {
+        expect(hermesAgentRoot()).toBe(resolve("custom", "home", "hermes-agent"))
+      })
+    })
+  })
+
+  test("falls back to HOME/.hermes/hermes-agent", () => {
+    withEnv("HERMES_AGENT_ROOT", undefined, () => {
+      withEnv("HERMES_HOME", undefined, () => {
+        withEnv("HOME", resolve("custom", "user"), () => {
+          expect(hermesAgentRoot()).toBe(resolve("custom", "user", ".hermes", "hermes-agent"))
+        })
+      })
+    })
+  })
+})
 
 describe("python", () => {
   test("uses HERMES_PYTHON when set", () => {


### PR DESCRIPTION
## Summary

Make gateway agent-root discovery honor `HERMES_HOME` when `HERMES_AGENT_ROOT` is not set.

This matches the discovery order already documented/used by `scripts/gen-schema.ts`:

1. `HERMES_AGENT_ROOT` explicit override
2. `HERMES_HOME/hermes-agent`
3. `~/.hermes/hermes-agent` fallback

## Why

Native Windows Hermes installations commonly live under `%LOCALAPPDATA%\hermes`. If `HERMES_HOME` points there but `HERMES_AGENT_ROOT` is not set, the TUI currently falls back to `~/.hermes/hermes-agent`, so it may fail to locate the gateway/source tree.

## Tests

- `bun test test/gateway-client.test.ts`
- `bunx tsc --noEmit`
