### PR TITLE
Fix model picker selection and resume provider

### DIFF
--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -2,7 +2,7 @@
 
 import { useMemo, useCallback } from "react"
 import * as preferences from "../context/preferences"
-import { sdb } from "../service/sessions-db"
+import { sdb, byId } from "../service/sessions-db"
 import { useGateway } from "../context/gateway"
 import { transcriptToMessages } from "./turnReducer"
 import type { Launch } from "./launch"
@@ -13,6 +13,12 @@ import type {
   TranscriptMessage,
 } from "../context/wire"
 import type { Message, Usage } from "../types/message"
+
+const spec = (row: ReturnType<typeof byId>) => {
+  if (!row?.model) return null
+  if (!row.billing_provider) return row.model
+  return `${row.model} --provider ${row.billing_provider}`
+}
 
 /** session.compress response shape — see upstream fc7f55f49.
  *
@@ -66,10 +72,13 @@ export function useSession(): SessionOps {
     // No tip-chasing here: Sessions-tab lineage walk and `/resume <id>`
     // pass exact ids on purpose; boot() resolves tips itself.
     const target = normalize(sid)
+    const row = byId(target)
     const res = await gw.request<SessionResumeResponse>("session.resume", { session_id: target })
     const id = res.session_id
     gw.setSession(id)
     preferences.set("lastSessionId", res.resumed ?? target)
+    const model = spec(row)
+    if (model) await gw.request("config.set", { key: "model", value: model }).catch(() => {})
     const messages = res.messages?.length ? transcriptToMessages(res.messages) : []
     return { id, messages }
   }, [gw])

--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -74,12 +74,14 @@ const ModelPickerDialog = (props: Props) => {
   if (!data) return <box width={50} padding={1}><text>Loading models…</text></box>
 
   if (step === "provider") {
-    const options: SelectOption[] = (data.providers ?? []).map(p => ({
-      title: p.name,
-      value: p.slug,
-      description: p.total_models ? `${p.total_models} models` : undefined,
-      category: p.is_current ? "Current" : "Available",
-    }))
+    const options: SelectOption[] = (data.providers ?? [])
+      .toSorted((a, b) => Number(Boolean(b.is_current)) - Number(Boolean(a.is_current)))
+      .map(p => ({
+        title: p.name,
+        value: p.slug,
+        description: p.total_models ? `${p.total_models} models` : undefined,
+        category: p.is_current ? "Current" : "Available",
+      }))
     return (
       <DialogSelect
         title={props.title ?? "Switch Provider"}
@@ -103,7 +105,7 @@ const ModelPickerDialog = (props: Props) => {
     <DialogSelect
       title={props.title ? `${props.title} · ${p?.name ?? provider}` : `Switch Model (${p?.name ?? provider})`}
       options={options}
-      current={data.model}
+      current={provider === data.provider ? data.model : undefined}
       onSelect={(o) => {
         if (provider) apply(o.value, provider)
         dialog.clear()

--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -90,6 +90,7 @@ export interface SessionRow {
   id: string
   sessionSource: string
   model: string | null
+  billing_provider: string | null
   started_at: number
   ended_at: number | null
   end_reason: string | null
@@ -180,7 +181,7 @@ export const kind = (
 // correlated subqueries — cheap at herm's DB sizes (thousands of rows)
 // and keeps the outer query a plain single-table scan.
 const COLS = `
-  s.id, s.source, s.model, s.started_at, s.ended_at, s.end_reason,
+  s.id, s.source, s.model, s.billing_provider, s.started_at, s.ended_at, s.end_reason,
   s.message_count, s.tool_call_count,
   s.input_tokens, s.output_tokens,
   s.cache_read_tokens, s.cache_write_tokens, s.reasoning_tokens,
@@ -196,7 +197,7 @@ const COLS = `
      AND (s.ended_at IS NULL OR c.started_at < s.ended_at)) AS subagent_count`
 
 type Raw = {
-  id: string; source: string; model: string | null
+  id: string; source: string; model: string | null; billing_provider: string | null
   started_at: number; ended_at: number | null; end_reason: string | null
   message_count: number; tool_call_count: number
   input_tokens: number; output_tokens: number
@@ -211,6 +212,7 @@ const toRow = (r: Raw, lineage: string | null = null): SessionRow => ({
   id: r.id,
   sessionSource: r.source,
   model: r.model,
+  billing_provider: r.billing_provider,
   started_at: r.started_at,
   ended_at: r.ended_at,
   end_reason: r.end_reason,

--- a/src/ui/dialog-select.tsx
+++ b/src/ui/dialog-select.tsx
@@ -73,14 +73,22 @@ export const DialogSelect = (props: Props) => {
     return map
   }, [filtered])
 
+  const rowId = (i: number) => `ds-row-${i}`
+
+  const scrollTo = (i: number) => sb.current?.scrollChildIntoView(rowId(i))
+
   // Clamp cursor
   useEffect(() => {
     if (cursor >= filtered.length) setCursor(Math.max(0, filtered.length - 1))
   }, [filtered.length, cursor])
 
-  const rowId = (i: number) => `ds-row-${i}`
-
-  const scrollTo = (i: number) => sb.current?.scrollChildIntoView(rowId(i))
+  useEffect(() => {
+    if (!props.current) { setCursor(0); return }
+    const i = filtered.findIndex(o => o.value === props.current)
+    const n = Math.max(0, i)
+    setCursor(n)
+    scrollTo(n)
+  }, [props.current, filtered])
 
   // Notify on move
   useEffect(() => {

--- a/test/fixtures/state-db.ts
+++ b/test/fixtures/state-db.ts
@@ -24,7 +24,7 @@ export const openStateDb = (): Database => {
   mkdirSync(HH, { recursive: true })
   const db = new Database(`${HH}/state.db`, { create: true })
   db.run(`CREATE TABLE IF NOT EXISTS sessions (
-    id TEXT PRIMARY KEY, title TEXT, source TEXT, model TEXT,
+    id TEXT PRIMARY KEY, title TEXT, source TEXT, model TEXT, billing_provider TEXT,
     started_at REAL, ended_at REAL, end_reason TEXT,
     message_count INTEGER DEFAULT 0, tool_call_count INTEGER DEFAULT 0,
     input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -156,6 +156,23 @@ describe("useSession.boot", () => {
     expect(gw.last("session.resume")?.params.session_id).toBe("real")
   })
 
+  test("mode:resume switches live model to the stored provider/model", async () => {
+    const db = seed()
+    sess(db, "past", "tui", 1005, 5, { model: "gpt-5.5", billing_provider: "openai-codex" })
+    db.close()
+    resetDb()
+
+    const sets: Array<Record<string, unknown>> = []
+    const gw = new MockGateway({
+      "session.resume": p => ({ session_id: "live-past", resumed: p.session_id, messages: [] }),
+      "config.set": p => { sets.push(p); return { value: p.value } },
+    })
+    await boot(gw, { mode: "resume", sid: "past" })
+
+    expect(gw.last("session.resume")?.params.session_id).toBe("past")
+    expect(sets).toEqual([{ session_id: "live-past", key: "model", value: "gpt-5.5 --provider openai-codex" }])
+  })
+
   test("mode:resume normalizes session_*.json filenames", async () => {
     const gw = new MockGateway()
     await boot(gw, { mode: "resume", sid: "session_20260509_002407_e8b6e4.json" })

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -73,4 +73,50 @@ describe("model-picker", () => {
     expect(sets[0].session_id).toBeUndefined()
     t.destroy()
   })
+
+  test("provider dialog leads with current provider and Enter selects it", async () => {
+    const opts = {
+      provider: "anthropic",
+      model: "claude-3",
+      providers: [
+        { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
+        { slug: "anthropic", name: "Anthropic", is_current: true, total_models: 2, models: ["claude-3", "claude-4"] },
+      ],
+    }
+    const t = await mountNode(<Open />, {
+      handlers: { "model.options": () => opts },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+    expect(t.frame().indexOf("Current")).toBeLessThan(t.frame().indexOf("Available"))
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Switch Model (Anthropic)"))
+    expect(t.frame()).toContain("claude-3")
+    t.destroy()
+  })
+
+  test("model step only marks current model for current provider", async () => {
+    const opts = {
+      provider: "anthropic",
+      model: "shared",
+      providers: [
+        { slug: "anthropic", name: "Anthropic", is_current: true, total_models: 1, models: ["shared"] },
+        { slug: "openai", name: "OpenAI", total_models: 2, models: ["shared", "gpt-4"] },
+      ],
+    }
+    const t = await mountNode(<Open />, {
+      handlers: { "model.options": () => opts },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+
+    act(() => t.keys.pressArrow("down"))
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Switch Model (OpenAI)"))
+
+    const row = t.frame().split("\n").find(l => l.includes("shared")) ?? ""
+    expect(row).not.toContain("●")
+    t.destroy()
+  })
+
 })

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -17,7 +17,7 @@ const NOIO = { list: () => [], search: () => [], remove: () => true, rename: () 
 // Stub SessionRow fields we actually consume; zero the rest.
 const detail = (over: Partial<SessionRow> & { id: string; sessionSource: string }): SessionRow => ({
   source: { file: "/tmp/state.db", relative: "state.db", label: "state.db" },
-  model: null, started_at: 1699999000, ended_at: null, end_reason: null,
+  model: null, billing_provider: null, started_at: 1699999000, ended_at: null, end_reason: null,
   message_count: 0, tool_call_count: 0,
   input_tokens: 0, output_tokens: 0,
   cache_read_tokens: 0, cache_write_tokens: 0, reasoning_tokens: 0,


### PR DESCRIPTION
## Summary
- keeps the current provider at the top of the model picker and syncs the cursor to the displayed current item
- only marks a model as current when the model list belongs to the active provider
- restores both provider and model when resuming a session, so provider-local model names do not get applied through the wrong provider

## Test plan
- `bun test test/model-picker.test.tsx test/launch.test.tsx test/sessions.test.tsx`
- `bunx tsc --noEmit`
