### PR TITLE
fix: avoid Map.groupBy in skills tab

### DIFF
--- a/src/tabs/Skills.tsx
+++ b/src/tabs/Skills.tsx
@@ -74,6 +74,12 @@ const HitRow = memo((props: { hit: Hit; selected: boolean; onHover: () => void }
   );
 });
 
+const bycat = (skills: SkillInfo[]) => skills.reduce((map, s) => {
+  const cat = s.category || "uncategorized"
+  map.set(cat, [...(map.get(cat) ?? []), s])
+  return map
+}, new Map<string, SkillInfo[]>())
+
 const line = (e: LineageEvent): string => {
   switch (e.kind) {
     case "absorbed":   return `absorbed ${e.sources.map(s => `\`${s}\``).join(", ")}`
@@ -321,7 +327,7 @@ export const Skills = memo((props: { focused?: boolean }) => {
           return tb - ta;
         })],
       ])
-    : Map.groupBy(skills, s => s.category || "uncategorized");
+    : bycat(skills);
 
   // Flat list for keyboard navigation
   const flat = [...groups].flatMap(([cat, items]) => [

--- a/test/skills.test.tsx
+++ b/test/skills.test.tsx
@@ -6,6 +6,23 @@ import { hermesPath } from "../src/service/hermes-home"
 import { Skills } from "../src/tabs/Skills"
 
 describe("Skills tab", () => {
+  test("renders installed skills without native Map.groupBy", async () => {
+    const group = Map.groupBy
+    Map.groupBy = undefined as unknown as typeof Map.groupBy
+    try {
+      const gw = new MockGateway({
+        "skills.manage": p => p.action === "list"
+          ? { skills: { general: ["local-skill"] } } : {},
+      })
+      const t = await mountNode(<Skills focused />, { gw, width: 160 })
+      await until(t, () => t.frame().includes("Skills (1)"))
+      expect(t.frame()).toContain("local-skill")
+      t.destroy()
+    } finally {
+      Map.groupBy = group
+    }
+  })
+
   test("enriches description/tags from SKILL.md frontmatter on disk", async () => {
     const dir = hermesPath("skills/general/local-skill")
     mkdirSync(dir, { recursive: true })


### PR DESCRIPTION
## Summary
- Replaces the Skills tab `Map.groupBy` dependency with local reducer-based grouping.
- Adds a regression test covering Skills render when native `Map.groupBy` is unavailable.

## Test Plan
- `bun test test/skills.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
- `bun test`
- Compiled bundle CONTROL smoke test: Config → Skills with 52 seeded skills

Closes #54
