### PR TITLE
feat: flag review-required kanban tasks

### DIFF
--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -160,6 +160,8 @@ const Card = memo((p: {
   onHover: () => void; onPick: () => void
 }) => {
   const theme = useTheme().theme
+  const title = `${p.t.review_required ? "⚑ " : ""}${p.t.title}`
+  const label = p.t.review_count ? `  ${p.t.review_count} review${p.t.review_count === 1 ? "" : "s"}` : ""
   return (
     <box id={p.id} height={2} flexDirection="row" paddingLeft={1}
          border={RULE} borderStyle="single" borderColor={theme.borderSubtle}
@@ -167,7 +169,7 @@ const Card = memo((p: {
          onMouseDown={p.onPick}
          onMouseMove={p.onHover}>
       <Ticker active={p.on || p.hov} fg={p.on ? theme.accent : theme.text}>
-        {p.t.title}
+        {`${title}${label}`}
       </Ticker>
     </box>
   )

--- a/src/utils/hermes-kanban.ts
+++ b/src/utils/hermes-kanban.ts
@@ -47,6 +47,7 @@ export type Task = {
   workspace_kind: string | null; workspace_path: string | null
   skills: string[]
   max_runtime_seconds: number | null
+  review_required: boolean; review_count: number
 }
 
 export type Run = {
@@ -237,7 +238,26 @@ const toTask = (r: Record<string, unknown>): Task => ({
   workspace_path: (r.workspace_path as string) ?? null,
   skills: parseSkills(r.skills),
   max_runtime_seconds: (r.max_runtime_seconds as number) ?? null,
+  review_required: Boolean(r.review_required),
+  review_count: Number(r.review_count) || 0,
 })
+
+const reviewOf = (conn: Database): Map<string, number> => {
+  try {
+    const rows = conn.query(
+      `SELECT task_id, COUNT(*) AS n FROM task_comments
+       WHERE lower(body) LIKE '%review-required%'
+       GROUP BY task_id`,
+    ).all() as Array<{ task_id: string; n: number }>
+    return new Map(rows.map(r => [r.task_id, Number(r.n) || 1]))
+  } catch { return new Map() }
+}
+
+const markReview = (t: Task, m: Map<string, number>): Task => {
+  const n = m.get(t.id) ?? 0
+  if (!n) return t
+  return { ...t, review_required: true, review_count: n }
+}
 
 const toRun = (r: Record<string, unknown>): Run => ({
   id: Number(r.id),
@@ -278,8 +298,9 @@ export function boardOf(s: string): Map<Status, Task[]> {
        FROM tasks WHERE status != 'archived'
        ORDER BY priority DESC, updated_at DESC`,
     ).all() as Array<Record<string, unknown>>
+    const reviews = reviewOf(conn)
     for (const r of rows) {
-      const t = toTask(r)
+      const t = markReview(toTask(r), reviews)
       out.get(t.status)?.push(t)
     }
   } catch {}
@@ -312,7 +333,7 @@ export function detailOf(s: string, id: string): Detail | null {
     const events = eventsOf(conn, id)
     const latest = latestSummary(conn, id)
     return {
-      ...toTask(row), parents, children, comments,
+      ...markReview(toTask(row), reviewOf(conn)), parents, children, comments,
       runs, events, latest_summary: latest,
     }
   } catch { return null }

--- a/test/context.test.tsx
+++ b/test/context.test.tsx
@@ -133,7 +133,7 @@ describe("Context tab", () => {
   describe("keyboard nav", () => {
     const msgs: Message[] = [{
       id: "m1", role: "user", timestamp: 0,
-      parts: [{ type: "text", content: "hello world ".repeat(50) }],
+      parts: [{ type: "text", content: "hello world ".repeat(50), streaming: false }],
       usage: { input: 200, output: 0, total: 200 },
     }]
     const info: SessionInfo = { model: "test", context_max: 10_000 }

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -68,6 +68,8 @@ beforeAll(() => {
   db.run("INSERT INTO task_links (parent_id, child_id) VALUES ('t1','t3'),('t2','t3')")
   db.run("INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?,?,?,?)",
     ["t1", "kaio", "check AWS reserved pricing too", now - 1000])
+  db.run("INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?,?,?,?)",
+    ["t5", "worker", "review-required: implementation ready for eyes", now - 700])
   db.close()
 
   // Second board with its own DB + log dir, and board.json metadata.
@@ -96,6 +98,7 @@ describe("hermes-kanban readers", () => {
     expect(b.get("blocked")?.[0]?.id).toBe("t5")
     expect(b.get("done")?.[0]?.result).toContain("memo.md")
     expect(b.get("triage")).toEqual([])
+    expect(b.get("blocked")?.[0]?.review_required).toBe(true)
   })
 
   test("boardOf() reads per-slug without touching current", () => {
@@ -182,6 +185,8 @@ describe("Kanban tab", () => {
     // One-line cards: title renders, meta line does not.
     expect(f).toContain("research cost")
     expect(f).toContain("upgrade forge")
+    expect(f).toContain("1 review")
+    expect(f).toContain("⚑ need decision")
     expect(f).not.toMatch(/t2\s+researcher\s+P3/)
     t.destroy()
   })


### PR DESCRIPTION
## Summary
- derive `review_required` / `review_count` for Kanban tasks from review-required comments
- show a compact ⚑ marker and inline review count on one-line Kanban cards
- cover board reader and TUI render behavior in Kanban tests

## Test Plan
- `npx --yes bun@latest test test/kanban.test.tsx --timeout 30000`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x tsc --noEmit` (still blocked by pre-existing `test/context.test.tsx(136,15)` fixture missing `streaming`)
