### PR TITLE
feat: flag review-required kanban tasks

### DIFF
--- a/src/service/hermes-kanban.ts
+++ b/src/service/hermes-kanban.ts
@@ -60,6 +60,7 @@ export type Task = {
   model_override: string | null
   session_id: string | null
   last_heartbeat_at: number | null
+  review_required: boolean; review_count: number
 }
 
 export type Run = {
@@ -516,7 +517,26 @@ const toTask = (r: Record<string, unknown>): Task => ({
   model_override: (r.model_override as string) ?? null,
   session_id: (r.session_id as string) ?? null,
   last_heartbeat_at: (r.last_heartbeat_at as number) ?? null,
+  review_required: Boolean(r.review_required),
+  review_count: Number(r.review_count) || 0,
 })
+
+const reviewOf = (conn: Database): Map<string, number> => {
+  try {
+    const rows = conn.query(
+      `SELECT task_id, COUNT(*) AS n FROM task_comments
+       WHERE lower(body) LIKE '%review-required%'
+       GROUP BY task_id`,
+    ).all() as Array<{ task_id: string; n: number }>
+    return new Map(rows.map(r => [r.task_id, Number(r.n) || 1]))
+  } catch { return new Map() }
+}
+
+const markReview = (t: Task, m: Map<string, number>): Task => {
+  const n = m.get(t.id) ?? 0
+  if (!n) return t
+  return { ...t, review_required: true, review_count: n }
+}
 
 const toRun = (r: Record<string, unknown>): Run => ({
   id: Number(r.id),
@@ -573,8 +593,9 @@ export function boardOf(s: string): Map<Status, Task[]> {
        FROM tasks WHERE status != 'archived'
        ORDER BY priority DESC, updated_at DESC`,
     ).all() as Array<Record<string, unknown>>
+    const reviews = reviewOf(conn)
     for (const r of rows) {
-      const t = toTask(r)
+      const t = markReview(toTask(r), reviews)
       out.get(t.status)?.push(t)
     }
     errors.delete(s)
@@ -623,7 +644,7 @@ export function detailOf(s: string, id: string): Detail | null {
     const attachments = attachmentsOf(conn, s, id)
     const latest = latestSummary(conn, id)
     return {
-      ...toTask(row), parents, children, comments,
+      ...markReview(toTask(row), reviewOf(conn)), parents, children, comments,
       runs, events, attachments, latest_summary: latest,
     }
   } catch { return null }

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -188,6 +188,8 @@ const Card = memo((p: {
   onHover: () => void; onPick: () => void
 }) => {
   const theme = useTheme().theme
+  const title = `${p.t.review_required ? "⚑ " : ""}${p.t.title}`
+  const label = p.t.review_count ? `  ${p.t.review_count} review${p.t.review_count === 1 ? "" : "s"}` : ""
   return (
     <box id={p.id} height={2} flexDirection="row" paddingLeft={1}
          border={RULE} borderStyle="single" borderColor={theme.borderSubtle}
@@ -198,7 +200,7 @@ const Card = memo((p: {
         {p.sev
           ? <><span fg={sevColor(p.sev, theme)}>{SEV_GLYPH[p.sev]}</span>{" "}</>
           : null}
-        {p.t.title}
+        {`${title}${label}`}
       </Ticker>
     </box>
   )

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -94,6 +94,8 @@ beforeAll(() => {
     (task_id, filename, stored_path, content_type, size, uploaded_by, created_at)
     VALUES (?, ?, ?, ?, ?, ?, ?)`,
     ["t1", "spec.pdf", defaultBlob, "application/pdf", 9, "kaio", now - 900])
+  db.run("INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?,?,?,?)",
+    ["t5", "worker", "review-required: implementation ready for eyes", now - 700])
   db.close()
 
   // Second board with its own DB + log dir, and board.json metadata.
@@ -129,6 +131,7 @@ describe("hermes-kanban readers", () => {
     expect(b.get("blocked")?.[0]?.id).toBe("t5")
     expect(b.get("done")?.[0]?.result).toContain("memo.md")
     expect(b.get("triage")?.[0]?.id).toBe("t0")
+    expect(b.get("blocked")?.[0]?.review_required).toBe(true)
   })
 
   test("boardOf() reads per-slug without touching current", () => {
@@ -370,6 +373,8 @@ describe("Kanban tab", () => {
     // One-line cards: title renders, meta line does not.
     expect(f).toContain("research cost")
     expect(f).toContain("upgrade forge")
+    expect(f).toMatch(/1 rev(?:iew)?/)
+    expect(f).toContain("⚑ need decision")
     expect(f).not.toMatch(/t2\s+researcher\s+P3/)
     t.destroy()
   })


### PR DESCRIPTION
## Summary
- derive `review_required` / `review_count` for Kanban tasks from review-required comments
- show a compact ⚑ marker and inline review count on one-line Kanban cards while preserving existing diagnostics severity glyphs
- cover board reader and TUI render behavior in Kanban tests

## Test Plan
- `npx --yes bun@latest install`
- `npx --yes bun@latest test test/kanban.test.tsx --timeout 30000`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x tsc --noEmit`
