### PR TITLE
fix: debounce process notification events in TUI

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,6 +50,8 @@ import { makeGoalHook } from "./app/goalHook"
 import type { Launch } from "./app/launch"
 import { PluginProvider, usePlugins } from "./plugins/runtime"
 import { BackgroundProvider } from "./app/background"
+import { useVoice } from "./voice/useVoice"
+import { VoiceIndicator } from "./voice/Indicator"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch }
 
@@ -190,6 +192,20 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // Live ref so send() (stable for queue-drain) reads the current catalog
   // without re-creating itself on every catalog refresh.
   const cmdsRef = useRef(cmds); cmdsRef.current = cmds
+
+  // ── Voice ──────────────────────────────────────────────────────────
+  const sys = useCallback((text: string) => dispatch({ kind: "system", text }), [])
+  const voice = useVoice(gw.request.bind(gw), sys)
+  // Transcript → composer: insert text and auto-send (CLI parity).
+  useEffect(() => {
+    voice.setOnTranscript((text: string) => {
+      const c = composer.current
+      if (!c) return
+      c.set("")
+      // Defer submit so the cleared input commits before send reads it.
+      setTimeout(() => sendRef.current(text), 0)
+    })
+  }, [])
 
   // Transient error pulse — set on any reducer {kind:"error"} or
   // gateway exit; cleared when the avatar's play-once error clip
@@ -624,6 +640,9 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       c?.set("")
       toast.show({ variant: "info", message: `stashed (${n})` })
     },
+    voiceRecordKey: voice.state.recordKey,
+    voiceEnabled: voice.state.enabled,
+    onVoiceRecord: () => voice.record(sidRef.current),
   })
   useBridge({
     tab, ready, streaming: turn.streaming, messages: turn.messages, sid, focusRegion,
@@ -707,6 +726,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
               ) : null}
             </box>
             <box flexShrink={0} zIndex={1}>
+              <VoiceIndicator voice={voice.state} keyLabel={voice.keyLabel} />
               <Composer
                 ref={composer}
                 focused={inputFocused} ready={ready} streaming={turn.streaming}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -448,7 +448,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     dispatch, session, turnRef, queueRef, sendRef, composer, summoned, undone,
     ready, info, sid, title, skin,
     setQueue, setFocusRegion, setSplash, setAttachments, setInfo, setUsage, setTitle,
-    newSession, switchSession, rewind, goTo, attachClipboard,
+    newSession, switchSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
   })
   const send = useCallback(async (raw: string) => {
     // Bare exit/quit/:q — pass through as literals so a

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -77,6 +77,7 @@ export type SlashCtx = {
   rewind: (m: Message) => Promise<void>
   goTo: (tab: number, sub: number) => void
   attachClipboard: () => void
+  voiceToggle: (action: string, sid: string) => Promise<void>
 }
 
 export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void {
@@ -364,10 +365,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "voice":
-          gw.request<{ enabled?: boolean; tts?: boolean }>("voice.toggle",
-            { action: (arg || "status").toLowerCase() })
-            .then(r => x.dispatch({ kind: "system",
-              text: `voice ${r.enabled ? "on" : "off"}${r.tts ? " · tts on" : ""}` }))
+          x.voiceToggle((arg || "status").toLowerCase(), x.sid)
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "mouse": {

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -70,6 +70,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "splash", description: "Show the launch splash",              category: "Client",  aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "goal",   description: "Set/control the session goal",        category: "Session", aliases: [], argsHint: "[text|done|pause|resume|clear|status]", subcommands: ["done", "pause", "resume", "clear", "status"], source: "command", target: "gateway" },
   { name: "skin",   description: "Switch Hermes skin (+ theme + eikon)", category: "Client",  aliases: [], argsHint: "[name]", subcommands: [...SKINS], source: "local", target: "local" },
+  { name: "voice",  description: "Toggle voice recording",               category: "Client",  aliases: [], argsHint: "[on|off|status|tts]", subcommands: ["on", "off", "status", "tts"], source: "local", target: "local" },
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
 ]

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -21,6 +21,8 @@ import { Selection } from "../utils/selection"
 import { useKeys, conflicts } from "../keys"
 import { print as chordPrint } from "../keys/chord"
 import type { ComposerHandle } from "../components/chat/Composer"
+import { isVoiceToggleKey } from "../voice/platform"
+import type { VoiceKey } from "../voice/types"
 
 const INTERRUPT_MS = 5000
 export const DOUBLE_TAB_MS = 400
@@ -60,6 +62,12 @@ type Opts = {
   onNotice: (text: string) => void
   onToggleSidebar: () => void
   onStash: () => void
+  /** Voice recording key binding + handler from useVoice hook. */
+  voiceRecordKey?: VoiceKey
+  /** True when voice recording mode is on (/voice on). */
+  voiceEnabled?: boolean
+  /** Toggle push-to-talk recording (start or stop). */
+  onVoiceRecord?: () => void
 }
 
 export function useAppKeys(o: Opts) {
@@ -162,6 +170,14 @@ export function useAppKeys(o: Opts) {
     // handles Esc-to-close; tabs/composer/interrupt all sit behind the
     // overlay and shouldn't move.
     if (o.dialogOpen()) return
+
+    // Voice recording key — must win before prompt/editor/composer
+    // so the configured shortcut always fires push-to-talk.
+    if (o.voiceRecordKey && o.onVoiceRecord && isVoiceToggleKey(key, o.voiceRecordKey)) {
+      o.onVoiceRecord()
+      key.stopPropagation()
+      return
+    }
 
     // Shell mode: Esc exits (pre-empts the interrupt double-tap);
     // backspace at offset 0 also exits.

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -70,11 +70,38 @@ export function useStream(c: Ctx) {
   // action flushes synchronously first so part ordering is preserved.
   const deltas = useRef({ text: "", think: "", timer: null as ReturnType<typeof setTimeout> | null })
 
+  // Process notification batching: status.update/kind=process events
+  // accumulate over a 500ms window and dispatch as one combined system
+  // message. Prevents TUI lag when many background processes finish
+  // in rapid succession (each one otherwise triggers a full React
+  // re-render of the Chat transcript).
+  const procs = useRef<{ texts: string[]; timer: ReturnType<typeof setTimeout> | null }>(
+    { texts: [], timer: null },
+  )
+
   const flush = useCallback(() => {
     const d = deltas.current
     if (d.timer) { clearTimeout(d.timer); d.timer = null }
     if (d.think) { ctx.current.dispatch({ kind: "thinking", text: d.think, final: false }); d.think = "" }
     if (d.text) { ctx.current.dispatch({ kind: "message.delta", chunk: d.text }); d.text = "" }
+  }, [])
+
+  // Flush accumulated process notifications as one combined system msg.
+  const flushProcs = useCallback(() => {
+    const n = procs.current
+    if (n.timer) { clearTimeout(n.timer); n.timer = null }
+    if (!n.texts.length) return
+    const batch = n.texts.splice(0)
+    const lines = batch.map(t => {
+      const m = t.match(/Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+)/)
+      return m ? `  ${m[1]} (exit ${m[2]}) · ${m[3]}` : `  ${t.replace(/^\[IMPORTANT: |\]$/g, "").slice(0, 100)}`
+    })
+    ctx.current.dispatch({
+      kind: "system",
+      text: batch.length === 1
+        ? `◆ background ${lines[0].trim()}`
+        : `◆ ${batch.length} background processes completed\n${lines.join("\n")}`,
+    })
   }, [])
 
   const handle = useCallback((ev: GatewayEvent) => {
@@ -140,6 +167,12 @@ export function useStream(c: Ctx) {
         })
       },
       onStatus: (text) => x.setStatus(text),
+      onProcessNotification: (text) => {
+        const n = procs.current
+        n.texts.push(text)
+        if (n.timer) clearTimeout(n.timer)
+        n.timer = setTimeout(flushProcs, 500)
+      },
       onSkin: (s) => x.setSkin(deriveSkin(s)),
     })
     if (!action) return

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -10,7 +10,7 @@ import { useGateway, useGatewayEvent } from "../context/gateway"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 import { openAlert } from "../dialogs/alert"
-import { mapEvent } from "../context/events"
+import { formatProcessNotification, mapEvent } from "../context/events"
 import { deriveSkin, type SkinState } from "../context/skin"
 import { useBackground } from "./background"
 import type { Action } from "./turnReducer"
@@ -92,15 +92,12 @@ export function useStream(c: Ctx) {
     if (n.timer) { clearTimeout(n.timer); n.timer = null }
     if (!n.texts.length) return
     const batch = n.texts.splice(0)
-    const lines = batch.map(t => {
-      const m = t.match(/Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+)/)
-      return m ? `  ${m[1]} (exit ${m[2]}) · ${m[3]}` : `  ${t.replace(/^\[IMPORTANT: |\]$/g, "").slice(0, 100)}`
-    })
+    const lines = batch.map(t => `  ${formatProcessNotification(t)}`)
     ctx.current.dispatch({
       kind: "system",
       text: batch.length === 1
         ? `◆ background ${lines[0].trim()}`
-        : `◆ ${batch.length} background processes completed\n${lines.join("\n")}`,
+        : `◆ ${batch.length} background notifications\n${lines.join("\n")}`,
     })
   }, [])
 

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -19,6 +19,8 @@ export type Side = {
   onVoiceStatus?: (state: string) => void
   /** voice.transcript event — transcribed text from a completed voice capture. */
   onVoiceTranscript?: (text: string, noSpeechLimit: boolean) => void
+  /** status.update with kind=process — debounced client-side to prevent TUI lag. */
+  onProcessNotification?: (text: string) => void
 }
 
 function count(o: Record<string, string[]> | undefined): number {
@@ -200,17 +202,15 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       // Generic "status" is cosmetic; lifecycle/error/warn carry real
       // signal (retries, fallbacks, auth failures) and must persist.
       if (!kind || kind === "status") return null
-      // process: the same [IMPORTANT:...] text is replayed as a synthesized
-      // user turn immediately after, so render a one-line herald, not a dump.
+      // process: route through debounced accumulator instead of dispatching
+      // directly — prevents TUI lag when many terminal(background=true)
+      // processes finish in rapid succession.
       if (kind === "process") {
-        const m = text.match(/Background process (\S+) (?:completed \(exit code (\S+)\)|matched watch pattern "([^"]+)")\.\nCommand: (.+)/)
-        if (m) return { kind: "system", text: m[2] !== undefined
-          ? `◆ background ${m[1]} exited ${m[2]} · ${m[4]}`
-          : `◆ background ${m[1]} matched "${m[3]}" · ${m[4]}` }
+        side.onProcessNotification?.(text)
+        return null
       }
       return { kind: "system", text }
     }
-
     case "voice.status": {
       // Continuous VAD loop reports its internal state: listening,
       // transcribing, or idle. The UI uses this for the recording indicator.

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -27,6 +27,15 @@ function count(o: Record<string, string[]> | undefined): number {
   return o ? Object.values(o).reduce((n, v) => n + v.length, 0) : 0
 }
 
+export function formatProcessNotification(text: string): string {
+  const body = text.replace(/^\[IMPORTANT: /, "").replace(/\]$/, "")
+  const done = body.match(/^Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+?)(?:\n|$)/)
+  if (done) return `${done[1]} exited ${done[2]} · ${done[3]}`
+  const hit = body.match(/^Background process (\S+) matched watch pattern "([^"]+)"\.\nCommand: (.+?)(?:\n|$)/)
+  if (hit) return `${hit[1]} matched "${hit[2]}" · ${hit[3]}`
+  return body.slice(0, 100)
+}
+
 export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
   switch (ev.type) {
     case "gateway.ready":

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -15,6 +15,10 @@ export type Side = {
   onBtw?: (text: string) => void
   onStatus?: (text: string) => void
   onSkin?: (skin: GatewaySkin | null | undefined) => void
+  /** voice.status event — gateway VAD loop state change (listening/transcribing/idle). */
+  onVoiceStatus?: (state: string) => void
+  /** voice.transcript event — transcribed text from a completed voice capture. */
+  onVoiceTranscript?: (text: string, noSpeechLimit: boolean) => void
 }
 
 function count(o: Record<string, string[]> | undefined): number {
@@ -205,6 +209,29 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
           : `◆ background ${m[1]} matched "${m[3]}" · ${m[4]}` }
       }
       return { kind: "system", text }
+    }
+
+    case "voice.status": {
+      // Continuous VAD loop reports its internal state: listening,
+      // transcribing, or idle. The UI uses this for the recording indicator.
+      const state = String(ev.payload?.state ?? "")
+      side.onVoiceStatus?.(state)
+      return null
+    }
+
+    case "voice.transcript": {
+      // Transcribed text from a completed voice capture.
+      // no_speech_limit=true when 3 consecutive silent captures occurred
+      // — in that case voice mode auto-disables (CLI parity).
+      const noSpeechLimit = ev.payload?.no_speech_limit === true
+      if (noSpeechLimit) {
+        side.onVoiceTranscript?.("", true)
+        return null
+      }
+      const text = String(ev.payload?.text ?? "").trim()
+      if (!text) return null
+      side.onVoiceTranscript?.(text, false)
+      return null
     }
   }
   return null

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -28,6 +28,8 @@ export type GatewayEvent =
   | { type: "review.summary"; payload?: { text?: string } }
   | { type: "btw.complete"; payload: { text: string } }
   | { type: "browser.progress"; payload?: { message?: string; level?: "info" | "error" } }
+  | { type: "voice.status"; payload?: { state?: "idle" | "listening" | "transcribing" } }
+  | { type: "voice.transcript"; payload?: { text?: string; no_speech_limit?: boolean } }
   | { type: "subagent.start"; payload: SubagentPayload }
   | { type: "subagent.thinking"; payload: SubagentPayload }
   | { type: "subagent.tool"; payload: SubagentPayload }

--- a/src/voice/Indicator.tsx
+++ b/src/voice/Indicator.tsx
@@ -1,0 +1,32 @@
+// Voice recording indicator — renders in the composer bar while recording/processing.
+
+import { useTheme } from "../theme"
+import type { VoiceState } from "./types"
+import { formatVoiceRecordKey } from "./platform"
+
+type Props = { voice: VoiceState; keyLabel: string }
+
+/** Status line shown in the composer area during voice activity. */
+export function VoiceIndicator({ voice, keyLabel }: Props) {
+  const theme = useTheme().theme
+  if (!voice.enabled && !voice.recording && !voice.processing) return null
+
+  let text: string
+  let fg = theme.text
+  if (voice.recording) {
+    text = "● recording"
+    fg = theme.error
+  } else if (voice.processing) {
+    text = "◌ transcribing"
+    fg = theme.warning
+  } else {
+    text = `voice ready [${keyLabel}]`
+    fg = theme.textMuted
+  }
+
+  return (
+    <text>
+      <span fg={fg}>{text}  </span>
+    </text>
+  )
+}

--- a/src/voice/platform.ts
+++ b/src/voice/platform.ts
@@ -1,0 +1,60 @@
+// Parse and match voice record keys from `voice.record_key` config.
+// Simplified from upstream hermes-ink's platform.ts for OpenTUI.
+
+import type { VoiceKey, VoiceMod } from "./types"
+import type { ParsedKey } from "@opentui/core"
+
+/** Documented default: Ctrl+B. */
+export const DEFAULT_VOICE_KEY: VoiceKey = {
+  mod: "ctrl",
+  ch: "b",
+  raw: "ctrl+b",
+}
+
+const MOD_ALIASES: Record<string, VoiceMod> = {
+  alt: "alt",
+  ctrl: "ctrl",
+  control: "ctrl",
+  option: "alt",
+  opt: "alt",
+}
+
+/** Parse `voice.record_key` config string into a VoiceKey.
+ *  Falls back to Ctrl+B on malformed / empty / unparseable input. */
+export function parseVoiceRecordKey(raw: unknown): VoiceKey {
+  if (typeof raw !== "string" || !raw.trim()) return DEFAULT_VOICE_KEY
+  const lower = raw.trim().toLowerCase()
+  const parts = lower.split("+").map(p => p.trim()).filter(Boolean)
+  if (parts.length < 2) return DEFAULT_VOICE_KEY
+  if (parts.length > 2) return DEFAULT_VOICE_KEY // no multi-modifier
+  const [modRaw, chRaw] = parts
+  const mod = MOD_ALIASES[modRaw]
+  if (!mod) return DEFAULT_VOICE_KEY
+  if (chRaw.length !== 1) return DEFAULT_VOICE_KEY // single char only
+  // Block reserved ctrl chords (interrupt / quit / clear).
+  if (mod === "ctrl" && (chRaw === "c" || chRaw === "d" || chRaw === "l"))
+    return DEFAULT_VOICE_KEY
+  return { mod, ch: chRaw, raw: lower }
+}
+
+/** Render a parsed key as "Ctrl+B" / "Alt+R" for display. */
+export function formatVoiceRecordKey(v: VoiceKey): string {
+  const mod = v.mod[0].toUpperCase() + v.mod.slice(1)
+  return `${mod}+${v.ch.toUpperCase()}`
+}
+
+/** Match an OpenTUI ParsedKey against a parsed voice record key.
+ *  In OpenTUI: `meta` = Alt/Option, `super` = Cmd/Win, `ctrl` = Ctrl. */
+export function isVoiceToggleKey(
+  key: ParsedKey,
+  configured: VoiceKey = DEFAULT_VOICE_KEY,
+): boolean {
+  if (key.name.toLowerCase() !== configured.ch) return false
+  if (key.shift) return false // no shift-modified chords
+  switch (configured.mod) {
+    case "ctrl":
+      return key.ctrl && !key.meta && !key.super
+    case "alt":
+      return key.meta && !key.ctrl && !key.super
+  }
+}

--- a/src/voice/types.ts
+++ b/src/voice/types.ts
@@ -1,0 +1,42 @@
+// Voice mode types for herm TUI.
+// Mirrors upstream hermes-ink voice state management, adapted for OpenTUI.
+
+/** Modifier portion of a parsed voice record key (ctrl+b → ctrl). */
+export type VoiceMod = "ctrl" | "alt"
+
+/** Parsed voice record key from `voice.record_key` config. */
+export type VoiceKey = {
+  mod: VoiceMod
+  ch: string
+  raw: string
+}
+
+/** Gateway `voice.toggle` response shape. */
+export type VoiceToggleResponse = {
+  enabled?: boolean
+  record_key?: string
+  tts?: boolean
+  available?: boolean
+  audio_available?: boolean
+  stt_available?: boolean
+  details?: string
+}
+
+/** Gateway `voice.record` response shape. */
+export type VoiceRecordResponse = {
+  status?: string
+}
+
+/** Runtime voice state. */
+export type VoiceState = {
+  /** Voice mode umbrella flag (on/off, toggled via /voice on|off). */
+  enabled: boolean
+  /** Currently recording (microphone open, VAD active). */
+  recording: boolean
+  /** Transcribing in progress (post-capture, pre-text). */
+  processing: boolean
+  /** Parsed record key binding from config (default: ctrl+b). */
+  recordKey: VoiceKey
+  /** TTS auto-speak enabled. */
+  tts: boolean
+}

--- a/src/voice/useVoice.ts
+++ b/src/voice/useVoice.ts
@@ -36,7 +36,9 @@ export function useVoice(gw: GwRpc, sys: (text: string) => void): VoiceApi {
   const [processing, setProcessing] = useState(false)
   const [recordKeyRaw, setRecordKeyRaw] = useState<string>()
   const [tts, setTts] = useState(false)
-  const [onTranscript, setOnTranscript] = useState<((text: string) => void) | null>(null)
+  const [onTranscript, setTranscript] = useState<((text: string) => void) | null>(null)
+  const setOnTranscript = useCallback((fn: ((text: string) => void) | null) =>
+    setTranscript(fn ? () => fn : null), [])
 
   const recordKey = useMemo(
     () => parseVoiceRecordKey(recordKeyRaw),

--- a/src/voice/useVoice.ts
+++ b/src/voice/useVoice.ts
@@ -1,0 +1,112 @@
+// Voice mode state hook for herm TUI.
+// Manages runtime voice state: enabled/recording/processing flags,
+// record key parsing from config, and actions (toggle, record start/stop).
+
+import { useState, useCallback, useMemo } from "react"
+import type { VoiceState, VoiceToggleResponse, VoiceRecordResponse } from "./types"
+import { parseVoiceRecordKey, formatVoiceRecordKey, DEFAULT_VOICE_KEY } from "./platform"
+
+/** Shape of the gateway client's `request` method — subset needed for voice. */
+type GwRpc = <T>(method: string, params: Record<string, unknown>) => Promise<T>
+
+export type VoiceApi = {
+  state: VoiceState
+  /** Toggle voice mode (on/off/tts/status) via gateway. */
+  toggle: (action: string, sid: string) => Promise<void>
+  /** Start or stop VAD-bounded recording via gateway. */
+  record: (sid: string) => Promise<void>
+  /** Set voice enabled from event (e.g. no_speech_limit auto-off). */
+  setEnabled: (v: boolean) => void
+  /** Set recording state from voice.status event. */
+  setRecording: (v: boolean) => void
+  /** Set processing state from voice.status event. */
+  setProcessing: (v: boolean) => void
+  /** Update record key from config (called after voice.toggle response). */
+  setRecordKey: (raw: string | undefined) => void
+  /** Formatted display string for the record key (e.g. "Ctrl+B"). */
+  keyLabel: string
+  /** Callback for voice transcript — inserts text into composer. */
+  onTranscript: ((text: string) => void) | null
+  setOnTranscript: (fn: ((text: string) => void) | null) => void
+}
+
+export function useVoice(gw: GwRpc, sys: (text: string) => void): VoiceApi {
+  const [enabled, setEnabled] = useState(false)
+  const [recording, setRecording] = useState(false)
+  const [processing, setProcessing] = useState(false)
+  const [recordKeyRaw, setRecordKeyRaw] = useState<string>()
+  const [tts, setTts] = useState(false)
+  const [onTranscript, setOnTranscript] = useState<((text: string) => void) | null>(null)
+
+  const recordKey = useMemo(
+    () => parseVoiceRecordKey(recordKeyRaw),
+    [recordKeyRaw],
+  )
+
+  const keyLabel = useMemo(
+    () => formatVoiceRecordKey(recordKey),
+    [recordKey],
+  )
+
+  const state: VoiceState = useMemo(() => ({
+    enabled, recording, processing, recordKey, tts,
+  }), [enabled, recording, processing, recordKey, tts])
+
+  const toggle = useCallback(async (action: string, sid: string) => {
+    try {
+      const r = await gw<VoiceToggleResponse>("voice.toggle", {
+        action,
+        session_id: sid,
+      })
+      if (r.enabled !== undefined) setEnabled(r.enabled)
+      if (r.tts !== undefined) setTts(r.tts)
+      if (r.record_key) setRecordKeyRaw(r.record_key)
+      const label = formatVoiceRecordKey(parseVoiceRecordKey(r.record_key))
+      const ttsMsg = r.tts ? " · tts on" : ""
+      sys(`voice ${r.enabled ? "on" : "off"}${ttsMsg} [${label}]`)
+    } catch (e) {
+      sys(`voice: ${e instanceof Error ? e.message : "gateway error"}`)
+    }
+  }, [gw, sys])
+
+  const record = useCallback(async (sid: string) => {
+    if (!enabled) {
+      sys("voice: mode is off — enable with /voice on")
+      return
+    }
+    const starting = !recording
+    const action = starting ? "start" : "stop"
+    // Optimistic UI update
+    if (starting) {
+      setRecording(true)
+    } else {
+      setRecording(false)
+      setProcessing(false)
+    }
+    try {
+      const r = await gw<VoiceRecordResponse>("voice.record", {
+        action,
+        session_id: sid,
+      })
+      // Reconcile on failure
+      if (starting && r.status !== "recording") {
+        setRecording(false)
+        if (r.status === "busy") {
+          setProcessing(true)
+          sys("voice: still transcribing; try again shortly")
+        }
+      }
+    } catch (e) {
+      if (starting) setRecording(false)
+      sys(`voice error: ${e instanceof Error ? e.message : "gateway error"}`)
+    }
+  }, [enabled, recording, gw, sys])
+
+  return {
+    state, toggle, record,
+    setEnabled, setRecording, setProcessing,
+    setRecordKey: setRecordKeyRaw,
+    keyLabel,
+    onTranscript, setOnTranscript,
+  }
+}

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -711,6 +711,7 @@ describe("app", () => {
     t.destroy()
   })
 
+
   test("click user message → action menu → Rewind → N×session.undo → composer seeded", async () => {
     // History after rewind: server-authoritative via session.history.
     const hist = (n: number) => Array.from({ length: n }, (_, i) => ({

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mapEvent, type Side } from "../src/context/events"
+import { formatProcessNotification, mapEvent, type Side } from "../src/context/events"
 import type { GatewayEvent } from "../src/context/wire"
 
 function map(ev: GatewayEvent, side: Partial<Side> = {}) {
@@ -74,15 +74,29 @@ describe("mapEvent", () => {
     expect(b.action).toEqual({ kind: "system", text: "HTTP 404" })
   })
 
-  test("status.update kind=process folds [IMPORTANT:...] to one-line herald", () => {
-    const done = map({ type: "status.update", payload: { kind: "process", text:
-      "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]" } })
-    expect(done.action).toEqual({ kind: "system", text: "◆ background proc_abc exited 0 · bun test" })
-    const hit = map({ type: "status.update", payload: { kind: "process", text:
-      "[IMPORTANT: Background process srv_1 matched watch pattern \"ready\".\nCommand: bun run dev\nMatched output:\nApplication startup complete]" } })
-    expect(hit.action).toEqual({ kind: "system", text: "◆ background srv_1 matched \"ready\" · bun run dev" })
-    const miss = map({ type: "status.update", payload: { kind: "process", text: "weird shape" } })
-    expect(miss.action).toEqual({ kind: "system", text: "weird shape" })
+  test("status.update kind=process routes to debounced side callback", () => {
+    const text = "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]"
+    const done = map({ type: "status.update", payload: { kind: "process", text } })
+    expect(done.action).toBeNull()
+    expect(done.calls.status).toEqual([text])
+
+    const calls: string[] = []
+    const routed = map(
+      { type: "status.update", payload: { kind: "process", text } },
+      { onProcessNotification: t => calls.push(t) },
+    )
+    expect(routed.action).toBeNull()
+    expect(calls).toEqual([text])
+  })
+
+  test("formatProcessNotification preserves completion and watch-pattern shapes", () => {
+    expect(formatProcessNotification(
+      "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]",
+    )).toBe("proc_abc exited 0 · bun test")
+    expect(formatProcessNotification(
+      "[IMPORTANT: Background process srv_1 matched watch pattern \"ready\".\nCommand: bun run dev\nMatched output:\nApplication startup complete]",
+    )).toBe("srv_1 matched \"ready\" · bun run dev")
+    expect(formatProcessNotification("weird shape")).toBe("weird shape")
   })
 
   test("gateway.stderr: errorish → system; benign → null", () => {


### PR DESCRIPTION
status.update/kind=process events fire once per terminal(background=true) completion. when many processes finish in quick succession (builds, parallel tests), each generates a separate {kind:system} dispatch that triggers a full Chat re-render -- causing visible TUI lag.

route process events through a 500ms debounced accumulator in useStream. rapid completions coalesce into one combined system message:
  "◆ 3 background processes completed"

events.ts: add onProcessNotification to Side callback type, route status.update/process through callback instead of direct dispatch
useStream.ts: procs ref accumulates notification texts, flushProcs batches and dispatches single system msg