### PR TITLE
Composer: extmark-backed parts model

### DIFF
--- a/src/app/parts.ts
+++ b/src/app/parts.ts
@@ -1,0 +1,246 @@
+// Extmark-backed parts model for the composer. Mirrors the opencode
+// shape (file/agent/text kinds with asymmetric `source` fields) so
+// serialized snapshots round-trip through the gateway wire when the
+// rest of the parts pipeline lands; today they only drive chip
+// rendering, atomic-chip backspace, and history restore.
+//
+// Offsets are display-width (what opentui's extmarks consume), not
+// JS string indices. virtual:true marks give cursor-atomic + delete-
+// atomic behavior for free — there is no custom backspace code here.
+
+import type { TextareaRenderable, ExtmarksController, SyntaxStyle, ColorInput } from "@opentui/core"
+
+export type PartKind = "file" | "agent" | "text"
+
+export type FilePart = {
+  type: "file"
+  mime: string
+  filename?: string
+  url?: string
+  source?: {
+    type: "file"
+    path: string
+    text: { start: number; end: number; value: string }
+  }
+}
+
+export type AgentPart = {
+  type: "agent"
+  name: string
+  source?: { start: number; end: number; value: string }
+}
+
+export type TextPart = {
+  type: "text"
+  text: string
+  synthetic?: boolean
+  source?: { text: { start: number; end: number; value: string } }
+}
+
+export type Part = FilePart | AgentPart | TextPart
+
+export type PartsSnapshot = {
+  v: 1
+  input: string
+  parts: Part[]
+}
+
+export const TYPE = "prompt-part"
+export const STYLE = {
+  file: "extmark.file",
+  agent: "extmark.agent",
+  paste: "extmark.paste",
+} as const
+
+// One-shot registration of extmark styles on a shared SyntaxStyle.
+// Idempotent — resolveStyleId short-circuits after the first register.
+export function styles(syntax: SyntaxStyle, theme: { accent: ColorInput; primary: ColorInput; textMuted: ColorInput }) {
+  const ensure = (name: string, def: { fg?: ColorInput; italic?: boolean }) => {
+    const id = syntax.getStyleId(name)
+    if (id !== null) return id
+    return syntax.registerStyle(name, def)
+  }
+  return {
+    file: ensure(STYLE.file, { fg: theme.accent }),
+    agent: ensure(STYLE.agent, { fg: theme.primary, italic: true }),
+    paste: ensure(STYLE.paste, { fg: theme.textMuted }),
+  }
+}
+
+type StyleIds = { file: number; agent: number; paste: number }
+
+// Bridge between a TextareaRenderable (source of truth for text +
+// extmarks) and a parallel parts[] array. The map id→index keeps the
+// two in sync: when a mark is deleted (atomic-chip backspace) we drop
+// the matching part; when marks shift (text inserted before them) we
+// rewrite the part's source range before emitting/snapshotting.
+export class PartsBuffer {
+  private ta: TextareaRenderable
+  private ex: ExtmarksController
+  private typeId: number
+  private style: StyleIds
+  private list: Part[] = []
+  private map = new Map<number, number>()
+
+  constructor(ta: TextareaRenderable, style: StyleIds) {
+    this.ta = ta
+    this.ex = ta.extmarks
+    this.style = style
+    this.typeId = this.ex.registerType(TYPE)
+  }
+
+  text() { return this.ta.plainText }
+
+  // The textarea may be destroyed mid-session (tab switch unmounting
+  // the composer, hot reload, etc.). Every op that reaches into
+  // opentui internals guards so the caller doesn't need to.
+  private alive() { return !this.ta.isDestroyed }
+
+  insertText(str: string) {
+    if (!this.alive()) return
+    this.ta.insertText(str)
+  }
+
+  // Insert a part at the current cursor. Writes the virtual text into
+  // the buffer and binds a mark to its display range. Trailing space
+  // matches opencode and keeps the caret outside the chip so the next
+  // keystroke doesn't extend the range. Extmark offsets are display-
+  // width — visualCursor.offset, not cursorOffset.
+  insertPart(part: Part, virtualText: string) {
+    if (!this.alive()) return
+    const start = this.ta.visualCursor.offset
+    const end = start + visualLen(virtualText)
+    this.ta.insertText(virtualText + " ")
+    const id = this.ex.create({
+      start,
+      end,
+      virtual: true,
+      styleId: styleFor(part.type, this.style),
+      typeId: this.typeId,
+    })
+    const idx = this.list.length
+    this.list.push(withSource(part, start, end, virtualText))
+    this.map.set(id, idx)
+  }
+
+  // Re-read mark ranges from the textarea and rebuild a compact
+  // parts[] reflecting only the marks that still exist. Any parts
+  // whose mark was deleted (atomic-chip backspace) drop out.
+  sync() {
+    if (!this.alive()) return
+    const alive = this.ex.getAllForTypeId(this.typeId)
+    const next: Part[] = []
+    const nextMap = new Map<number, number>()
+    for (const m of alive) {
+      const idx = this.map.get(m.id)
+      if (idx === undefined) continue
+      const p = this.list[idx]
+      if (!p) continue
+      nextMap.set(m.id, next.length)
+      next.push(rangeTo(p, m.start, m.end))
+    }
+    this.list = next
+    this.map = nextMap
+  }
+
+  // Parts in display order. `sync()` first so callers always see the
+  // current mark ranges — callers don't need to remember to call it.
+  parts(): readonly Part[] {
+    this.sync()
+    return this.list
+  }
+
+  // Snapshot for history/rewind: stores the plain text + parts with
+  // their source ranges frozen. fromSnapshot() rebuilds both.
+  toSnapshot(): PartsSnapshot {
+    return { v: 1, input: this.text(), parts: [...this.parts()] }
+  }
+
+  fromSnapshot(snap: PartsSnapshot) {
+    if (!this.alive()) return
+    this.ta.setText(snap.input)
+    this.ex.clear()
+    this.list = []
+    this.map = new Map()
+    for (const p of snap.parts) {
+      const r = rangeOf(p)
+      if (!r) continue
+      const id = this.ex.create({
+        start: r.start,
+        end: r.end,
+        virtual: true,
+        styleId: styleFor(p.type, this.style),
+        typeId: this.typeId,
+      })
+      this.map.set(id, this.list.length)
+      this.list.push(p)
+    }
+    this.ta.gotoBufferEnd()
+  }
+
+  clear() {
+    this.list = []
+    this.map = new Map()
+    if (!this.alive()) return
+    this.ta.setText("")
+    this.ex.clear()
+  }
+
+  // Inline-expand text parts into their original value (paste body)
+  // and strip them from the parts[] — only file/agent parts ride as
+  // real message parts to the gateway. Matches opencode submit path.
+  expand(): { text: string; parts: Part[] } {
+    if (!this.alive()) return { text: "", parts: [] }
+    this.sync()
+    let text = this.text()
+    const marks = this.ex.getAllForTypeId(this.typeId).sort((a, b) => b.start - a.start)
+    for (const m of marks) {
+      const idx = this.map.get(m.id)
+      if (idx === undefined) continue
+      const p = this.list[idx]
+      if (p?.type !== "text") continue
+      text = text.slice(0, m.start) + p.text + text.slice(m.end)
+    }
+    return { text, parts: this.list.filter(p => p.type !== "text") }
+  }
+}
+
+function visualLen(s: string): number {
+  // Fallback for runtimes without Bun.stringWidth; matches opentui's
+  // assumption that ASCII chips are one column per char.
+  const B = (globalThis as { Bun?: { stringWidth?: (s: string) => number } }).Bun
+  return B?.stringWidth ? B.stringWidth(s) : s.length
+}
+
+function styleFor(k: PartKind, s: StyleIds) {
+  if (k === "file") return s.file
+  if (k === "agent") return s.agent
+  return s.paste
+}
+
+function withSource(p: Part, start: number, end: number, value: string): Part {
+  if (p.type === "file") return { ...p, source: p.source ?? { type: "file", path: "", text: { start, end, value } } }
+  if (p.type === "agent") return { ...p, source: { start, end, value } }
+  return { ...p, source: { text: { start, end, value } } }
+}
+
+function rangeTo(p: Part, start: number, end: number): Part {
+  if (p.type === "file") {
+    const src = p.source ?? { type: "file" as const, path: "", text: { start, end, value: "" } }
+    return { ...p, source: { ...src, text: { ...src.text, start, end } } }
+  }
+  if (p.type === "agent") {
+    const src = p.source ?? { start, end, value: "" }
+    return { ...p, source: { ...src, start, end } }
+  }
+  const src = p.source ?? { text: { start, end, value: "" } }
+  return { ...p, source: { text: { ...src.text, start, end } } }
+}
+
+function rangeOf(p: Part) {
+  if (p.type === "file") return p.source?.text
+  if (p.type === "agent") return p.source
+  return p.source?.text
+}
+
+export * as parts from "./parts"

--- a/src/app/parts.ts
+++ b/src/app/parts.ts
@@ -1,12 +1,6 @@
-// Extmark-backed parts model for the composer. Mirrors the opencode
-// shape (file/agent/text kinds with asymmetric `source` fields) so
-// serialized snapshots round-trip through the gateway wire when the
-// rest of the parts pipeline lands; today they only drive chip
-// rendering, atomic-chip backspace, and history restore.
-//
-// Offsets are display-width (what opentui's extmarks consume), not
-// JS string indices. virtual:true marks give cursor-atomic + delete-
-// atomic behavior for free — there is no custom backspace code here.
+// Extmark-backed parts model for the composer. Offsets are display-width
+// (what extmarks consume), not JS string indices. virtual:true marks give
+// cursor-atomic + delete-atomic behavior; there is no custom backspace code.
 
 import type { TextareaRenderable, ExtmarksController, SyntaxStyle, ColorInput } from "@opentui/core"
 
@@ -52,8 +46,7 @@ export const STYLE = {
   paste: "extmark.paste",
 } as const
 
-// One-shot registration of extmark styles on a shared SyntaxStyle.
-// Idempotent — resolveStyleId short-circuits after the first register.
+// Idempotent style registration on a shared SyntaxStyle.
 export function styles(syntax: SyntaxStyle, theme: { accent: ColorInput; primary: ColorInput; textMuted: ColorInput }) {
   const ensure = (name: string, def: { fg?: ColorInput; italic?: boolean }) => {
     const id = syntax.getStyleId(name)
@@ -69,11 +62,9 @@ export function styles(syntax: SyntaxStyle, theme: { accent: ColorInput; primary
 
 type StyleIds = { file: number; agent: number; paste: number }
 
-// Bridge between a TextareaRenderable (source of truth for text +
-// extmarks) and a parallel parts[] array. The map id→index keeps the
-// two in sync: when a mark is deleted (atomic-chip backspace) we drop
-// the matching part; when marks shift (text inserted before them) we
-// rewrite the part's source range before emitting/snapshotting.
+// Bridges a TextareaRenderable (source of truth) and a parallel parts[].
+// The id→index map drops parts whose mark was deleted and rewrites ranges
+// when marks shift.
 export class PartsBuffer {
   private ta: TextareaRenderable
   private ex: ExtmarksController
@@ -91,9 +82,7 @@ export class PartsBuffer {
 
   text() { return this.ta.plainText }
 
-  // The textarea may be destroyed mid-session (tab switch unmounting
-  // the composer, hot reload, etc.). Every op that reaches into
-  // opentui internals guards so the caller doesn't need to.
+  // The textarea can be destroyed mid-session (tab switch, hot reload).
   private alive() { return !this.ta.isDestroyed }
 
   insertText(str: string) {
@@ -101,11 +90,8 @@ export class PartsBuffer {
     this.ta.insertText(str)
   }
 
-  // Insert a part at the current cursor. Writes the virtual text into
-  // the buffer and binds a mark to its display range. Trailing space
-  // matches opencode and keeps the caret outside the chip so the next
-  // keystroke doesn't extend the range. Extmark offsets are display-
-  // width — visualCursor.offset, not cursorOffset.
+  // Trailing space keeps the caret outside the chip so the next keystroke
+  // doesn't extend the range. Offsets are visualCursor.offset, not cursorOffset.
   insertPart(part: Part, virtualText: string) {
     if (!this.alive()) return
     const start = this.ta.visualCursor.offset
@@ -123,9 +109,7 @@ export class PartsBuffer {
     this.map.set(id, idx)
   }
 
-  // Re-read mark ranges from the textarea and rebuild a compact
-  // parts[] reflecting only the marks that still exist. Any parts
-  // whose mark was deleted (atomic-chip backspace) drop out.
+  // Rebuild parts[] from the marks that still exist.
   sync() {
     if (!this.alive()) return
     const alive = this.ex.getAllForTypeId(this.typeId)
@@ -143,15 +127,11 @@ export class PartsBuffer {
     this.map = nextMap
   }
 
-  // Parts in display order. `sync()` first so callers always see the
-  // current mark ranges — callers don't need to remember to call it.
   parts(): readonly Part[] {
     this.sync()
     return this.list
   }
 
-  // Snapshot for history/rewind: stores the plain text + parts with
-  // their source ranges frozen. fromSnapshot() rebuilds both.
   toSnapshot(): PartsSnapshot {
     return { v: 1, input: this.text(), parts: [...this.parts()] }
   }
@@ -186,9 +166,8 @@ export class PartsBuffer {
     this.ex.clear()
   }
 
-  // Inline-expand text parts into their original value (paste body)
-  // and strip them from the parts[] — only file/agent parts ride as
-  // real message parts to the gateway. Matches opencode submit path.
+  // Inline text parts (paste bodies) back into the string; only file/agent
+  // parts ride to the gateway.
   expand(): { text: string; parts: Part[] } {
     if (!this.alive()) return { text: "", parts: [] }
     this.sync()
@@ -206,8 +185,7 @@ export class PartsBuffer {
 }
 
 function visualLen(s: string): number {
-  // Fallback for runtimes without Bun.stringWidth; matches opentui's
-  // assumption that ASCII chips are one column per char.
+
   const B = (globalThis as { Bun?: { stringWidth?: (s: string) => number } }).Bun
   return B?.stringWidth ? B.stringWidth(s) : s.length
 }

--- a/src/app/useInputHistory.ts
+++ b/src/app/useInputHistory.ts
@@ -1,39 +1,66 @@
 // Up/down history for composer input.
 // Persisted under the herm config dir (typically ~/.hermes/herm/history).
+//
+// On-disk format is JSONL of { input, parts? } entries. Legacy lines
+// that are raw strings (with `\n` encoded as NUL) are read as
+// { input: <decoded>, parts: [] } so existing histories keep working.
 
 import { useState, useRef, useCallback } from "react"
 import { join } from "path"
 import { existsSync, mkdirSync, readFileSync, appendFileSync, writeFileSync } from "fs"
 import { configDir } from "../utils/paths"
+import type { Part, PartsSnapshot } from "./parts"
 
 const MAX = 500
 
+export type HistEntry = { input: string; parts: readonly Part[] }
+
 const file = () => join(configDir(), "history")
+
+function parse(line: string): HistEntry {
+  if (line[0] === "{") {
+    const j = safe(line)
+    if (j && typeof j.input === "string") {
+      return { input: j.input, parts: Array.isArray(j.parts) ? j.parts : [] }
+    }
+  }
+  return { input: line.replace(/\0/g, "\n"), parts: [] }
+}
+
+function safe(s: string): { input?: unknown; parts?: unknown } | null {
+  try { return JSON.parse(s) } catch { return null }
+}
 
 // In-memory order is newest-first (index 0 = most recent); on-disk is
 // append-only newest-last, so load() reverses.
-function load() {
+function load(): HistEntry[] {
   const FILE = file()
   if (!existsSync(FILE)) return []
   return readFileSync(FILE, "utf-8").split("\n").filter(Boolean)
-    .map(l => l.replace(/\0/g, "\n")).slice(-MAX).reverse()
+    .map(parse).slice(-MAX).reverse()
 }
 
-function enc(s: string) { return s.replace(/\n/g, "\0") }
+function enc(e: HistEntry) {
+  if (e.parts.length === 0) return JSON.stringify({ input: e.input })
+  return JSON.stringify({ input: e.input, parts: e.parts })
+}
 
-export function useInputHistory(input: string, setInput: (v: string) => void) {
-  const hist = useRef<string[]>(null)
+export function useInputHistory(input: string, restore: (e: HistEntry) => void) {
+  const hist = useRef<HistEntry[]>(null)
   if (hist.current === null) hist.current = load()
   const [, bump] = useState(0)
   const idx = useRef(-1)
-  const stash = useRef("")
+  const stash = useRef<HistEntry>({ input: "", parts: [] })
 
-  const push = useCallback((msg: string) => {
+  const push = useCallback((entry: HistEntry | string) => {
     idx.current = -1
-    stash.current = ""
+    stash.current = { input: "", parts: [] }
+    const e: HistEntry = typeof entry === "string" ? { input: entry, parts: [] } : entry
+    if (!e.input && e.parts.length === 0) return
     const h = hist.current!
-    if (msg === h[0]) return
-    h.unshift(msg)
+    const top = h[0]
+    if (top && top.input === e.input && sameParts(top.parts, e.parts)) return
+    h.unshift(e)
     const DIR = configDir()
     const FILE = file()
     if (!existsSync(DIR)) mkdirSync(DIR, { recursive: true })
@@ -41,7 +68,7 @@ export function useInputHistory(input: string, setInput: (v: string) => void) {
       h.length = MAX
       writeFileSync(FILE, [...h].reverse().map(enc).join("\n") + "\n", "utf-8")
     } else {
-      appendFileSync(FILE, enc(msg) + "\n", "utf-8")
+      appendFileSync(FILE, enc(e) + "\n", "utf-8")
     }
     bump(n => n + 1)
   }, [])
@@ -49,18 +76,27 @@ export function useInputHistory(input: string, setInput: (v: string) => void) {
   const up = useCallback(() => {
     const h = hist.current!
     if (h.length === 0) return
-    if (idx.current === -1) stash.current = input
+    if (idx.current === -1) stash.current = { input, parts: [] }
     const next = Math.min(idx.current + 1, h.length - 1)
     idx.current = next
-    setInput(h[next])
-  }, [input, setInput])
+    restore(h[next])
+  }, [input, restore])
 
   const down = useCallback(() => {
     if (idx.current === -1) return
     const next = idx.current - 1
     idx.current = next
-    setInput(next === -1 ? stash.current : hist.current![next])
-  }, [setInput])
+    restore(next === -1 ? stash.current : hist.current![next])
+  }, [restore])
 
   return { push, up, down }
 }
+
+function sameParts(a: readonly Part[], b: readonly Part[]) {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i]?.type !== b[i]?.type) return false
+  return true
+}
+
+export type { PartsSnapshot }
+

--- a/src/app/useInputHistory.ts
+++ b/src/app/useInputHistory.ts
@@ -1,9 +1,6 @@
-// Up/down history for composer input.
-// Persisted under the herm config dir (typically ~/.hermes/herm/history).
-//
-// On-disk format is JSONL of { input, parts? } entries. Legacy lines
-// that are raw strings (with `\n` encoded as NUL) are read as
-// { input: <decoded>, parts: [] } so existing histories keep working.
+// Up/down history for composer input, persisted under the herm config dir.
+// On-disk format is JSONL of { input, parts? }. Legacy raw-string lines
+// (newlines NUL-encoded) still load.
 
 import { useState, useRef, useCallback } from "react"
 import { join } from "path"

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -90,8 +90,6 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const bg = useBackground()
   const ta = useRef<TextareaRenderable | null>(null)
   const buf = useRef<PartsBuffer | null>(null)
-  // Style ids are registered once per SyntaxStyle; memoized so theme
-  // swaps (which build a new SyntaxStyle) re-register automatically.
   const sids = useMemo(() => partStyles(syntaxStyle, theme), [syntaxStyle, theme])
   // Mirror of the textarea buffer. The renderable is the source of truth;
   // this drives React-side derivations (popover matching, row count, hints).
@@ -123,8 +121,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     setInput(v)
   }, [])
 
-  // History restore. Plain strings round-trip through setText; entries
-  // with parts go through the snapshot path so chips + ranges rebuild.
+  // Entries with parts restore via snapshot so chips + ranges rebuild.
   const restore = useCallback((e: HistEntry) => {
     if (e.parts.length === 0) { write(e.input); return }
     buf.current?.fromSnapshot({ v: 1, input: e.input, parts: [...e.parts] })
@@ -163,11 +160,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     live.current.props.onSlash(c)
   }
 
-  // Accept an @-ref from the popover. Complete refs (`@file:path`,
-  // `@diff`, `@git:3`, `@url:…`) land as styled chips — one keystroke
-  // deletes them whole. Prefix keywords that keep the popover open
-  // (`@file:`, `@folder:`, `@url:`) take the classic string-write
-  // path since there's nothing yet to anchor a mark to.
+  // Complete @-refs land as styled chips; prefix keywords that keep the
+  // popover open have nothing to anchor a mark to and stay plain text.
   const atAccept = (idx?: number) => {
     const off = ta.current?.cursorOffset
     const src = live.current.input
@@ -182,11 +176,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (next !== null) write(next)
       return
     }
-    // Complete ref → chip. Splice the `@word` out via deleteRange
-    // (surgical — preserves existing extmarks; setText would wipe
-    // every prior chip's mark), then let PartsBuffer.insertPart drop
-    // a mark-backed virtual run. Match at.accept()'s frecency bump
-    // for path-like items so ranking still reflects acceptance.
+    // Splice the @word out via deleteRange — setText would wipe every
+    // prior chip's mark.
     if (it.text.includes(":")) frecency.bump(it.text)
     const eb = ta.current.editBuffer
     const s = eb.offsetToPosition(a.start)
@@ -265,10 +256,6 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (c) select(c)
       return
     }
-    // Expand captures the current buffer + parts, inline-expands any
-    // text parts (pasted content) so the wire still sees plain text,
-    // and filters them out of the emitted parts[] — matches opencode
-    // submit semantics.
     const exp = buf.current?.expand() ?? { text: live.current.input, parts: [] }
     if (modeRef.current === "shell") {
       const cmd = exp.text.trim()
@@ -356,10 +343,9 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     },
   }), [hist.up, hist.down, pop.setCursor, write])
 
-  // Stable ref callback so re-renders don't cycle (r → null → r) and
-  // throw away the PartsBuffer's extmark→part map mid-edit. sids is a
-  // ref-via-closure rather than a dep so theme swaps rebuild the buffer
-  // through the unmount path instead of on every render.
+  // Stable ref callback so re-renders don't cycle r → null → r and drop
+  // the PartsBuffer mid-edit; sids via closure so theme swaps rebuild
+  // through the unmount path.
   const sidsRef = useRef(sids); sidsRef.current = sids
   const taRef = useCallback((r: TextareaRenderable | null) => {
     ta.current = r

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -182,13 +182,17 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (next !== null) write(next)
       return
     }
-    // Complete ref → chip. Splice the `@word` out, position the caret,
-    // then let PartsBuffer.insertPart drop a mark-backed virtual run.
-    // Match at.accept()'s frecency bump for path-like items so ranking
-    // still reflects acceptance.
+    // Complete ref → chip. Splice the `@word` out via deleteRange
+    // (surgical — preserves existing extmarks; setText would wipe
+    // every prior chip's mark), then let PartsBuffer.insertPart drop
+    // a mark-backed virtual run. Match at.accept()'s frecency bump
+    // for path-like items so ranking still reflects acceptance.
     if (it.text.includes(":")) frecency.bump(it.text)
-    const trimmed = src.slice(0, a.start) + src.slice(a.start + a.word.length)
-    ta.current.setText(trimmed)
+    const eb = ta.current.editBuffer
+    const s = eb.offsetToPosition(a.start)
+    const e = eb.offsetToPosition(a.start + a.word.length)
+    if (!s || !e) return
+    ta.current.deleteRange(s.row, s.col, e.row, e.col)
     ta.current.cursorOffset = a.start
     const part: FilePart = {
       type: "file",

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -12,9 +12,11 @@ import type { ImageAttachResponse, DropDetectResponse } from "../../context/wire
 import { looksLikePath } from "../../utils/drop"
 import type { SlashCommand } from "../../app/slashCommands"
 import { useSlashPopover } from "../../app/useSlashPopover"
-import { useAtRefPopover } from "../../app/useAtRefPopover"
-import { useInputHistory } from "../../app/useInputHistory"
+import { useAtRefPopover, atWordAt } from "../../app/useAtRefPopover"
+import { frecency } from "../../app/frecency"
+import { useInputHistory, type HistEntry } from "../../app/useInputHistory"
 import { useBackground } from "../../app/background"
+import { PartsBuffer, styles as partStyles, type Part, type FilePart } from "../../app/parts"
 import { SlashPopover } from "./SlashPopover"
 import { AtRefPopover } from "./AtRefPopover"
 import { ChafaImage } from "../../ui/ChafaImage"
@@ -56,7 +58,7 @@ type Props = {
   queue?: ReadonlyArray<string>
   attachments?: ReadonlyArray<ImageAttachResponse>
   cmds: ReadonlyArray<SlashCommand>
-  onSend: (text: string) => void
+  onSend: (text: string, parts?: readonly Part[]) => void
   onSlash: (cmd: SlashCommand) => void
   /** Shell-mode submit (`!` at cursor 0). Not a prompt turn — routed
    *  to shell.exec and rendered as a transcript $ cmd / stdout pair. */
@@ -82,10 +84,15 @@ function fmt(n: number): string {
 
 export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const theme = useTheme().theme
+  const syntaxStyle = useTheme().syntaxStyle
   const gw = useGateway()
   const keys = useKeys()
   const bg = useBackground()
   const ta = useRef<TextareaRenderable | null>(null)
+  const buf = useRef<PartsBuffer | null>(null)
+  // Style ids are registered once per SyntaxStyle; memoized so theme
+  // swaps (which build a new SyntaxStyle) re-register automatically.
+  const sids = useMemo(() => partStyles(syntaxStyle, theme), [syntaxStyle, theme])
   // Mirror of the textarea buffer. The renderable is the source of truth;
   // this drives React-side derivations (popover matching, row count, hints).
   const [input, setInput] = useState("")
@@ -109,12 +116,22 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const at = useAtRefPopover(mode === "normal" ? input : "", caret)
 
   const write = useCallback((v: string) => {
-    ta.current?.setText(v)
+    // clear() wipes text + extmarks via setText(""); replay v after.
+    buf.current?.clear()
+    if (v) ta.current?.setText(v)
     ta.current?.gotoBufferEnd()
     setInput(v)
   }, [])
 
-  const hist = useInputHistory(input, write)
+  // History restore. Plain strings round-trip through setText; entries
+  // with parts go through the snapshot path so chips + ranges rebuild.
+  const restore = useCallback((e: HistEntry) => {
+    if (e.parts.length === 0) { write(e.input); return }
+    buf.current?.fromSnapshot({ v: 1, input: e.input, parts: [...e.parts] })
+    setInput(e.input)
+  }, [write])
+
+  const hist = useInputHistory(input, restore)
 
   // Merged over the renderable's default map (which has bare return →
   // newline), so input.submit's `return` entry overrides it and the
@@ -146,10 +163,41 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     live.current.props.onSlash(c)
   }
 
+  // Accept an @-ref from the popover. Complete refs (`@file:path`,
+  // `@diff`, `@git:3`, `@url:…`) land as styled chips — one keystroke
+  // deletes them whole. Prefix keywords that keep the popover open
+  // (`@file:`, `@folder:`, `@url:`) take the classic string-write
+  // path since there's nothing yet to anchor a mark to.
   const atAccept = (idx?: number) => {
     const off = ta.current?.cursorOffset
-    const next = live.current.at.accept(live.current.input, idx, off)
-    if (next !== null) write(next)
+    const src = live.current.input
+    const which = idx ?? live.current.at.cursor
+    const it = live.current.at.items[which]
+    if (!it) return
+    const a = atWordAt(src, off)
+    const trail = it.text.endsWith(":") || it.text.endsWith("/")
+    const b = buf.current
+    if (trail || !b || !ta.current || !a) {
+      const next = live.current.at.accept(src, idx, off)
+      if (next !== null) write(next)
+      return
+    }
+    // Complete ref → chip. Splice the `@word` out, position the caret,
+    // then let PartsBuffer.insertPart drop a mark-backed virtual run.
+    // Match at.accept()'s frecency bump for path-like items so ranking
+    // still reflects acceptance.
+    if (it.text.includes(":")) frecency.bump(it.text)
+    const trimmed = src.slice(0, a.start) + src.slice(a.start + a.word.length)
+    ta.current.setText(trimmed)
+    ta.current.cursorOffset = a.start
+    const part: FilePart = {
+      type: "file",
+      mime: "text/uri-list",
+      filename: it.text,
+      source: { type: "file", path: it.text, text: { start: a.start, end: a.start + it.text.length, value: it.text } },
+    }
+    b.insertPart(part, it.text)
+    setInput(ta.current.plainText)
   }
 
   // Paste routing, in priority order:
@@ -213,34 +261,39 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (c) select(c)
       return
     }
+    // Expand captures the current buffer + parts, inline-expands any
+    // text parts (pasted content) so the wire still sees plain text,
+    // and filters them out of the emitted parts[] — matches opencode
+    // submit semantics.
+    const exp = buf.current?.expand() ?? { text: live.current.input, parts: [] }
     if (modeRef.current === "shell") {
-      const text = live.current.input.trim()
-      if (!text) return
-      hist.push(text)
+      const cmd = exp.text.trim()
+      if (!cmd) return
+      hist.push({ input: cmd, parts: exp.parts })
       write("")
       setMode("normal")
-      live.current.props.onShell?.(text)
+      live.current.props.onShell?.(cmd)
       return
     }
-    const text = live.current.input.trim()
+    const text = exp.text.trim()
     if (live.current.props.streaming) {
       if (!text || !live.current.props.ready) return
-      hist.push(text)
+      hist.push({ input: text, parts: exp.parts })
       write("")
       // Slash-shaped input routes through onSend so send() → slash()
       // can apply per-command streaming policy (local cases fire now,
       // gateway-target cases self-queue). Only plain text hits the
       // app-side busy-mode branch.
-      if (text.startsWith("/")) return void live.current.props.onSend(text)
+      if (text.startsWith("/")) return void live.current.props.onSend(text, exp.parts)
       live.current.props.onEnqueue?.(text)
       return
     }
     const hasAtt = (live.current.props.attachments?.length ?? 0) > 0
     if (!text && !hasAtt) { live.current.props.onEmptyEnter?.(); return }
     if (!live.current.props.ready) return
-    if (text) hist.push(text)
+    if (text) hist.push({ input: text, parts: exp.parts })
     write("")
-    live.current.props.onSend(text)
+    live.current.props.onSend(text, exp.parts)
   }
 
   useImperativeHandle(ref, () => ({
@@ -382,7 +435,12 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         <box width={1}><text fg={theme.primary}>{mode === "shell" ? "$" : ">"}</text></box>
         <box width={1} />
         <textarea
-          ref={ta}
+          ref={(r) => {
+            ta.current = r
+            if (r && !buf.current) buf.current = new PartsBuffer(r, sids)
+            if (!r) buf.current = null
+          }}
+          syntaxStyle={syntaxStyle}
           onContentChange={() => {
             const t = ta.current
             setInput(t?.plainText ?? "")

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -352,6 +352,17 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     },
   }), [hist.up, hist.down, pop.setCursor, write])
 
+  // Stable ref callback so re-renders don't cycle (r → null → r) and
+  // throw away the PartsBuffer's extmark→part map mid-edit. sids is a
+  // ref-via-closure rather than a dep so theme swaps rebuild the buffer
+  // through the unmount path instead of on every render.
+  const sidsRef = useRef(sids); sidsRef.current = sids
+  const taRef = useCallback((r: TextareaRenderable | null) => {
+    ta.current = r
+    if (r && !buf.current) buf.current = new PartsBuffer(r, sidsRef.current)
+    if (!r) buf.current = null
+  }, [])
+
   const label = !props.ready ? "Connecting..."
     : props.streaming ? (props.status || "Generating...")
     : "Ready"
@@ -435,11 +446,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         <box width={1}><text fg={theme.primary}>{mode === "shell" ? "$" : ">"}</text></box>
         <box width={1} />
         <textarea
-          ref={(r) => {
-            ta.current = r
-            if (r && !buf.current) buf.current = new PartsBuffer(r, sids)
-            if (!r) buf.current = null
-          }}
+          ref={taRef}
           syntaxStyle={syntaxStyle}
           onContentChange={() => {
             const t = ta.current

--- a/test/composer-parts.test.tsx
+++ b/test/composer-parts.test.tsx
@@ -89,6 +89,25 @@ describe("composer parts — submit", () => {
     expect(sent).toEqual([{ text: "no chips here", parts: [] }])
     t.destroy()
   })
+
+  test("two chips back-to-back → parts[] carries both FileParts on submit", async () => {
+    const { t, ref, sent } = await setup(fileGateway())
+    await chip(t, ref, "@file:src/a.ts")
+    await chip(t, ref, "@file:src/b.ts")
+    expect(ref.current?.value()).toBe("@file:src/a.ts @file:src/b.ts ")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("@file:src/a.ts @file:src/b.ts")
+    expect(sent[0]!.parts).toHaveLength(2)
+    const parts = sent[0]!.parts as readonly FilePart[]
+    expect(parts[0]!.type).toBe("file")
+    expect(parts[0]!.filename).toBe("@file:src/a.ts")
+    expect(parts[1]!.type).toBe("file")
+    expect(parts[1]!.filename).toBe("@file:src/b.ts")
+    t.destroy()
+  })
 })
 describe("composer parts — atomic backspace", () => {
   test("single backspace past a chip removes it whole (and drops its part on submit)", async () => {

--- a/test/composer-parts.test.tsx
+++ b/test/composer-parts.test.tsx
@@ -1,0 +1,150 @@
+// Composer ↔ PartsBuffer integration. The unit tests in parts.test.tsx
+// cover the buffer in isolation; these drive it through the <Composer>
+// surface the app actually mounts — submit emits parts[], a single
+// backspace past a chip boundary eats it whole, and history restore
+// rebuilds chips rather than dropping them to plain text.
+
+import { describe, expect, test } from "bun:test"
+import { act, createRef } from "react"
+import type { RefObject } from "react"
+import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { join } from "path"
+import { mountNode, until, MockGateway, type Harness } from "./harness"
+import { Composer, type ComposerHandle } from "../src/components/chat/Composer"
+import { LOCAL_COMMANDS } from "../src/app/slashCommands"
+import type { Part, FilePart } from "../src/app/parts"
+
+type Sent = { text: string; parts: readonly Part[] | undefined }
+
+// Gateway that resolves any `@file:<query>` word to a single item whose
+// text equals the query — so popAccept() accepts a "complete" chip
+// (not a prefix that ends in `:` or `/`) and drives the insertPart path.
+function fileGateway(): MockGateway {
+  return new MockGateway({
+    "complete.path": p => {
+      const w = String(p.word)
+      if (w.startsWith("@file:") && !w.endsWith(":") && !w.endsWith("/")) {
+        return { items: [{ text: w, display: w, meta: "file" }] }
+      }
+      return { items: [] }
+    },
+  })
+}
+
+async function setup(gw = new MockGateway()) {
+  const ref = createRef<ComposerHandle>()
+  const sent: Sent[] = []
+  const t: Harness = await mountNode(
+    <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+      <box flexGrow={1} />
+      <Composer
+        ref={ref}
+        focused ready streaming={false} cmds={LOCAL_COMMANDS}
+        onSend={(text, parts) => sent.push({ text, parts })}
+        onSlash={() => {}}
+      />
+    </box>,
+    { gw, width: 120, height: 30 },
+  )
+  await until(t, () => t.frame().includes("Ready"))
+  return { t, ref, sent }
+}
+
+// Type an @file ref and accept the popover — lands a chip via the real
+// atAccept() path (the one the user hits with Tab/Enter on the popover).
+async function chip(t: Harness, ref: RefObject<ComposerHandle | null>, word: string) {
+  await act(async () => { await t.keys.typeText(word) })
+  await until(t, () => ref.current?.popOpen() === true)
+  act(() => ref.current?.popAccept())
+  await t.settle()
+}
+
+describe("composer parts — submit", () => {
+  test("chip + text → onSend gets text with chip inlined and parts[] carrying the FilePart", async () => {
+    const { t, ref, sent } = await setup(fileGateway())
+    await chip(t, ref, "@file:src/a.ts")
+    // atAccept appends a trailing space after the chip
+    expect(ref.current?.value()).toBe("@file:src/a.ts ")
+    await act(async () => { await t.keys.typeText("and hello") })
+    await t.settle()
+    expect(ref.current?.value()).toBe("@file:src/a.ts and hello")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("@file:src/a.ts and hello")
+    expect(sent[0]!.parts).toHaveLength(1)
+    const p = sent[0]!.parts![0] as FilePart
+    expect(p.type).toBe("file")
+    expect(p.filename).toBe("@file:src/a.ts")
+    expect(p.source?.text.value).toBe("@file:src/a.ts")
+    t.destroy()
+  })
+
+  test("plain text → parts[] is empty", async () => {
+    const { t, sent } = await setup()
+    await act(async () => { await t.keys.typeText("no chips here") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toEqual([{ text: "no chips here", parts: [] }])
+    t.destroy()
+  })
+})
+describe("composer parts — atomic backspace", () => {
+  test("single backspace past a chip removes it whole (and drops its part on submit)", async () => {
+    const { t, ref, sent } = await setup(fileGateway())
+    await chip(t, ref, "@file:src/a.ts")
+    expect(ref.current?.value()).toBe("@file:src/a.ts ")
+
+    // First ⌫ eats the trailing space; the second lands on the chip
+    // boundary and deletes the whole virtual run in one keystroke.
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(ref.current?.value()).toBe("@file:src/a.ts")
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(ref.current?.value()).toBe("")
+
+    // Submit a new plain message so the previous chip doesn't ride on parts[]
+    await act(async () => { await t.keys.typeText("after") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toEqual([{ text: "after", parts: [] }])
+    t.destroy()
+  })
+})
+
+describe("composer parts — history restore", () => {
+  test("↑ into a history entry with parts rebuilds chips, submit re-emits the FilePart", async () => {
+    // Seed history with an entry that carries a FilePart. The composer's
+    // restore() dispatches to fromSnapshot when parts.length > 0 — that's
+    // the chip-rebuild path we need to exercise.
+    const dir = process.env.HERM_CONFIG_DIR!
+    mkdirSync(dir, { recursive: true })
+    const part: FilePart = {
+      type: "file",
+      mime: "text/uri-list",
+      filename: "@file:src/x.ts",
+      source: { type: "file", path: "@file:src/x.ts", text: { start: 0, end: 14, value: "@file:src/x.ts" } },
+    }
+    const entry = { input: "@file:src/x.ts tail", parts: [part] }
+    writeFileSync(join(dir, "history"), JSON.stringify(entry) + "\n", "utf-8")
+
+    const { t, ref, sent } = await setup()
+    // mountNode doesn't wire useAppKeys, so drive history via the
+    // imperative handle the shell normally binds to ArrowUp.
+    act(() => { ref.current?.historyUp() })
+    await t.settle()
+    expect(ref.current?.value()).toBe("@file:src/x.ts tail")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("@file:src/x.ts tail")
+    expect(sent[0]!.parts).toHaveLength(1)
+    expect((sent[0]!.parts![0] as FilePart).filename).toBe("@file:src/x.ts")
+
+    rmSync(join(dir, "history"), { force: true })
+    t.destroy()
+  })
+})

--- a/test/input-history.test.tsx
+++ b/test/input-history.test.tsx
@@ -3,7 +3,8 @@ import { act } from "react"
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs"
 import { join } from "path"
 import { mountNode } from "./harness"
-import { useInputHistory } from "../src/app/useInputHistory"
+import { useInputHistory, type HistEntry } from "../src/app/useInputHistory"
+import type { FilePart } from "../src/app/parts"
 
 const dir = process.env.HERM_CONFIG_DIR!
 const file = join(dir, "history")
@@ -12,14 +13,14 @@ type Hook = ReturnType<typeof useInputHistory>
 
 async function setup() {
   let hook!: Hook
-  let val = ""
+  let val: HistEntry = { input: "", parts: [] }
   const Probe = () => {
-    const h = useInputHistory(val, v => (val = v))
+    const h = useInputHistory(val.input, e => (val = e))
     hook = h
     return null
   }
   const t = await mountNode(<Probe />)
-  return { t, hook: () => hook, val: () => val }
+  return { t, hook: () => hook, val: () => val.input, entry: () => val }
 }
 
 describe("useInputHistory", () => {
@@ -27,7 +28,7 @@ describe("useInputHistory", () => {
     rmSync(file, { force: true })
   })
 
-  test("loads from disk — ↑ recalls newest-last entry", async () => {
+  test("loads legacy raw-string entries from disk — ↑ recalls newest-last", async () => {
     mkdirSync(dir, { recursive: true })
     writeFileSync(file, "old\nmid\nnew\n")
     const s = await setup()
@@ -40,18 +41,40 @@ describe("useInputHistory", () => {
     s.t.destroy()
   })
 
-  test("push appends to disk and dedupes adjacent", async () => {
+  test("push appends JSONL to disk and dedupes adjacent", async () => {
     const s = await setup()
     act(() => s.hook().push("a"))
     act(() => s.hook().push("a"))
     act(() => s.hook().push("b"))
     act(() => s.hook().push("a"))
     await s.t.settle()
-    expect(readFileSync(file, "utf-8")).toBe("a\nb\na\n")
+    expect(readFileSync(file, "utf-8")).toBe(
+      `{"input":"a"}\n{"input":"b"}\n{"input":"a"}\n`,
+    )
     act(() => s.hook().up())
     expect(s.val()).toBe("a")
     act(() => s.hook().up())
     expect(s.val()).toBe("b")
+    s.t.destroy()
+  })
+
+  test("entries with parts round-trip through disk", async () => {
+    const part: FilePart = {
+      type: "file",
+      mime: "text/uri-list",
+      filename: "@file:src/x.ts",
+      source: { type: "file", path: "@file:src/x.ts", text: { start: 0, end: 14, value: "@file:src/x.ts" } },
+    }
+    const s = await setup()
+    act(() => s.hook().push({ input: "@file:src/x.ts here", parts: [part] }))
+    await s.t.settle()
+    const line = readFileSync(file, "utf-8").trim()
+    const parsed = JSON.parse(line)
+    expect(parsed.input).toBe("@file:src/x.ts here")
+    expect(parsed.parts).toHaveLength(1)
+    expect(parsed.parts[0].type).toBe("file")
+    act(() => s.hook().up())
+    expect(s.entry().parts).toHaveLength(1)
     s.t.destroy()
   })
 
@@ -70,7 +93,7 @@ describe("useInputHistory", () => {
     const s = await setup()
     act(() => s.hook().push("over"))
     await s.t.settle()
-    const out = readFileSync(file, "utf-8").split("\n").filter(Boolean)
+    const out = readFileSync(file, "utf-8").split("\n").filter(Boolean).map(l => JSON.parse(l).input)
     expect(out.length).toBe(500)
     expect(out[0]).toBe("m1")
     expect(out[499]).toBe("over")

--- a/test/parts.test.tsx
+++ b/test/parts.test.tsx
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "bun:test"
+import { act, createRef, useImperativeHandle, forwardRef, useRef } from "react"
+import type { TextareaRenderable } from "@opentui/core"
+import { mountNode, until, type Harness } from "./harness"
+import { PartsBuffer, styles as partStyles, type FilePart, type AgentPart, type TextPart } from "../src/app/parts"
+import { useTheme } from "../src/theme"
+
+// Probe mounts a bare <textarea> inside a ThemeProvider so partStyles
+// can register against a real SyntaxStyle. Exposes the TextareaRenderable
+// and the PartsBuffer bound to it so tests drive both directly.
+type Probe = {
+  ta: TextareaRenderable
+  buf: PartsBuffer
+}
+
+const Harn = forwardRef<Probe>((_, ref) => {
+  const theme = useTheme()
+  const ta = useRef<TextareaRenderable | null>(null)
+  const buf = useRef<PartsBuffer | null>(null)
+  useImperativeHandle(ref, () => ({
+    get ta() { return ta.current! },
+    get buf() { return buf.current! },
+  }), [])
+  const sids = partStyles(theme.syntaxStyle, theme.theme)
+  return (
+    <textarea
+      ref={r => {
+        ta.current = r
+        if (r && !buf.current) buf.current = new PartsBuffer(r, sids)
+        if (!r) buf.current = null
+      }}
+      syntaxStyle={theme.syntaxStyle}
+      focused
+      minHeight={1}
+      maxHeight={6}
+      wrapMode="word"
+    />
+  )
+})
+
+async function setup(): Promise<{ t: Harness; probe: Probe }> {
+  const ref = createRef<Probe>()
+  const t = await mountNode(<Harn ref={ref} />, { width: 80, height: 10 })
+  await until(t, () => ref.current?.ta != null && ref.current?.buf != null)
+  return { t, probe: ref.current! }
+}
+
+function file(name: string): FilePart {
+  return {
+    type: "file",
+    mime: "text/uri-list",
+    filename: name,
+    source: { type: "file", path: name, text: { start: 0, end: name.length, value: name } },
+  }
+}
+
+function agent(name: string): AgentPart {
+  return { type: "agent", name }
+}
+
+function text(body: string): TextPart {
+  return { type: "text", text: body }
+}
+
+describe("PartsBuffer", () => {
+  test("insertText appends plain text, produces no parts", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("hello"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("hello")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("insertPart writes virtualText + trailing space, records part with range", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:src/a.ts"), "@file:src/a.ts"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:src/a.ts ")
+    const ps = probe.buf.parts()
+    expect(ps).toHaveLength(1)
+    const p = ps[0]!
+    expect(p.type).toBe("file")
+    if (p.type === "file") {
+      expect(p.filename).toBe("@file:src/a.ts")
+      expect(p.source?.text.start).toBe(0)
+      expect(p.source?.text.end).toBe(14)
+      expect(p.source?.text.value).toBe("@file:src/a.ts")
+    }
+    t.destroy()
+  })
+
+  test("insertText + insertPart + insertText preserves display order", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("see "))
+    act(() => probe.buf.insertPart(file("@file:a.ts"), "@file:a.ts"))
+    act(() => probe.buf.insertText("then "))
+    act(() => probe.buf.insertPart(agent("reviewer"), "@reviewer"))
+    act(() => probe.buf.insertText("done"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("see @file:a.ts then @reviewer done")
+    const ps = probe.buf.parts()
+    expect(ps.map(p => p.type)).toEqual(["file", "agent"])
+    // ranges in ascending order
+    const r0 = ps[0]!.type === "file" ? ps[0]!.source!.text : null
+    const r1 = ps[1]!.type === "agent" ? ps[1]!.source! : null
+    expect(r0!.start).toBeLessThan(r1!.start)
+    t.destroy()
+  })
+
+  test("listParts equivalent: parts() reflects kinds and ranges", async () => {
+    const { t, probe } = await setup()
+    const f = file("@file:x")
+    const a = agent("reviewer")
+    const txt = text("pasted content body")
+    act(() => probe.buf.insertPart(f, "@file:x"))
+    act(() => probe.buf.insertPart(a, "@reviewer"))
+    act(() => probe.buf.insertPart(txt, "[Pasted #1]"))
+    await t.settle()
+    const kinds = probe.buf.parts().map(p => p.type)
+    expect(kinds).toEqual(["file", "agent", "text"])
+    t.destroy()
+  })
+
+  test("chip at buffer start", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertText("after"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a after")
+    const p = probe.buf.parts()[0]!
+    if (p.type === "file") expect(p.source?.text.start).toBe(0)
+    t.destroy()
+  })
+
+  test("chip at buffer end (no trailing text after the chip's trailing space)", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("before "))
+    act(() => probe.buf.insertPart(file("@file:b"), "@file:b"))
+    await t.settle()
+    // insertPart always appends a trailing space; caret lands after it
+    expect(probe.buf.text()).toBe("before @file:b ")
+    expect(probe.buf.parts()).toHaveLength(1)
+    t.destroy()
+  })
+
+  test("adjacent chips — two chips inserted back to back", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertPart(file("@file:b"), "@file:b"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a @file:b ")
+    const ps = probe.buf.parts()
+    expect(ps).toHaveLength(2)
+    const r0 = ps[0]!.type === "file" ? ps[0]!.source!.text : null
+    const r1 = ps[1]!.type === "file" ? ps[1]!.source!.text : null
+    expect(r0!.end).toBeLessThanOrEqual(r1!.start)
+    expect(r1!.start - r0!.end).toBe(1) // the space between them
+    t.destroy()
+  })
+
+  test("inserting text immediately before a chip does NOT extend the chip's range", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    const before = probe.buf.parts()[0]!
+    const origLen = before.type === "file" ? before.source!.text.end - before.source!.text.start : 0
+    // Move caret to 0 and insert "xx" before the chip
+    act(() => { probe.ta.cursorOffset = 0 })
+    act(() => probe.buf.insertText("xx"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("xx@file:a ")
+    const after = probe.buf.parts()[0]!
+    if (after.type === "file") {
+      const newLen = after.source!.text.end - after.source!.text.start
+      expect(newLen).toBe(origLen)
+      expect(after.source!.text.start).toBe(2) // shifted, not extended
+    }
+    t.destroy()
+  })
+
+  test("inserting text immediately after a chip does NOT extend the chip's range", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    const before = probe.buf.parts()[0]!
+    const origEnd = before.type === "file" ? before.source!.text.end : 0
+    // Caret already at end of buffer after insertPart; insert more text
+    act(() => probe.buf.insertText("yy"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a yy")
+    const after = probe.buf.parts()[0]!
+    if (after.type === "file") {
+      expect(after.source!.text.end).toBe(origEnd)
+      expect(after.source!.text.start).toBe(0)
+    }
+    t.destroy()
+  })
+
+  test("atomic-chip backspace: one keystroke removes the whole chip + its part", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    // caret sits just past the trailing space; remove the space first so
+    // the next backspace lands on the chip boundary
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a")
+    expect(probe.buf.parts()).toHaveLength(1)
+    // Now a single backspace deletes the entire chip atomically
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("backspace inside plain text deletes one char (regression guard)", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("hello"))
+    await t.settle()
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("hell")
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("hel")
+    t.destroy()
+  })
+
+  test("deleteRange spanning a chip removes it cleanly", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("prefix "))
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertText("suffix"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("prefix @file:a suffix")
+    // Delete everything from end of "prefix " through "@file:a" (cols 7..14
+    // inclusive) by replacing the whole buffer — setText + sync mirrors
+    // what a selection+delete via the textarea would do.
+    act(() => {
+      probe.ta.deleteRange(0, 7, 0, 15)
+    })
+    await t.settle()
+    expect(probe.buf.text()).toBe("prefix suffix")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("toSnapshot() + fromSnapshot() round-trip is lossless", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("look "))
+    act(() => probe.buf.insertPart(file("@file:src/z.ts"), "@file:src/z.ts"))
+    act(() => probe.buf.insertText("and "))
+    act(() => probe.buf.insertPart(agent("reviewer"), "@reviewer"))
+    await t.settle()
+    const snap = probe.buf.toSnapshot()
+    expect(snap.v).toBe(1)
+    expect(snap.input).toBe(probe.buf.text())
+    expect(snap.parts).toHaveLength(2)
+
+    // Clear, then restore; text + parts must match exactly.
+    act(() => probe.buf.clear())
+    await t.settle()
+    expect(probe.buf.text()).toBe("")
+    expect(probe.buf.parts()).toEqual([])
+
+    act(() => probe.buf.fromSnapshot(snap))
+    await t.settle()
+    expect(probe.buf.text()).toBe(snap.input)
+    // Deep-equal parts
+    expect(probe.buf.parts()).toEqual(snap.parts)
+
+    // Second snapshot must deep-equal the first.
+    const snap2 = probe.buf.toSnapshot()
+    expect(snap2).toEqual(snap)
+    t.destroy()
+  })
+
+  test("clear() wipes text, marks, and parts", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("x "))
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    expect(probe.buf.parts()).toHaveLength(1)
+    act(() => probe.buf.clear())
+    await t.settle()
+    expect(probe.buf.text()).toBe("")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("expand() inlines text parts, keeps file/agent parts in emitted list", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("here "))
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertText(" and "))
+    act(() => probe.buf.insertPart(text("the real pasted body"), "[Pasted #1]"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("here @file:a  and [Pasted #1] ")
+    const exp = probe.buf.expand()
+    // [Pasted #1] replaced by its source text, @file:a chip preserved as-is
+    expect(exp.text).toBe("here @file:a  and the real pasted body ")
+    expect(exp.parts).toHaveLength(1)
+    expect(exp.parts[0]!.type).toBe("file")
+    t.destroy()
+  })
+
+  test("sync() drops parts whose marks were deleted (atomic backspace case)", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertPart(file("@file:b"), "@file:b"))
+    await t.settle()
+    expect(probe.buf.parts()).toHaveLength(2)
+    // Delete the trailing space, then the second chip via backspace.
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    const ps = probe.buf.parts()
+    expect(ps).toHaveLength(1)
+    if (ps[0]!.type === "file") expect(ps[0]!.filename).toBe("@file:a")
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## What

Adds `src/app/parts.ts` — a `PartsBuffer` adapter over `@opentui/core` extmarks — and wires it into the composer.

- **Styled chips for @-refs.** Accepting a complete `@file:path` / `@diff` / `@git:N` ref from the popover lands it as a styled, mark-backed chip instead of plain text. Prefix keywords that keep the popover open (`@file:`, `@folder:`) keep the classic string-write path.
- **Atomic backspace.** One keystroke deletes a whole chip. Comes free from `virtual:true` extmarks — no custom key handling.
- **Parts round-trip through history.** History entries persist as JSONL `{input, parts?}`; recalling an entry with parts rebuilds the chips and their ranges. Legacy NUL-encoded raw-string lines still load.
- **Submit emits `onSend(text, parts?)`.** Text parts (pasted content) are inlined back into the text before send; file/agent parts ride as a side-channel. No wire change — today's callers only consume `text`. This unblocks a follow-up gateway task without blocking this ship.

## Behavioral notes

- `~/.hermes/herm/history` migrates from NUL-encoded lines to JSONL on the next write. Old lines are read via a tolerant parser; the file becomes mixed-format after first use.
- `<textarea>` now receives `syntaxStyle` so extmark styles resolve. Theme swaps re-register style ids and rebuild the buffer through the unmount path.

## Tests

`test/parts.test.tsx` (16 cases: insert ordering, chip boundaries, adjacent chips, atomic backspace, deleteRange across a chip, snapshot round-trip, expand semantics) + `test/composer-parts.test.tsx` (5 cases: submit emits parts, two chips back-to-back, backspace drops the part, history restore re-emits). The two-chips case guards a real bug found during review: the accept path previously rebuilt the buffer with `setText()`, wiping every prior chip's mark.

tsc clean, 1007/1007 pass.