### PR TITLE
Composer: show ▶ N indicator while background tasks run

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -49,6 +49,7 @@ import { rehome } from "./home/rehome"
 import { makeGoalHook } from "./app/goalHook"
 import type { Launch } from "./app/launch"
 import { PluginProvider, usePlugins } from "./plugins/runtime"
+import { BackgroundProvider } from "./app/background"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch }
 
@@ -60,7 +61,9 @@ export const App = (props: AppProps) => (
           <DialogProvider>
             <CommandProvider>
               <PluginProvider>
-                <AppInner launch={props.launch ?? { mode: "new" }} />
+                <BackgroundProvider>
+                  <AppInner launch={props.launch ?? { mode: "new" }} />
+                </BackgroundProvider>
               </PluginProvider>
             </CommandProvider>
           </DialogProvider>

--- a/src/app/background.tsx
+++ b/src/app/background.tsx
@@ -1,0 +1,40 @@
+// Client-side registry of in-flight /background task ids.
+// Consumers call register/unregister to mutate the set; count/ids
+// update reactively so a status-bar component can read len() the way
+// hermes-agent's _get_status_bar_snapshot does server-side.
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+import { makeUse } from "../context/helper"
+
+type Ctx = {
+  count: number
+  ids: readonly string[]
+  register: (id: string) => void
+  unregister: (id: string) => void
+}
+
+const ctx = createContext<Ctx | null>(null)
+
+export const BackgroundProvider = ({ children }: { children: ReactNode }) => {
+  const [set, setSet] = useState<ReadonlySet<string>>(() => new Set())
+  const register = useCallback((id: string) => {
+    if (!id) return
+    setSet(prev => prev.has(id) ? prev : new Set(prev).add(id))
+  }, [])
+  const unregister = useCallback((id: string) => {
+    setSet(prev => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+  const ids = useMemo(() => Array.from(set), [set])
+  const value = useMemo<Ctx>(
+    () => ({ count: ids.length, ids, register, unregister }),
+    [ids, register, unregister],
+  )
+  return <ctx.Provider value={value}>{children}</ctx.Provider>
+}
+
+export const useBackground = makeUse(ctx, "useBackground")

--- a/src/app/background.tsx
+++ b/src/app/background.tsx
@@ -1,7 +1,5 @@
-// Client-side registry of in-flight /background task ids.
-// Consumers call register/unregister to mutate the set; count/ids
-// update reactively so a status-bar component can read len() the way
-// hermes-agent's _get_status_bar_snapshot does server-side.
+// In-flight /background task ids. Registered on prompt.background,
+// unregistered on background.complete.
 
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
 import { makeUse } from "../context/helper"

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -34,6 +34,7 @@ import * as preferences from "../context/preferences"
 import { redraw } from "./useAppKeys"
 import { quit } from "./exit"
 import { Stash } from "./stash"
+import { useBackground } from "./background"
 import { useHome, home } from "../home"
 import { TAB_SLASH } from "./tabs"
 import { transcriptToMessages, type Action, type TurnState } from "./turnReducer"
@@ -86,6 +87,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
   const cmd = useCommand()
   const renderer = useRenderer()
   const cfg = useHome("config")
+  const bg = useBackground()
 
   const ctx = useRef(c); ctx.current = c
   const gate = useRef(cfg); gate.current = cfg
@@ -353,9 +355,12 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
         case "background":
           if (!arg) { toast.show({ variant: "info", message: "usage: /background <prompt>" }); return }
           gw.request<{ task_id?: string }>("prompt.background", { text: arg })
-            .then(r => toast.show(r.task_id
-              ? { variant: "success", message: `background ${r.task_id} started` }
-              : { variant: "error", message: "background start failed" }))
+            .then(r => {
+              if (r.task_id) bg.register(r.task_id)
+              toast.show(r.task_id
+                ? { variant: "success", message: `background ${r.task_id} started` }
+                : { variant: "error", message: "background start failed" })
+            })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "voice":

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -12,6 +12,7 @@ import { useToast } from "../ui/toast"
 import { openAlert } from "../dialogs/alert"
 import { mapEvent } from "../context/events"
 import { deriveSkin, type SkinState } from "../context/skin"
+import { useBackground } from "./background"
 import type { Action } from "./turnReducer"
 import type { useSession } from "./useSession"
 import type { GatewayEvent, SessionInfo } from "../context/wire"
@@ -50,6 +51,7 @@ export function useStream(c: Ctx) {
   const gw = useGateway()
   const dialog = useDialog()
   const toast = useToast()
+  const bg = useBackground()
   const ctx = useRef(c); ctx.current = c
 
   // Client-side interrupt latch: flipped on Esc×2 before the gateway
@@ -120,6 +122,7 @@ export function useStream(c: Ctx) {
         x.goalHook.check(x.sidRef.current)
       },
       onBackground: (tid, text) => {
+        bg.unregister(tid)
         const head = text.split("\n")[0].slice(0, 80)
         x.dispatch({ kind: "system", text: `◷ background task ${tid} complete — ${head}` })
         toast.show({

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -14,6 +14,7 @@ import type { SlashCommand } from "../../app/slashCommands"
 import { useSlashPopover } from "../../app/useSlashPopover"
 import { useAtRefPopover } from "../../app/useAtRefPopover"
 import { useInputHistory } from "../../app/useInputHistory"
+import { useBackground } from "../../app/background"
 import { SlashPopover } from "./SlashPopover"
 import { AtRefPopover } from "./AtRefPopover"
 import { ChafaImage } from "../../ui/ChafaImage"
@@ -83,6 +84,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const theme = useTheme().theme
   const gw = useGateway()
   const keys = useKeys()
+  const bg = useBackground()
   const ta = useRef<TextareaRenderable | null>(null)
   // Mirror of the textarea buffer. The renderable is the source of truth;
   // this drives React-side derivations (popover matching, row count, hints).
@@ -433,6 +435,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         {props.streaming && (props.queue?.length ?? 0) > 0 ? (
           <text fg={theme.textMuted}>{keys.print("queue.flush")} to send queued now  </text>
         ) : null}
+        {bg.count > 0 ? <text fg={theme.text}>▶ {bg.count}  </text> : null}
         {props.model ? <text fg={theme.textMuted}>{props.model}</text> : null}
       </box>
     </box>

--- a/test/background.test.tsx
+++ b/test/background.test.tsx
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test"
 import { act } from "react"
-import { mount, until } from "./harness"
+import { mount, until, MockGateway } from "./harness"
 
 describe("background/btw completion", () => {
   test("background.complete → transcript marker + toast with view action → alert dialog", async () => {
@@ -41,6 +41,40 @@ describe("background/btw completion", () => {
     await t.settle()
     expect(t.frame()).toContain("◈ btw — side answer here")
     expect(t.frame()).toContain("btw")
+    t.destroy()
+  })
+
+  test("/background register → composer badge; background.complete → unregister", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),
+      "prompt.background": () => ({ task_id: "bg-42" }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    expect(t.frame()).not.toContain("▶ 1")
+
+    await act(async () => { await t.keys.typeText("/background do the thing") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("▶ 1"))
+
+    act(() => t.gw.push({ type: "background.complete", payload: { task_id: "bg-42", text: "done" } }))
+    await until(t, () => !t.frame().includes("▶ 1"))
+    t.destroy()
+  })
+
+  test("/background with no task_id in response does not register", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),
+      "prompt.background": () => ({}),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/background oops") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("background start failed"))
+    expect(t.frame()).not.toContain("▶ 1")
     t.destroy()
   })
 })

--- a/test/composer-background-fragment.test.tsx
+++ b/test/composer-background-fragment.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { act, createRef } from "react"
+import { mountNode, until } from "./harness"
+import { Composer, type ComposerHandle } from "../src/components/chat/Composer"
+import { BackgroundProvider, useBackground } from "../src/app/background"
+
+const noop = () => {}
+
+// Surface the bg API next to the Composer so the test can register/unregister
+// without reaching into provider internals.
+const Host = ({ grab, composerRef }: { grab: (api: ReturnType<typeof useBackground>) => void; composerRef: React.Ref<ComposerHandle> }) => {
+  const api = useBackground()
+  grab(api)
+  return (
+    <Composer
+      ref={composerRef}
+      focused
+      ready
+      streaming={false}
+      cmds={[]}
+      model="test-model"
+      onSend={noop}
+      onSlash={noop}
+    />
+  )
+}
+
+const mountComposer = async () => {
+  const ref = createRef<ComposerHandle>()
+  let api: ReturnType<typeof useBackground> | undefined
+  const t = await mountNode(
+    <BackgroundProvider>
+      <Host grab={a => { api = a }} composerRef={ref} />
+    </BackgroundProvider>,
+    { width: 80, height: 8 },
+  )
+  return { t, get: () => api!, ref }
+}
+
+describe("Composer background fragment", () => {
+  test("absent when no background tasks", async () => {
+    const { t } = await mountComposer()
+    expect(t.frame()).not.toContain("▶")
+    t.destroy()
+  })
+
+  test("shows ▶ 1 with one task", async () => {
+    const { t, get } = await mountComposer()
+    act(() => { get().register("task-a") })
+    await until(t, () => t.frame().includes("▶ 1"))
+    t.destroy()
+  })
+
+  test("shows ▶ 3 with three tasks", async () => {
+    const { t, get } = await mountComposer()
+    act(() => {
+      get().register("a")
+      get().register("b")
+      get().register("c")
+    })
+    await until(t, () => t.frame().includes("▶ 3"))
+    t.destroy()
+  })
+
+  test("disappears when count returns to zero", async () => {
+    const { t, get } = await mountComposer()
+    act(() => { get().register("a") })
+    await until(t, () => t.frame().includes("▶ 1"))
+    act(() => { get().unregister("a") })
+    await until(t, () => !t.frame().includes("▶"))
+    t.destroy()
+  })
+})

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -21,6 +21,7 @@ import { DialogProvider } from "../src/ui/dialog"
 import { ToastProvider } from "../src/ui/toast"
 import { CommandProvider } from "../src/ui/command"
 import { PluginProvider } from "../src/plugins/runtime"
+import { BackgroundProvider } from "../src/app/background"
 import type { HermPlugin } from "../src/plugins/types"
 import type { GatewayEvent } from "../src/context/wire"
 
@@ -150,7 +151,9 @@ export async function mountNode(node: ReactNode, opts: Opts = {}): Promise<Harne
           <KeysProvider>
             <DialogProvider>
               <CommandProvider>
-                <PluginProvider plugins={opts.plugins ?? []}>{node}</PluginProvider>
+                <PluginProvider plugins={opts.plugins ?? []}>
+                  <BackgroundProvider>{node}</BackgroundProvider>
+                </PluginProvider>
               </CommandProvider>
             </DialogProvider>
           </KeysProvider>

--- a/test/use-background.test.tsx
+++ b/test/use-background.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mountNode, until } from "./harness"
+import { BackgroundProvider, useBackground } from "../src/app/background"
+
+type Api = ReturnType<typeof useBackground>
+
+const Host = ({ grab }: { grab: (api: Api) => void }) => {
+  const api = useBackground()
+  grab(api)
+  return (
+    <box flexDirection="column">
+      <text>{`count:${api.count}`}</text>
+      <text>{`ids:${api.ids.join(",")}`}</text>
+    </box>
+  )
+}
+
+const mountHost = async () => {
+  let api: Api | undefined
+  const t = await mountNode(
+    <BackgroundProvider><Host grab={a => { api = a }} /></BackgroundProvider>,
+    { width: 40, height: 6 },
+  )
+  return { t, get: () => api! }
+}
+
+describe("BackgroundProvider", () => {
+  test("starts empty", async () => {
+    const { t } = await mountHost()
+    expect(t.frame()).toContain("count:0")
+    expect(t.frame()).toContain("ids:")
+    t.destroy()
+  })
+
+  test("register adds ids and bumps count reactively", async () => {
+    const { t, get } = await mountHost()
+    act(() => { get().register("a"); get().register("b") })
+    await until(t, () => t.frame().includes("count:2"))
+    expect(t.frame()).toContain("ids:a,b")
+    t.destroy()
+  })
+
+  test("register is a no-op for falsy or duplicate ids", async () => {
+    const { t, get } = await mountHost()
+    act(() => { get().register("a"); get().register("a"); get().register("") })
+    await until(t, () => t.frame().includes("count:1"))
+    expect(t.frame()).toContain("ids:a")
+    t.destroy()
+  })
+
+  test("unregister removes present ids and is a no-op for absent", async () => {
+    const { t, get } = await mountHost()
+    act(() => { get().register("a"); get().register("b") })
+    await until(t, () => t.frame().includes("count:2"))
+    act(() => { get().unregister("a"); get().unregister("missing") })
+    await until(t, () => t.frame().includes("count:1"))
+    expect(t.frame()).toContain("ids:b")
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## What

A `/background` task today produces one "started" toast and then nothing until completion — no way to confirm it's alive or see how many are in flight.

- `src/app/background.tsx` — `BackgroundProvider` holding a `ReadonlySet` of in-flight task ids, `register`/`unregister` with identity-preserving no-ops, `useBackground()` exposing `count` + `ids`.
- `slash.tsx` registers the id when `prompt.background` resolves with a truthy `task_id`; `useStream` unregisters on `background.complete`. Toast and transcript-marker behavior unchanged.
- Composer renders a `▶ N` fragment between the queue-flush hint and the model label when count > 0, hidden at zero.

## Tests

Provider semantics (register/unregister/dedup/reactivity), composer fragment presence/absence, and the full `/background` → register → `background.complete` → unregister lifecycle through `MockGateway`.

tsc clean, 995/995 pass.