### PR TITLE
1.7.0

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,6 +50,8 @@ import { makeGoalHook } from "./app/goalHook"
 import type { Launch } from "./app/launch"
 import { PluginProvider, usePlugins } from "./plugins/runtime"
 import { BackgroundProvider } from "./app/background"
+import { useVoice } from "./voice/useVoice"
+import { VoiceIndicator } from "./voice/Indicator"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch }
 
@@ -190,6 +192,20 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // Live ref so send() (stable for queue-drain) reads the current catalog
   // without re-creating itself on every catalog refresh.
   const cmdsRef = useRef(cmds); cmdsRef.current = cmds
+
+  // ── Voice ──────────────────────────────────────────────────────────
+  const sys = useCallback((text: string) => dispatch({ kind: "system", text }), [])
+  const voice = useVoice(gw.request.bind(gw), sys)
+  // Transcript → composer: insert text and auto-send (CLI parity).
+  useEffect(() => {
+    voice.setOnTranscript((text: string) => {
+      const c = composer.current
+      if (!c) return
+      c.set("")
+      // Defer submit so the cleared input commits before send reads it.
+      setTimeout(() => sendRef.current(text), 0)
+    })
+  }, [])
 
   // Transient error pulse — set on any reducer {kind:"error"} or
   // gateway exit; cleared when the avatar's play-once error clip
@@ -624,6 +640,9 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       c?.set("")
       toast.show({ variant: "info", message: `stashed (${n})` })
     },
+    voiceRecordKey: voice.state.recordKey,
+    voiceEnabled: voice.state.enabled,
+    onVoiceRecord: () => voice.record(sidRef.current),
   })
   useBridge({
     tab, ready, streaming: turn.streaming, messages: turn.messages, sid, focusRegion,
@@ -707,6 +726,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
               ) : null}
             </box>
             <box flexShrink={0} zIndex={1}>
+              <VoiceIndicator voice={voice.state} keyLabel={voice.keyLabel} />
               <Composer
                 ref={composer}
                 focused={inputFocused} ready={ready} streaming={turn.streaming}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -448,7 +448,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     dispatch, session, turnRef, queueRef, sendRef, composer, summoned, undone,
     ready, info, sid, title, skin,
     setQueue, setFocusRegion, setSplash, setAttachments, setInfo, setUsage, setTitle,
-    newSession, switchSession, rewind, goTo, attachClipboard,
+    newSession, switchSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
   })
   const send = useCallback(async (raw: string) => {
     // Bare exit/quit/:q — pass through as literals so a

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -49,6 +49,7 @@ import { rehome } from "./home/rehome"
 import { makeGoalHook } from "./app/goalHook"
 import type { Launch } from "./app/launch"
 import { PluginProvider, usePlugins } from "./plugins/runtime"
+import { BackgroundProvider } from "./app/background"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch }
 
@@ -60,7 +61,9 @@ export const App = (props: AppProps) => (
           <DialogProvider>
             <CommandProvider>
               <PluginProvider>
-                <AppInner launch={props.launch ?? { mode: "new" }} />
+                <BackgroundProvider>
+                  <AppInner launch={props.launch ?? { mode: "new" }} />
+                </BackgroundProvider>
               </PluginProvider>
             </CommandProvider>
           </DialogProvider>

--- a/src/app/background.tsx
+++ b/src/app/background.tsx
@@ -1,0 +1,40 @@
+// Client-side registry of in-flight /background task ids.
+// Consumers call register/unregister to mutate the set; count/ids
+// update reactively so a status-bar component can read len() the way
+// hermes-agent's _get_status_bar_snapshot does server-side.
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+import { makeUse } from "../context/helper"
+
+type Ctx = {
+  count: number
+  ids: readonly string[]
+  register: (id: string) => void
+  unregister: (id: string) => void
+}
+
+const ctx = createContext<Ctx | null>(null)
+
+export const BackgroundProvider = ({ children }: { children: ReactNode }) => {
+  const [set, setSet] = useState<ReadonlySet<string>>(() => new Set())
+  const register = useCallback((id: string) => {
+    if (!id) return
+    setSet(prev => prev.has(id) ? prev : new Set(prev).add(id))
+  }, [])
+  const unregister = useCallback((id: string) => {
+    setSet(prev => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+  const ids = useMemo(() => Array.from(set), [set])
+  const value = useMemo<Ctx>(
+    () => ({ count: ids.length, ids, register, unregister }),
+    [ids, register, unregister],
+  )
+  return <ctx.Provider value={value}>{children}</ctx.Provider>
+}
+
+export const useBackground = makeUse(ctx, "useBackground")

--- a/src/app/background.tsx
+++ b/src/app/background.tsx
@@ -1,7 +1,5 @@
-// Client-side registry of in-flight /background task ids.
-// Consumers call register/unregister to mutate the set; count/ids
-// update reactively so a status-bar component can read len() the way
-// hermes-agent's _get_status_bar_snapshot does server-side.
+// In-flight /background task ids. Registered on prompt.background,
+// unregistered on background.complete.
 
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
 import { makeUse } from "../context/helper"

--- a/src/app/parts.ts
+++ b/src/app/parts.ts
@@ -1,0 +1,246 @@
+// Extmark-backed parts model for the composer. Mirrors the opencode
+// shape (file/agent/text kinds with asymmetric `source` fields) so
+// serialized snapshots round-trip through the gateway wire when the
+// rest of the parts pipeline lands; today they only drive chip
+// rendering, atomic-chip backspace, and history restore.
+//
+// Offsets are display-width (what opentui's extmarks consume), not
+// JS string indices. virtual:true marks give cursor-atomic + delete-
+// atomic behavior for free — there is no custom backspace code here.
+
+import type { TextareaRenderable, ExtmarksController, SyntaxStyle, ColorInput } from "@opentui/core"
+
+export type PartKind = "file" | "agent" | "text"
+
+export type FilePart = {
+  type: "file"
+  mime: string
+  filename?: string
+  url?: string
+  source?: {
+    type: "file"
+    path: string
+    text: { start: number; end: number; value: string }
+  }
+}
+
+export type AgentPart = {
+  type: "agent"
+  name: string
+  source?: { start: number; end: number; value: string }
+}
+
+export type TextPart = {
+  type: "text"
+  text: string
+  synthetic?: boolean
+  source?: { text: { start: number; end: number; value: string } }
+}
+
+export type Part = FilePart | AgentPart | TextPart
+
+export type PartsSnapshot = {
+  v: 1
+  input: string
+  parts: Part[]
+}
+
+export const TYPE = "prompt-part"
+export const STYLE = {
+  file: "extmark.file",
+  agent: "extmark.agent",
+  paste: "extmark.paste",
+} as const
+
+// One-shot registration of extmark styles on a shared SyntaxStyle.
+// Idempotent — resolveStyleId short-circuits after the first register.
+export function styles(syntax: SyntaxStyle, theme: { accent: ColorInput; primary: ColorInput; textMuted: ColorInput }) {
+  const ensure = (name: string, def: { fg?: ColorInput; italic?: boolean }) => {
+    const id = syntax.getStyleId(name)
+    if (id !== null) return id
+    return syntax.registerStyle(name, def)
+  }
+  return {
+    file: ensure(STYLE.file, { fg: theme.accent }),
+    agent: ensure(STYLE.agent, { fg: theme.primary, italic: true }),
+    paste: ensure(STYLE.paste, { fg: theme.textMuted }),
+  }
+}
+
+type StyleIds = { file: number; agent: number; paste: number }
+
+// Bridge between a TextareaRenderable (source of truth for text +
+// extmarks) and a parallel parts[] array. The map id→index keeps the
+// two in sync: when a mark is deleted (atomic-chip backspace) we drop
+// the matching part; when marks shift (text inserted before them) we
+// rewrite the part's source range before emitting/snapshotting.
+export class PartsBuffer {
+  private ta: TextareaRenderable
+  private ex: ExtmarksController
+  private typeId: number
+  private style: StyleIds
+  private list: Part[] = []
+  private map = new Map<number, number>()
+
+  constructor(ta: TextareaRenderable, style: StyleIds) {
+    this.ta = ta
+    this.ex = ta.extmarks
+    this.style = style
+    this.typeId = this.ex.registerType(TYPE)
+  }
+
+  text() { return this.ta.plainText }
+
+  // The textarea may be destroyed mid-session (tab switch unmounting
+  // the composer, hot reload, etc.). Every op that reaches into
+  // opentui internals guards so the caller doesn't need to.
+  private alive() { return !this.ta.isDestroyed }
+
+  insertText(str: string) {
+    if (!this.alive()) return
+    this.ta.insertText(str)
+  }
+
+  // Insert a part at the current cursor. Writes the virtual text into
+  // the buffer and binds a mark to its display range. Trailing space
+  // matches opencode and keeps the caret outside the chip so the next
+  // keystroke doesn't extend the range. Extmark offsets are display-
+  // width — visualCursor.offset, not cursorOffset.
+  insertPart(part: Part, virtualText: string) {
+    if (!this.alive()) return
+    const start = this.ta.visualCursor.offset
+    const end = start + visualLen(virtualText)
+    this.ta.insertText(virtualText + " ")
+    const id = this.ex.create({
+      start,
+      end,
+      virtual: true,
+      styleId: styleFor(part.type, this.style),
+      typeId: this.typeId,
+    })
+    const idx = this.list.length
+    this.list.push(withSource(part, start, end, virtualText))
+    this.map.set(id, idx)
+  }
+
+  // Re-read mark ranges from the textarea and rebuild a compact
+  // parts[] reflecting only the marks that still exist. Any parts
+  // whose mark was deleted (atomic-chip backspace) drop out.
+  sync() {
+    if (!this.alive()) return
+    const alive = this.ex.getAllForTypeId(this.typeId)
+    const next: Part[] = []
+    const nextMap = new Map<number, number>()
+    for (const m of alive) {
+      const idx = this.map.get(m.id)
+      if (idx === undefined) continue
+      const p = this.list[idx]
+      if (!p) continue
+      nextMap.set(m.id, next.length)
+      next.push(rangeTo(p, m.start, m.end))
+    }
+    this.list = next
+    this.map = nextMap
+  }
+
+  // Parts in display order. `sync()` first so callers always see the
+  // current mark ranges — callers don't need to remember to call it.
+  parts(): readonly Part[] {
+    this.sync()
+    return this.list
+  }
+
+  // Snapshot for history/rewind: stores the plain text + parts with
+  // their source ranges frozen. fromSnapshot() rebuilds both.
+  toSnapshot(): PartsSnapshot {
+    return { v: 1, input: this.text(), parts: [...this.parts()] }
+  }
+
+  fromSnapshot(snap: PartsSnapshot) {
+    if (!this.alive()) return
+    this.ta.setText(snap.input)
+    this.ex.clear()
+    this.list = []
+    this.map = new Map()
+    for (const p of snap.parts) {
+      const r = rangeOf(p)
+      if (!r) continue
+      const id = this.ex.create({
+        start: r.start,
+        end: r.end,
+        virtual: true,
+        styleId: styleFor(p.type, this.style),
+        typeId: this.typeId,
+      })
+      this.map.set(id, this.list.length)
+      this.list.push(p)
+    }
+    this.ta.gotoBufferEnd()
+  }
+
+  clear() {
+    this.list = []
+    this.map = new Map()
+    if (!this.alive()) return
+    this.ta.setText("")
+    this.ex.clear()
+  }
+
+  // Inline-expand text parts into their original value (paste body)
+  // and strip them from the parts[] — only file/agent parts ride as
+  // real message parts to the gateway. Matches opencode submit path.
+  expand(): { text: string; parts: Part[] } {
+    if (!this.alive()) return { text: "", parts: [] }
+    this.sync()
+    let text = this.text()
+    const marks = this.ex.getAllForTypeId(this.typeId).sort((a, b) => b.start - a.start)
+    for (const m of marks) {
+      const idx = this.map.get(m.id)
+      if (idx === undefined) continue
+      const p = this.list[idx]
+      if (p?.type !== "text") continue
+      text = text.slice(0, m.start) + p.text + text.slice(m.end)
+    }
+    return { text, parts: this.list.filter(p => p.type !== "text") }
+  }
+}
+
+function visualLen(s: string): number {
+  // Fallback for runtimes without Bun.stringWidth; matches opentui's
+  // assumption that ASCII chips are one column per char.
+  const B = (globalThis as { Bun?: { stringWidth?: (s: string) => number } }).Bun
+  return B?.stringWidth ? B.stringWidth(s) : s.length
+}
+
+function styleFor(k: PartKind, s: StyleIds) {
+  if (k === "file") return s.file
+  if (k === "agent") return s.agent
+  return s.paste
+}
+
+function withSource(p: Part, start: number, end: number, value: string): Part {
+  if (p.type === "file") return { ...p, source: p.source ?? { type: "file", path: "", text: { start, end, value } } }
+  if (p.type === "agent") return { ...p, source: { start, end, value } }
+  return { ...p, source: { text: { start, end, value } } }
+}
+
+function rangeTo(p: Part, start: number, end: number): Part {
+  if (p.type === "file") {
+    const src = p.source ?? { type: "file" as const, path: "", text: { start, end, value: "" } }
+    return { ...p, source: { ...src, text: { ...src.text, start, end } } }
+  }
+  if (p.type === "agent") {
+    const src = p.source ?? { start, end, value: "" }
+    return { ...p, source: { ...src, start, end } }
+  }
+  const src = p.source ?? { text: { start, end, value: "" } }
+  return { ...p, source: { text: { ...src.text, start, end } } }
+}
+
+function rangeOf(p: Part) {
+  if (p.type === "file") return p.source?.text
+  if (p.type === "agent") return p.source
+  return p.source?.text
+}
+
+export * as parts from "./parts"

--- a/src/app/parts.ts
+++ b/src/app/parts.ts
@@ -1,12 +1,6 @@
-// Extmark-backed parts model for the composer. Mirrors the opencode
-// shape (file/agent/text kinds with asymmetric `source` fields) so
-// serialized snapshots round-trip through the gateway wire when the
-// rest of the parts pipeline lands; today they only drive chip
-// rendering, atomic-chip backspace, and history restore.
-//
-// Offsets are display-width (what opentui's extmarks consume), not
-// JS string indices. virtual:true marks give cursor-atomic + delete-
-// atomic behavior for free — there is no custom backspace code here.
+// Extmark-backed parts model for the composer. Offsets are display-width
+// (what extmarks consume), not JS string indices. virtual:true marks give
+// cursor-atomic + delete-atomic behavior; there is no custom backspace code.
 
 import type { TextareaRenderable, ExtmarksController, SyntaxStyle, ColorInput } from "@opentui/core"
 
@@ -52,8 +46,7 @@ export const STYLE = {
   paste: "extmark.paste",
 } as const
 
-// One-shot registration of extmark styles on a shared SyntaxStyle.
-// Idempotent — resolveStyleId short-circuits after the first register.
+// Idempotent style registration on a shared SyntaxStyle.
 export function styles(syntax: SyntaxStyle, theme: { accent: ColorInput; primary: ColorInput; textMuted: ColorInput }) {
   const ensure = (name: string, def: { fg?: ColorInput; italic?: boolean }) => {
     const id = syntax.getStyleId(name)
@@ -69,11 +62,9 @@ export function styles(syntax: SyntaxStyle, theme: { accent: ColorInput; primary
 
 type StyleIds = { file: number; agent: number; paste: number }
 
-// Bridge between a TextareaRenderable (source of truth for text +
-// extmarks) and a parallel parts[] array. The map id→index keeps the
-// two in sync: when a mark is deleted (atomic-chip backspace) we drop
-// the matching part; when marks shift (text inserted before them) we
-// rewrite the part's source range before emitting/snapshotting.
+// Bridges a TextareaRenderable (source of truth) and a parallel parts[].
+// The id→index map drops parts whose mark was deleted and rewrites ranges
+// when marks shift.
 export class PartsBuffer {
   private ta: TextareaRenderable
   private ex: ExtmarksController
@@ -91,9 +82,7 @@ export class PartsBuffer {
 
   text() { return this.ta.plainText }
 
-  // The textarea may be destroyed mid-session (tab switch unmounting
-  // the composer, hot reload, etc.). Every op that reaches into
-  // opentui internals guards so the caller doesn't need to.
+  // The textarea can be destroyed mid-session (tab switch, hot reload).
   private alive() { return !this.ta.isDestroyed }
 
   insertText(str: string) {
@@ -101,11 +90,8 @@ export class PartsBuffer {
     this.ta.insertText(str)
   }
 
-  // Insert a part at the current cursor. Writes the virtual text into
-  // the buffer and binds a mark to its display range. Trailing space
-  // matches opencode and keeps the caret outside the chip so the next
-  // keystroke doesn't extend the range. Extmark offsets are display-
-  // width — visualCursor.offset, not cursorOffset.
+  // Trailing space keeps the caret outside the chip so the next keystroke
+  // doesn't extend the range. Offsets are visualCursor.offset, not cursorOffset.
   insertPart(part: Part, virtualText: string) {
     if (!this.alive()) return
     const start = this.ta.visualCursor.offset
@@ -123,9 +109,7 @@ export class PartsBuffer {
     this.map.set(id, idx)
   }
 
-  // Re-read mark ranges from the textarea and rebuild a compact
-  // parts[] reflecting only the marks that still exist. Any parts
-  // whose mark was deleted (atomic-chip backspace) drop out.
+  // Rebuild parts[] from the marks that still exist.
   sync() {
     if (!this.alive()) return
     const alive = this.ex.getAllForTypeId(this.typeId)
@@ -143,15 +127,11 @@ export class PartsBuffer {
     this.map = nextMap
   }
 
-  // Parts in display order. `sync()` first so callers always see the
-  // current mark ranges — callers don't need to remember to call it.
   parts(): readonly Part[] {
     this.sync()
     return this.list
   }
 
-  // Snapshot for history/rewind: stores the plain text + parts with
-  // their source ranges frozen. fromSnapshot() rebuilds both.
   toSnapshot(): PartsSnapshot {
     return { v: 1, input: this.text(), parts: [...this.parts()] }
   }
@@ -186,9 +166,8 @@ export class PartsBuffer {
     this.ex.clear()
   }
 
-  // Inline-expand text parts into their original value (paste body)
-  // and strip them from the parts[] — only file/agent parts ride as
-  // real message parts to the gateway. Matches opencode submit path.
+  // Inline text parts (paste bodies) back into the string; only file/agent
+  // parts ride to the gateway.
   expand(): { text: string; parts: Part[] } {
     if (!this.alive()) return { text: "", parts: [] }
     this.sync()
@@ -206,8 +185,7 @@ export class PartsBuffer {
 }
 
 function visualLen(s: string): number {
-  // Fallback for runtimes without Bun.stringWidth; matches opentui's
-  // assumption that ASCII chips are one column per char.
+
   const B = (globalThis as { Bun?: { stringWidth?: (s: string) => number } }).Bun
   return B?.stringWidth ? B.stringWidth(s) : s.length
 }

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -34,6 +34,7 @@ import * as preferences from "../context/preferences"
 import { redraw } from "./useAppKeys"
 import { quit } from "./exit"
 import { Stash } from "./stash"
+import { useBackground } from "./background"
 import { useHome, home } from "../home"
 import { TAB_SLASH } from "./tabs"
 import { transcriptToMessages, type Action, type TurnState } from "./turnReducer"
@@ -86,6 +87,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
   const cmd = useCommand()
   const renderer = useRenderer()
   const cfg = useHome("config")
+  const bg = useBackground()
 
   const ctx = useRef(c); ctx.current = c
   const gate = useRef(cfg); gate.current = cfg
@@ -353,9 +355,12 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
         case "background":
           if (!arg) { toast.show({ variant: "info", message: "usage: /background <prompt>" }); return }
           gw.request<{ task_id?: string }>("prompt.background", { text: arg })
-            .then(r => toast.show(r.task_id
-              ? { variant: "success", message: `background ${r.task_id} started` }
-              : { variant: "error", message: "background start failed" }))
+            .then(r => {
+              if (r.task_id) bg.register(r.task_id)
+              toast.show(r.task_id
+                ? { variant: "success", message: `background ${r.task_id} started` }
+                : { variant: "error", message: "background start failed" })
+            })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "voice":

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -77,6 +77,7 @@ export type SlashCtx = {
   rewind: (m: Message) => Promise<void>
   goTo: (tab: number, sub: number) => void
   attachClipboard: () => void
+  voiceToggle: (action: string, sid: string) => Promise<void>
 }
 
 export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void {
@@ -364,10 +365,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "voice":
-          gw.request<{ enabled?: boolean; tts?: boolean }>("voice.toggle",
-            { action: (arg || "status").toLowerCase() })
-            .then(r => x.dispatch({ kind: "system",
-              text: `voice ${r.enabled ? "on" : "off"}${r.tts ? " · tts on" : ""}` }))
+          x.voiceToggle((arg || "status").toLowerCase(), x.sid)
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "mouse": {

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -70,6 +70,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "splash", description: "Show the launch splash",              category: "Client",  aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "goal",   description: "Set/control the session goal",        category: "Session", aliases: [], argsHint: "[text|done|pause|resume|clear|status]", subcommands: ["done", "pause", "resume", "clear", "status"], source: "command", target: "gateway" },
   { name: "skin",   description: "Switch Hermes skin (+ theme + eikon)", category: "Client",  aliases: [], argsHint: "[name]", subcommands: [...SKINS], source: "local", target: "local" },
+  { name: "voice",  description: "Toggle voice recording",               category: "Client",  aliases: [], argsHint: "[on|off|status|tts]", subcommands: ["on", "off", "status", "tts"], source: "local", target: "local" },
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
 ]

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -21,6 +21,8 @@ import { Selection } from "../utils/selection"
 import { useKeys, conflicts } from "../keys"
 import { print as chordPrint } from "../keys/chord"
 import type { ComposerHandle } from "../components/chat/Composer"
+import { isVoiceToggleKey } from "../voice/platform"
+import type { VoiceKey } from "../voice/types"
 
 const INTERRUPT_MS = 5000
 export const DOUBLE_TAB_MS = 400
@@ -60,6 +62,12 @@ type Opts = {
   onNotice: (text: string) => void
   onToggleSidebar: () => void
   onStash: () => void
+  /** Voice recording key binding + handler from useVoice hook. */
+  voiceRecordKey?: VoiceKey
+  /** True when voice recording mode is on (/voice on). */
+  voiceEnabled?: boolean
+  /** Toggle push-to-talk recording (start or stop). */
+  onVoiceRecord?: () => void
 }
 
 export function useAppKeys(o: Opts) {
@@ -162,6 +170,14 @@ export function useAppKeys(o: Opts) {
     // handles Esc-to-close; tabs/composer/interrupt all sit behind the
     // overlay and shouldn't move.
     if (o.dialogOpen()) return
+
+    // Voice recording key — must win before prompt/editor/composer
+    // so the configured shortcut always fires push-to-talk.
+    if (o.voiceRecordKey && o.onVoiceRecord && isVoiceToggleKey(key, o.voiceRecordKey)) {
+      o.onVoiceRecord()
+      key.stopPropagation()
+      return
+    }
 
     // Shell mode: Esc exits (pre-empts the interrupt double-tap);
     // backspace at offset 0 also exits.

--- a/src/app/useInputHistory.ts
+++ b/src/app/useInputHistory.ts
@@ -1,39 +1,66 @@
 // Up/down history for composer input.
 // Persisted under the herm config dir (typically ~/.hermes/herm/history).
+//
+// On-disk format is JSONL of { input, parts? } entries. Legacy lines
+// that are raw strings (with `\n` encoded as NUL) are read as
+// { input: <decoded>, parts: [] } so existing histories keep working.
 
 import { useState, useRef, useCallback } from "react"
 import { join } from "path"
 import { existsSync, mkdirSync, readFileSync, appendFileSync, writeFileSync } from "fs"
 import { configDir } from "../utils/paths"
+import type { Part, PartsSnapshot } from "./parts"
 
 const MAX = 500
 
+export type HistEntry = { input: string; parts: readonly Part[] }
+
 const file = () => join(configDir(), "history")
+
+function parse(line: string): HistEntry {
+  if (line[0] === "{") {
+    const j = safe(line)
+    if (j && typeof j.input === "string") {
+      return { input: j.input, parts: Array.isArray(j.parts) ? j.parts : [] }
+    }
+  }
+  return { input: line.replace(/\0/g, "\n"), parts: [] }
+}
+
+function safe(s: string): { input?: unknown; parts?: unknown } | null {
+  try { return JSON.parse(s) } catch { return null }
+}
 
 // In-memory order is newest-first (index 0 = most recent); on-disk is
 // append-only newest-last, so load() reverses.
-function load() {
+function load(): HistEntry[] {
   const FILE = file()
   if (!existsSync(FILE)) return []
   return readFileSync(FILE, "utf-8").split("\n").filter(Boolean)
-    .map(l => l.replace(/\0/g, "\n")).slice(-MAX).reverse()
+    .map(parse).slice(-MAX).reverse()
 }
 
-function enc(s: string) { return s.replace(/\n/g, "\0") }
+function enc(e: HistEntry) {
+  if (e.parts.length === 0) return JSON.stringify({ input: e.input })
+  return JSON.stringify({ input: e.input, parts: e.parts })
+}
 
-export function useInputHistory(input: string, setInput: (v: string) => void) {
-  const hist = useRef<string[]>(null)
+export function useInputHistory(input: string, restore: (e: HistEntry) => void) {
+  const hist = useRef<HistEntry[]>(null)
   if (hist.current === null) hist.current = load()
   const [, bump] = useState(0)
   const idx = useRef(-1)
-  const stash = useRef("")
+  const stash = useRef<HistEntry>({ input: "", parts: [] })
 
-  const push = useCallback((msg: string) => {
+  const push = useCallback((entry: HistEntry | string) => {
     idx.current = -1
-    stash.current = ""
+    stash.current = { input: "", parts: [] }
+    const e: HistEntry = typeof entry === "string" ? { input: entry, parts: [] } : entry
+    if (!e.input && e.parts.length === 0) return
     const h = hist.current!
-    if (msg === h[0]) return
-    h.unshift(msg)
+    const top = h[0]
+    if (top && top.input === e.input && sameParts(top.parts, e.parts)) return
+    h.unshift(e)
     const DIR = configDir()
     const FILE = file()
     if (!existsSync(DIR)) mkdirSync(DIR, { recursive: true })
@@ -41,7 +68,7 @@ export function useInputHistory(input: string, setInput: (v: string) => void) {
       h.length = MAX
       writeFileSync(FILE, [...h].reverse().map(enc).join("\n") + "\n", "utf-8")
     } else {
-      appendFileSync(FILE, enc(msg) + "\n", "utf-8")
+      appendFileSync(FILE, enc(e) + "\n", "utf-8")
     }
     bump(n => n + 1)
   }, [])
@@ -49,18 +76,27 @@ export function useInputHistory(input: string, setInput: (v: string) => void) {
   const up = useCallback(() => {
     const h = hist.current!
     if (h.length === 0) return
-    if (idx.current === -1) stash.current = input
+    if (idx.current === -1) stash.current = { input, parts: [] }
     const next = Math.min(idx.current + 1, h.length - 1)
     idx.current = next
-    setInput(h[next])
-  }, [input, setInput])
+    restore(h[next])
+  }, [input, restore])
 
   const down = useCallback(() => {
     if (idx.current === -1) return
     const next = idx.current - 1
     idx.current = next
-    setInput(next === -1 ? stash.current : hist.current![next])
-  }, [setInput])
+    restore(next === -1 ? stash.current : hist.current![next])
+  }, [restore])
 
   return { push, up, down }
 }
+
+function sameParts(a: readonly Part[], b: readonly Part[]) {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i]?.type !== b[i]?.type) return false
+  return true
+}
+
+export type { PartsSnapshot }
+

--- a/src/app/useInputHistory.ts
+++ b/src/app/useInputHistory.ts
@@ -1,9 +1,6 @@
-// Up/down history for composer input.
-// Persisted under the herm config dir (typically ~/.hermes/herm/history).
-//
-// On-disk format is JSONL of { input, parts? } entries. Legacy lines
-// that are raw strings (with `\n` encoded as NUL) are read as
-// { input: <decoded>, parts: [] } so existing histories keep working.
+// Up/down history for composer input, persisted under the herm config dir.
+// On-disk format is JSONL of { input, parts? }. Legacy raw-string lines
+// (newlines NUL-encoded) still load.
 
 import { useState, useRef, useCallback } from "react"
 import { join } from "path"

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -70,11 +70,38 @@ export function useStream(c: Ctx) {
   // action flushes synchronously first so part ordering is preserved.
   const deltas = useRef({ text: "", think: "", timer: null as ReturnType<typeof setTimeout> | null })
 
+  // Process notification batching: status.update/kind=process events
+  // accumulate over a 500ms window and dispatch as one combined system
+  // message. Prevents TUI lag when many background processes finish
+  // in rapid succession (each one otherwise triggers a full React
+  // re-render of the Chat transcript).
+  const procs = useRef<{ texts: string[]; timer: ReturnType<typeof setTimeout> | null }>(
+    { texts: [], timer: null },
+  )
+
   const flush = useCallback(() => {
     const d = deltas.current
     if (d.timer) { clearTimeout(d.timer); d.timer = null }
     if (d.think) { ctx.current.dispatch({ kind: "thinking", text: d.think, final: false }); d.think = "" }
     if (d.text) { ctx.current.dispatch({ kind: "message.delta", chunk: d.text }); d.text = "" }
+  }, [])
+
+  // Flush accumulated process notifications as one combined system msg.
+  const flushProcs = useCallback(() => {
+    const n = procs.current
+    if (n.timer) { clearTimeout(n.timer); n.timer = null }
+    if (!n.texts.length) return
+    const batch = n.texts.splice(0)
+    const lines = batch.map(t => {
+      const m = t.match(/Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+)/)
+      return m ? `  ${m[1]} (exit ${m[2]}) · ${m[3]}` : `  ${t.replace(/^\[IMPORTANT: |\]$/g, "").slice(0, 100)}`
+    })
+    ctx.current.dispatch({
+      kind: "system",
+      text: batch.length === 1
+        ? `◆ background ${lines[0].trim()}`
+        : `◆ ${batch.length} background processes completed\n${lines.join("\n")}`,
+    })
   }, [])
 
   const handle = useCallback((ev: GatewayEvent) => {
@@ -140,6 +167,12 @@ export function useStream(c: Ctx) {
         })
       },
       onStatus: (text) => x.setStatus(text),
+      onProcessNotification: (text) => {
+        const n = procs.current
+        n.texts.push(text)
+        if (n.timer) clearTimeout(n.timer)
+        n.timer = setTimeout(flushProcs, 500)
+      },
       onSkin: (s) => x.setSkin(deriveSkin(s)),
     })
     if (!action) return

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -10,7 +10,7 @@ import { useGateway, useGatewayEvent } from "../context/gateway"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 import { openAlert } from "../dialogs/alert"
-import { mapEvent } from "../context/events"
+import { formatProcessNotification, mapEvent } from "../context/events"
 import { deriveSkin, type SkinState } from "../context/skin"
 import { useBackground } from "./background"
 import type { Action } from "./turnReducer"
@@ -92,15 +92,12 @@ export function useStream(c: Ctx) {
     if (n.timer) { clearTimeout(n.timer); n.timer = null }
     if (!n.texts.length) return
     const batch = n.texts.splice(0)
-    const lines = batch.map(t => {
-      const m = t.match(/Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+)/)
-      return m ? `  ${m[1]} (exit ${m[2]}) · ${m[3]}` : `  ${t.replace(/^\[IMPORTANT: |\]$/g, "").slice(0, 100)}`
-    })
+    const lines = batch.map(t => `  ${formatProcessNotification(t)}`)
     ctx.current.dispatch({
       kind: "system",
       text: batch.length === 1
         ? `◆ background ${lines[0].trim()}`
-        : `◆ ${batch.length} background processes completed\n${lines.join("\n")}`,
+        : `◆ ${batch.length} background notifications\n${lines.join("\n")}`,
     })
   }, [])
 

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -12,6 +12,7 @@ import { useToast } from "../ui/toast"
 import { openAlert } from "../dialogs/alert"
 import { mapEvent } from "../context/events"
 import { deriveSkin, type SkinState } from "../context/skin"
+import { useBackground } from "./background"
 import type { Action } from "./turnReducer"
 import type { useSession } from "./useSession"
 import type { GatewayEvent, SessionInfo } from "../context/wire"
@@ -50,6 +51,7 @@ export function useStream(c: Ctx) {
   const gw = useGateway()
   const dialog = useDialog()
   const toast = useToast()
+  const bg = useBackground()
   const ctx = useRef(c); ctx.current = c
 
   // Client-side interrupt latch: flipped on Esc×2 before the gateway
@@ -120,6 +122,7 @@ export function useStream(c: Ctx) {
         x.goalHook.check(x.sidRef.current)
       },
       onBackground: (tid, text) => {
+        bg.unregister(tid)
         const head = text.split("\n")[0].slice(0, 80)
         x.dispatch({ kind: "system", text: `◷ background task ${tid} complete — ${head}` })
         toast.show({

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -90,8 +90,6 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const bg = useBackground()
   const ta = useRef<TextareaRenderable | null>(null)
   const buf = useRef<PartsBuffer | null>(null)
-  // Style ids are registered once per SyntaxStyle; memoized so theme
-  // swaps (which build a new SyntaxStyle) re-register automatically.
   const sids = useMemo(() => partStyles(syntaxStyle, theme), [syntaxStyle, theme])
   // Mirror of the textarea buffer. The renderable is the source of truth;
   // this drives React-side derivations (popover matching, row count, hints).
@@ -123,8 +121,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     setInput(v)
   }, [])
 
-  // History restore. Plain strings round-trip through setText; entries
-  // with parts go through the snapshot path so chips + ranges rebuild.
+  // Entries with parts restore via snapshot so chips + ranges rebuild.
   const restore = useCallback((e: HistEntry) => {
     if (e.parts.length === 0) { write(e.input); return }
     buf.current?.fromSnapshot({ v: 1, input: e.input, parts: [...e.parts] })
@@ -163,11 +160,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     live.current.props.onSlash(c)
   }
 
-  // Accept an @-ref from the popover. Complete refs (`@file:path`,
-  // `@diff`, `@git:3`, `@url:…`) land as styled chips — one keystroke
-  // deletes them whole. Prefix keywords that keep the popover open
-  // (`@file:`, `@folder:`, `@url:`) take the classic string-write
-  // path since there's nothing yet to anchor a mark to.
+  // Complete @-refs land as styled chips; prefix keywords that keep the
+  // popover open have nothing to anchor a mark to and stay plain text.
   const atAccept = (idx?: number) => {
     const off = ta.current?.cursorOffset
     const src = live.current.input
@@ -182,11 +176,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (next !== null) write(next)
       return
     }
-    // Complete ref → chip. Splice the `@word` out via deleteRange
-    // (surgical — preserves existing extmarks; setText would wipe
-    // every prior chip's mark), then let PartsBuffer.insertPart drop
-    // a mark-backed virtual run. Match at.accept()'s frecency bump
-    // for path-like items so ranking still reflects acceptance.
+    // Splice the @word out via deleteRange — setText would wipe every
+    // prior chip's mark.
     if (it.text.includes(":")) frecency.bump(it.text)
     const eb = ta.current.editBuffer
     const s = eb.offsetToPosition(a.start)
@@ -265,10 +256,6 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (c) select(c)
       return
     }
-    // Expand captures the current buffer + parts, inline-expands any
-    // text parts (pasted content) so the wire still sees plain text,
-    // and filters them out of the emitted parts[] — matches opencode
-    // submit semantics.
     const exp = buf.current?.expand() ?? { text: live.current.input, parts: [] }
     if (modeRef.current === "shell") {
       const cmd = exp.text.trim()
@@ -356,10 +343,9 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     },
   }), [hist.up, hist.down, pop.setCursor, write])
 
-  // Stable ref callback so re-renders don't cycle (r → null → r) and
-  // throw away the PartsBuffer's extmark→part map mid-edit. sids is a
-  // ref-via-closure rather than a dep so theme swaps rebuild the buffer
-  // through the unmount path instead of on every render.
+  // Stable ref callback so re-renders don't cycle r → null → r and drop
+  // the PartsBuffer mid-edit; sids via closure so theme swaps rebuild
+  // through the unmount path.
   const sidsRef = useRef(sids); sidsRef.current = sids
   const taRef = useCallback((r: TextareaRenderable | null) => {
     ta.current = r

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -182,13 +182,17 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (next !== null) write(next)
       return
     }
-    // Complete ref → chip. Splice the `@word` out, position the caret,
-    // then let PartsBuffer.insertPart drop a mark-backed virtual run.
-    // Match at.accept()'s frecency bump for path-like items so ranking
-    // still reflects acceptance.
+    // Complete ref → chip. Splice the `@word` out via deleteRange
+    // (surgical — preserves existing extmarks; setText would wipe
+    // every prior chip's mark), then let PartsBuffer.insertPart drop
+    // a mark-backed virtual run. Match at.accept()'s frecency bump
+    // for path-like items so ranking still reflects acceptance.
     if (it.text.includes(":")) frecency.bump(it.text)
-    const trimmed = src.slice(0, a.start) + src.slice(a.start + a.word.length)
-    ta.current.setText(trimmed)
+    const eb = ta.current.editBuffer
+    const s = eb.offsetToPosition(a.start)
+    const e = eb.offsetToPosition(a.start + a.word.length)
+    if (!s || !e) return
+    ta.current.deleteRange(s.row, s.col, e.row, e.col)
     ta.current.cursorOffset = a.start
     const part: FilePart = {
       type: "file",

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -12,9 +12,11 @@ import type { ImageAttachResponse, DropDetectResponse } from "../../context/wire
 import { looksLikePath } from "../../utils/drop"
 import type { SlashCommand } from "../../app/slashCommands"
 import { useSlashPopover } from "../../app/useSlashPopover"
-import { useAtRefPopover } from "../../app/useAtRefPopover"
-import { useInputHistory } from "../../app/useInputHistory"
+import { useAtRefPopover, atWordAt } from "../../app/useAtRefPopover"
+import { frecency } from "../../app/frecency"
+import { useInputHistory, type HistEntry } from "../../app/useInputHistory"
 import { useBackground } from "../../app/background"
+import { PartsBuffer, styles as partStyles, type Part, type FilePart } from "../../app/parts"
 import { SlashPopover } from "./SlashPopover"
 import { AtRefPopover } from "./AtRefPopover"
 import { ChafaImage } from "../../ui/ChafaImage"
@@ -56,7 +58,7 @@ type Props = {
   queue?: ReadonlyArray<string>
   attachments?: ReadonlyArray<ImageAttachResponse>
   cmds: ReadonlyArray<SlashCommand>
-  onSend: (text: string) => void
+  onSend: (text: string, parts?: readonly Part[]) => void
   onSlash: (cmd: SlashCommand) => void
   /** Shell-mode submit (`!` at cursor 0). Not a prompt turn — routed
    *  to shell.exec and rendered as a transcript $ cmd / stdout pair. */
@@ -82,10 +84,15 @@ function fmt(n: number): string {
 
 export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const theme = useTheme().theme
+  const syntaxStyle = useTheme().syntaxStyle
   const gw = useGateway()
   const keys = useKeys()
   const bg = useBackground()
   const ta = useRef<TextareaRenderable | null>(null)
+  const buf = useRef<PartsBuffer | null>(null)
+  // Style ids are registered once per SyntaxStyle; memoized so theme
+  // swaps (which build a new SyntaxStyle) re-register automatically.
+  const sids = useMemo(() => partStyles(syntaxStyle, theme), [syntaxStyle, theme])
   // Mirror of the textarea buffer. The renderable is the source of truth;
   // this drives React-side derivations (popover matching, row count, hints).
   const [input, setInput] = useState("")
@@ -109,12 +116,22 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const at = useAtRefPopover(mode === "normal" ? input : "", caret)
 
   const write = useCallback((v: string) => {
-    ta.current?.setText(v)
+    // clear() wipes text + extmarks via setText(""); replay v after.
+    buf.current?.clear()
+    if (v) ta.current?.setText(v)
     ta.current?.gotoBufferEnd()
     setInput(v)
   }, [])
 
-  const hist = useInputHistory(input, write)
+  // History restore. Plain strings round-trip through setText; entries
+  // with parts go through the snapshot path so chips + ranges rebuild.
+  const restore = useCallback((e: HistEntry) => {
+    if (e.parts.length === 0) { write(e.input); return }
+    buf.current?.fromSnapshot({ v: 1, input: e.input, parts: [...e.parts] })
+    setInput(e.input)
+  }, [write])
+
+  const hist = useInputHistory(input, restore)
 
   // Merged over the renderable's default map (which has bare return →
   // newline), so input.submit's `return` entry overrides it and the
@@ -146,10 +163,41 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     live.current.props.onSlash(c)
   }
 
+  // Accept an @-ref from the popover. Complete refs (`@file:path`,
+  // `@diff`, `@git:3`, `@url:…`) land as styled chips — one keystroke
+  // deletes them whole. Prefix keywords that keep the popover open
+  // (`@file:`, `@folder:`, `@url:`) take the classic string-write
+  // path since there's nothing yet to anchor a mark to.
   const atAccept = (idx?: number) => {
     const off = ta.current?.cursorOffset
-    const next = live.current.at.accept(live.current.input, idx, off)
-    if (next !== null) write(next)
+    const src = live.current.input
+    const which = idx ?? live.current.at.cursor
+    const it = live.current.at.items[which]
+    if (!it) return
+    const a = atWordAt(src, off)
+    const trail = it.text.endsWith(":") || it.text.endsWith("/")
+    const b = buf.current
+    if (trail || !b || !ta.current || !a) {
+      const next = live.current.at.accept(src, idx, off)
+      if (next !== null) write(next)
+      return
+    }
+    // Complete ref → chip. Splice the `@word` out, position the caret,
+    // then let PartsBuffer.insertPart drop a mark-backed virtual run.
+    // Match at.accept()'s frecency bump for path-like items so ranking
+    // still reflects acceptance.
+    if (it.text.includes(":")) frecency.bump(it.text)
+    const trimmed = src.slice(0, a.start) + src.slice(a.start + a.word.length)
+    ta.current.setText(trimmed)
+    ta.current.cursorOffset = a.start
+    const part: FilePart = {
+      type: "file",
+      mime: "text/uri-list",
+      filename: it.text,
+      source: { type: "file", path: it.text, text: { start: a.start, end: a.start + it.text.length, value: it.text } },
+    }
+    b.insertPart(part, it.text)
+    setInput(ta.current.plainText)
   }
 
   // Paste routing, in priority order:
@@ -213,34 +261,39 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       if (c) select(c)
       return
     }
+    // Expand captures the current buffer + parts, inline-expands any
+    // text parts (pasted content) so the wire still sees plain text,
+    // and filters them out of the emitted parts[] — matches opencode
+    // submit semantics.
+    const exp = buf.current?.expand() ?? { text: live.current.input, parts: [] }
     if (modeRef.current === "shell") {
-      const text = live.current.input.trim()
-      if (!text) return
-      hist.push(text)
+      const cmd = exp.text.trim()
+      if (!cmd) return
+      hist.push({ input: cmd, parts: exp.parts })
       write("")
       setMode("normal")
-      live.current.props.onShell?.(text)
+      live.current.props.onShell?.(cmd)
       return
     }
-    const text = live.current.input.trim()
+    const text = exp.text.trim()
     if (live.current.props.streaming) {
       if (!text || !live.current.props.ready) return
-      hist.push(text)
+      hist.push({ input: text, parts: exp.parts })
       write("")
       // Slash-shaped input routes through onSend so send() → slash()
       // can apply per-command streaming policy (local cases fire now,
       // gateway-target cases self-queue). Only plain text hits the
       // app-side busy-mode branch.
-      if (text.startsWith("/")) return void live.current.props.onSend(text)
+      if (text.startsWith("/")) return void live.current.props.onSend(text, exp.parts)
       live.current.props.onEnqueue?.(text)
       return
     }
     const hasAtt = (live.current.props.attachments?.length ?? 0) > 0
     if (!text && !hasAtt) { live.current.props.onEmptyEnter?.(); return }
     if (!live.current.props.ready) return
-    if (text) hist.push(text)
+    if (text) hist.push({ input: text, parts: exp.parts })
     write("")
-    live.current.props.onSend(text)
+    live.current.props.onSend(text, exp.parts)
   }
 
   useImperativeHandle(ref, () => ({
@@ -382,7 +435,12 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         <box width={1}><text fg={theme.primary}>{mode === "shell" ? "$" : ">"}</text></box>
         <box width={1} />
         <textarea
-          ref={ta}
+          ref={(r) => {
+            ta.current = r
+            if (r && !buf.current) buf.current = new PartsBuffer(r, sids)
+            if (!r) buf.current = null
+          }}
+          syntaxStyle={syntaxStyle}
           onContentChange={() => {
             const t = ta.current
             setInput(t?.plainText ?? "")

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -352,6 +352,17 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     },
   }), [hist.up, hist.down, pop.setCursor, write])
 
+  // Stable ref callback so re-renders don't cycle (r → null → r) and
+  // throw away the PartsBuffer's extmark→part map mid-edit. sids is a
+  // ref-via-closure rather than a dep so theme swaps rebuild the buffer
+  // through the unmount path instead of on every render.
+  const sidsRef = useRef(sids); sidsRef.current = sids
+  const taRef = useCallback((r: TextareaRenderable | null) => {
+    ta.current = r
+    if (r && !buf.current) buf.current = new PartsBuffer(r, sidsRef.current)
+    if (!r) buf.current = null
+  }, [])
+
   const label = !props.ready ? "Connecting..."
     : props.streaming ? (props.status || "Generating...")
     : "Ready"
@@ -435,11 +446,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         <box width={1}><text fg={theme.primary}>{mode === "shell" ? "$" : ">"}</text></box>
         <box width={1} />
         <textarea
-          ref={(r) => {
-            ta.current = r
-            if (r && !buf.current) buf.current = new PartsBuffer(r, sids)
-            if (!r) buf.current = null
-          }}
+          ref={taRef}
           syntaxStyle={syntaxStyle}
           onContentChange={() => {
             const t = ta.current

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -14,6 +14,7 @@ import type { SlashCommand } from "../../app/slashCommands"
 import { useSlashPopover } from "../../app/useSlashPopover"
 import { useAtRefPopover } from "../../app/useAtRefPopover"
 import { useInputHistory } from "../../app/useInputHistory"
+import { useBackground } from "../../app/background"
 import { SlashPopover } from "./SlashPopover"
 import { AtRefPopover } from "./AtRefPopover"
 import { ChafaImage } from "../../ui/ChafaImage"
@@ -83,6 +84,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const theme = useTheme().theme
   const gw = useGateway()
   const keys = useKeys()
+  const bg = useBackground()
   const ta = useRef<TextareaRenderable | null>(null)
   // Mirror of the textarea buffer. The renderable is the source of truth;
   // this drives React-side derivations (popover matching, row count, hints).
@@ -433,6 +435,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         {props.streaming && (props.queue?.length ?? 0) > 0 ? (
           <text fg={theme.textMuted}>{keys.print("queue.flush")} to send queued now  </text>
         ) : null}
+        {bg.count > 0 ? <text fg={theme.text}>▶ {bg.count}  </text> : null}
         {props.model ? <text fg={theme.textMuted}>{props.model}</text> : null}
       </box>
     </box>

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -19,6 +19,8 @@ export type Side = {
   onVoiceStatus?: (state: string) => void
   /** voice.transcript event — transcribed text from a completed voice capture. */
   onVoiceTranscript?: (text: string, noSpeechLimit: boolean) => void
+  /** status.update with kind=process — debounced client-side to prevent TUI lag. */
+  onProcessNotification?: (text: string) => void
 }
 
 function count(o: Record<string, string[]> | undefined): number {
@@ -200,17 +202,15 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       // Generic "status" is cosmetic; lifecycle/error/warn carry real
       // signal (retries, fallbacks, auth failures) and must persist.
       if (!kind || kind === "status") return null
-      // process: the same [IMPORTANT:...] text is replayed as a synthesized
-      // user turn immediately after, so render a one-line herald, not a dump.
+      // process: route through debounced accumulator instead of dispatching
+      // directly — prevents TUI lag when many terminal(background=true)
+      // processes finish in rapid succession.
       if (kind === "process") {
-        const m = text.match(/Background process (\S+) (?:completed \(exit code (\S+)\)|matched watch pattern "([^"]+)")\.\nCommand: (.+)/)
-        if (m) return { kind: "system", text: m[2] !== undefined
-          ? `◆ background ${m[1]} exited ${m[2]} · ${m[4]}`
-          : `◆ background ${m[1]} matched "${m[3]}" · ${m[4]}` }
+        side.onProcessNotification?.(text)
+        return null
       }
       return { kind: "system", text }
     }
-
     case "voice.status": {
       // Continuous VAD loop reports its internal state: listening,
       // transcribing, or idle. The UI uses this for the recording indicator.

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -27,6 +27,15 @@ function count(o: Record<string, string[]> | undefined): number {
   return o ? Object.values(o).reduce((n, v) => n + v.length, 0) : 0
 }
 
+export function formatProcessNotification(text: string): string {
+  const body = text.replace(/^\[IMPORTANT: /, "").replace(/\]$/, "")
+  const done = body.match(/^Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+?)(?:\n|$)/)
+  if (done) return `${done[1]} exited ${done[2]} · ${done[3]}`
+  const hit = body.match(/^Background process (\S+) matched watch pattern "([^"]+)"\.\nCommand: (.+?)(?:\n|$)/)
+  if (hit) return `${hit[1]} matched "${hit[2]}" · ${hit[3]}`
+  return body.slice(0, 100)
+}
+
 export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
   switch (ev.type) {
     case "gateway.ready":

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -15,6 +15,10 @@ export type Side = {
   onBtw?: (text: string) => void
   onStatus?: (text: string) => void
   onSkin?: (skin: GatewaySkin | null | undefined) => void
+  /** voice.status event — gateway VAD loop state change (listening/transcribing/idle). */
+  onVoiceStatus?: (state: string) => void
+  /** voice.transcript event — transcribed text from a completed voice capture. */
+  onVoiceTranscript?: (text: string, noSpeechLimit: boolean) => void
 }
 
 function count(o: Record<string, string[]> | undefined): number {
@@ -205,6 +209,29 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
           : `◆ background ${m[1]} matched "${m[3]}" · ${m[4]}` }
       }
       return { kind: "system", text }
+    }
+
+    case "voice.status": {
+      // Continuous VAD loop reports its internal state: listening,
+      // transcribing, or idle. The UI uses this for the recording indicator.
+      const state = String(ev.payload?.state ?? "")
+      side.onVoiceStatus?.(state)
+      return null
+    }
+
+    case "voice.transcript": {
+      // Transcribed text from a completed voice capture.
+      // no_speech_limit=true when 3 consecutive silent captures occurred
+      // — in that case voice mode auto-disables (CLI parity).
+      const noSpeechLimit = ev.payload?.no_speech_limit === true
+      if (noSpeechLimit) {
+        side.onVoiceTranscript?.("", true)
+        return null
+      }
+      const text = String(ev.payload?.text ?? "").trim()
+      if (!text) return null
+      side.onVoiceTranscript?.(text, false)
+      return null
     }
   }
   return null

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -28,6 +28,8 @@ export type GatewayEvent =
   | { type: "review.summary"; payload?: { text?: string } }
   | { type: "btw.complete"; payload: { text: string } }
   | { type: "browser.progress"; payload?: { message?: string; level?: "info" | "error" } }
+  | { type: "voice.status"; payload?: { state?: "idle" | "listening" | "transcribing" } }
+  | { type: "voice.transcript"; payload?: { text?: string; no_speech_limit?: boolean } }
   | { type: "subagent.start"; payload: SubagentPayload }
   | { type: "subagent.thinking"; payload: SubagentPayload }
   | { type: "subagent.tool"; payload: SubagentPayload }

--- a/src/utils/open-file.ts
+++ b/src/utils/open-file.ts
@@ -1,19 +1,6 @@
-/**
- * open-file.ts — Open files and URLs using the OS default handler.
- *
- * Two entry points:
- * - openFile(path): local file paths, via the `open` npm package.
- * - openUrl(raw):   external URLs, http(s)-only, spawned with no shell.
- *
- * Fire-and-forget; neither blocks the TUI.
- *
- * URL safety: a hostile model can emit `<Link url="file:///etc/passwd">` or
- * `javascript:…` and trick a click into running a local handler with
- * attacker-controlled input. openUrl parses via `new URL()` and rejects
- * anything whose protocol is not http(s), then spawns the platform opener
- * with an argv array so shell metacharacters in the URL cannot be
- * interpreted as commands.
- */
+// Open files and URLs in the OS default handler. Fire-and-forget.
+// openFile: local paths via the `open` package. openUrl: http(s) only,
+// spawned with an argv array so shell metacharacters in the URL are inert.
 
 import { spawn, type SpawnOptions } from "node:child_process"
 import { platform } from "node:os"
@@ -28,14 +15,7 @@ export type Deps = {
   platform?: () => string
 }
 
-/**
- * Open an external URL in the OS default browser. Returns true if a spawn
- * was attempted, false if the URL was rejected, no opener is known for the
- * platform, or spawn threw synchronously. Async failures after spawn (the
- * binary couldn't exec) still return true — the no-op `'error'` listener
- * absorbs the event so the TUI doesn't crash; user just doesn't see the
- * browser pop.
- */
+/** Returns false if the URL was rejected, no opener is known, or spawn threw. */
 export function openUrl(raw: string, deps: Deps = {}): boolean {
   const url = parseSafeUrl(raw)
   if (!url) return false
@@ -45,14 +25,12 @@ export function openUrl(raw: string, deps: Deps = {}): boolean {
   const cmd = openCommand(id)
   if (!cmd) return false
 
-  // spawn can throw synchronously on argv-validation failures (e.g. NUL
-  // in the path). Treat it as a no-op rather than crashing the TUI.
+  // spawn throws synchronously on argv-validation failures (NUL bytes).
   let child
   try {
     child = spawnFn(cmd.command, [...cmd.args, url.toString()], {
-      // Detach so closing the TUI later doesn't kill the browser, and
-      // ignore stdio so we don't leak FDs into the raw-mode terminal
-      // (Chrome's stderr otherwise lands in the alt screen).
+      // detached: closing the TUI shouldn't kill the browser.
+      // stdio ignore: Chrome's stderr otherwise lands in the alt screen.
       detached: true,
       stdio: "ignore",
     } satisfies SpawnOptions)
@@ -60,11 +38,7 @@ export function openUrl(raw: string, deps: Deps = {}): boolean {
     return false
   }
 
-  // spawn returns a ChildProcess synchronously even when the binary is
-  // missing (ENOENT on xdg-open / explorer.exe) — the failure surfaces
-  // later as an 'error' event. Without a handler, an unhandled 'error'
-  // on an EventEmitter crashes Node and tears down the TUI. Attach the
-  // no-op listener BEFORE unref() so the event has a consumer.
+  // ENOENT surfaces as an async 'error' event; unhandled it crashes Node.
   child.once("error", () => {})
   child.unref()
 
@@ -81,12 +55,10 @@ export function parseSafeUrl(value: string): null | URL {
     return null
   }
 
-  // http(s) only. file:, data:, javascript:, vbscript:, etc. would let
-  // a malicious model invoke a local handler on a single click.
+  // file:, data:, javascript: etc. would invoke a local handler on click.
   if (url.protocol !== "http:" && url.protocol !== "https:") return null
 
-  // Some Node versions accept URLs like 'http:///foo'. Defensively
-  // reject empty or all-whitespace hostnames.
+  // Some Node versions accept 'http:///foo'.
   if (!url.hostname.trim()) return null
 
   return url
@@ -94,17 +66,8 @@ export function parseSafeUrl(value: string): null | URL {
 
 type OpenCommand = { command: string; args: readonly string[] }
 
-/**
- * Per-platform opener. We deliberately avoid `cmd.exe /c start` on
- * win32 — `start` is a cmd builtin, the URL is reparsed by cmd's
- * tokenizer, and `&`, `|`, `^`, `<`, `>` either break the command or
- * get interpreted as more commands. `explorer.exe <url>` invokes the
- * registered http(s) handler without going through cmd.
- *
- * Returns null for platforms where we don't know a safe opener
- * (aix, sunos, cygwin, haiku, …). The caller then honestly surfaces
- * "no opener" instead of optimistically trying xdg-open.
- */
+// win32 uses explorer.exe, not `cmd /c start` — cmd's tokenizer reparses
+// the URL and & | ^ < > become command syntax. Unknown platforms get null.
 export function openCommand(id: string): OpenCommand | null {
   if (id === "darwin") return { command: "open", args: [] }
   if (id === "win32") return { command: "explorer.exe", args: [] }

--- a/src/utils/open-file.ts
+++ b/src/utils/open-file.ts
@@ -1,13 +1,116 @@
 /**
  * open-file.ts — Open files and URLs using the OS default handler.
  *
- * Uses the `open` package (cross-platform: xdg-open on Linux, open on macOS, start on Windows).
- * Fire-and-forget — does not block the TUI.
+ * Two entry points:
+ * - openFile(path): local file paths, via the `open` npm package.
+ * - openUrl(raw):   external URLs, http(s)-only, spawned with no shell.
+ *
+ * Fire-and-forget; neither blocks the TUI.
+ *
+ * URL safety: a hostile model can emit `<Link url="file:///etc/passwd">` or
+ * `javascript:…` and trick a click into running a local handler with
+ * attacker-controlled input. openUrl parses via `new URL()` and rejects
+ * anything whose protocol is not http(s), then spawns the platform opener
+ * with an argv array so shell metacharacters in the URL cannot be
+ * interpreted as commands.
  */
 
-import open from "open";
+import { spawn, type SpawnOptions } from "node:child_process"
+import { platform } from "node:os"
+import open from "open"
 
-/** Open a file in the OS default handler for its type */
 export function openFile(path: string): void {
-  open(path).catch(() => {});
+  open(path).catch(() => {})
+}
+
+export type Deps = {
+  spawn?: typeof spawn
+  platform?: () => string
+}
+
+/**
+ * Open an external URL in the OS default browser. Returns true if a spawn
+ * was attempted, false if the URL was rejected, no opener is known for the
+ * platform, or spawn threw synchronously. Async failures after spawn (the
+ * binary couldn't exec) still return true — the no-op `'error'` listener
+ * absorbs the event so the TUI doesn't crash; user just doesn't see the
+ * browser pop.
+ */
+export function openUrl(raw: string, deps: Deps = {}): boolean {
+  const url = parseSafeUrl(raw)
+  if (!url) return false
+
+  const spawnFn = deps.spawn ?? spawn
+  const id = deps.platform?.() ?? platform()
+  const cmd = openCommand(id)
+  if (!cmd) return false
+
+  // spawn can throw synchronously on argv-validation failures (e.g. NUL
+  // in the path). Treat it as a no-op rather than crashing the TUI.
+  let child
+  try {
+    child = spawnFn(cmd.command, [...cmd.args, url.toString()], {
+      // Detach so closing the TUI later doesn't kill the browser, and
+      // ignore stdio so we don't leak FDs into the raw-mode terminal
+      // (Chrome's stderr otherwise lands in the alt screen).
+      detached: true,
+      stdio: "ignore",
+    } satisfies SpawnOptions)
+  } catch {
+    return false
+  }
+
+  // spawn returns a ChildProcess synchronously even when the binary is
+  // missing (ENOENT on xdg-open / explorer.exe) — the failure surfaces
+  // later as an 'error' event. Without a handler, an unhandled 'error'
+  // on an EventEmitter crashes Node and tears down the TUI. Attach the
+  // no-op listener BEFORE unref() so the event has a consumer.
+  child.once("error", () => {})
+  child.unref()
+
+  return true
+}
+
+export function parseSafeUrl(value: string): null | URL {
+  if (!value || typeof value !== "string") return null
+
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return null
+  }
+
+  // http(s) only. file:, data:, javascript:, vbscript:, etc. would let
+  // a malicious model invoke a local handler on a single click.
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null
+
+  // Some Node versions accept URLs like 'http:///foo'. Defensively
+  // reject empty or all-whitespace hostnames.
+  if (!url.hostname.trim()) return null
+
+  return url
+}
+
+type OpenCommand = { command: string; args: readonly string[] }
+
+/**
+ * Per-platform opener. We deliberately avoid `cmd.exe /c start` on
+ * win32 — `start` is a cmd builtin, the URL is reparsed by cmd's
+ * tokenizer, and `&`, `|`, `^`, `<`, `>` either break the command or
+ * get interpreted as more commands. `explorer.exe <url>` invokes the
+ * registered http(s) handler without going through cmd.
+ *
+ * Returns null for platforms where we don't know a safe opener
+ * (aix, sunos, cygwin, haiku, …). The caller then honestly surfaces
+ * "no opener" instead of optimistically trying xdg-open.
+ */
+export function openCommand(id: string): OpenCommand | null {
+  if (id === "darwin") return { command: "open", args: [] }
+  if (id === "win32") return { command: "explorer.exe", args: [] }
+
+  const xdg = new Set(["linux", "freebsd", "openbsd", "netbsd", "dragonfly"])
+  if (xdg.has(id)) return { command: "xdg-open", args: [] }
+
+  return null
 }

--- a/src/voice/Indicator.tsx
+++ b/src/voice/Indicator.tsx
@@ -1,0 +1,32 @@
+// Voice recording indicator — renders in the composer bar while recording/processing.
+
+import { useTheme } from "../theme"
+import type { VoiceState } from "./types"
+import { formatVoiceRecordKey } from "./platform"
+
+type Props = { voice: VoiceState; keyLabel: string }
+
+/** Status line shown in the composer area during voice activity. */
+export function VoiceIndicator({ voice, keyLabel }: Props) {
+  const theme = useTheme().theme
+  if (!voice.enabled && !voice.recording && !voice.processing) return null
+
+  let text: string
+  let fg = theme.text
+  if (voice.recording) {
+    text = "● recording"
+    fg = theme.error
+  } else if (voice.processing) {
+    text = "◌ transcribing"
+    fg = theme.warning
+  } else {
+    text = `voice ready [${keyLabel}]`
+    fg = theme.textMuted
+  }
+
+  return (
+    <text>
+      <span fg={fg}>{text}  </span>
+    </text>
+  )
+}

--- a/src/voice/platform.ts
+++ b/src/voice/platform.ts
@@ -1,0 +1,60 @@
+// Parse and match voice record keys from `voice.record_key` config.
+// Simplified from upstream hermes-ink's platform.ts for OpenTUI.
+
+import type { VoiceKey, VoiceMod } from "./types"
+import type { ParsedKey } from "@opentui/core"
+
+/** Documented default: Ctrl+B. */
+export const DEFAULT_VOICE_KEY: VoiceKey = {
+  mod: "ctrl",
+  ch: "b",
+  raw: "ctrl+b",
+}
+
+const MOD_ALIASES: Record<string, VoiceMod> = {
+  alt: "alt",
+  ctrl: "ctrl",
+  control: "ctrl",
+  option: "alt",
+  opt: "alt",
+}
+
+/** Parse `voice.record_key` config string into a VoiceKey.
+ *  Falls back to Ctrl+B on malformed / empty / unparseable input. */
+export function parseVoiceRecordKey(raw: unknown): VoiceKey {
+  if (typeof raw !== "string" || !raw.trim()) return DEFAULT_VOICE_KEY
+  const lower = raw.trim().toLowerCase()
+  const parts = lower.split("+").map(p => p.trim()).filter(Boolean)
+  if (parts.length < 2) return DEFAULT_VOICE_KEY
+  if (parts.length > 2) return DEFAULT_VOICE_KEY // no multi-modifier
+  const [modRaw, chRaw] = parts
+  const mod = MOD_ALIASES[modRaw]
+  if (!mod) return DEFAULT_VOICE_KEY
+  if (chRaw.length !== 1) return DEFAULT_VOICE_KEY // single char only
+  // Block reserved ctrl chords (interrupt / quit / clear).
+  if (mod === "ctrl" && (chRaw === "c" || chRaw === "d" || chRaw === "l"))
+    return DEFAULT_VOICE_KEY
+  return { mod, ch: chRaw, raw: lower }
+}
+
+/** Render a parsed key as "Ctrl+B" / "Alt+R" for display. */
+export function formatVoiceRecordKey(v: VoiceKey): string {
+  const mod = v.mod[0].toUpperCase() + v.mod.slice(1)
+  return `${mod}+${v.ch.toUpperCase()}`
+}
+
+/** Match an OpenTUI ParsedKey against a parsed voice record key.
+ *  In OpenTUI: `meta` = Alt/Option, `super` = Cmd/Win, `ctrl` = Ctrl. */
+export function isVoiceToggleKey(
+  key: ParsedKey,
+  configured: VoiceKey = DEFAULT_VOICE_KEY,
+): boolean {
+  if (key.name.toLowerCase() !== configured.ch) return false
+  if (key.shift) return false // no shift-modified chords
+  switch (configured.mod) {
+    case "ctrl":
+      return key.ctrl && !key.meta && !key.super
+    case "alt":
+      return key.meta && !key.ctrl && !key.super
+  }
+}

--- a/src/voice/types.ts
+++ b/src/voice/types.ts
@@ -1,0 +1,42 @@
+// Voice mode types for herm TUI.
+// Mirrors upstream hermes-ink voice state management, adapted for OpenTUI.
+
+/** Modifier portion of a parsed voice record key (ctrl+b → ctrl). */
+export type VoiceMod = "ctrl" | "alt"
+
+/** Parsed voice record key from `voice.record_key` config. */
+export type VoiceKey = {
+  mod: VoiceMod
+  ch: string
+  raw: string
+}
+
+/** Gateway `voice.toggle` response shape. */
+export type VoiceToggleResponse = {
+  enabled?: boolean
+  record_key?: string
+  tts?: boolean
+  available?: boolean
+  audio_available?: boolean
+  stt_available?: boolean
+  details?: string
+}
+
+/** Gateway `voice.record` response shape. */
+export type VoiceRecordResponse = {
+  status?: string
+}
+
+/** Runtime voice state. */
+export type VoiceState = {
+  /** Voice mode umbrella flag (on/off, toggled via /voice on|off). */
+  enabled: boolean
+  /** Currently recording (microphone open, VAD active). */
+  recording: boolean
+  /** Transcribing in progress (post-capture, pre-text). */
+  processing: boolean
+  /** Parsed record key binding from config (default: ctrl+b). */
+  recordKey: VoiceKey
+  /** TTS auto-speak enabled. */
+  tts: boolean
+}

--- a/src/voice/useVoice.ts
+++ b/src/voice/useVoice.ts
@@ -36,7 +36,9 @@ export function useVoice(gw: GwRpc, sys: (text: string) => void): VoiceApi {
   const [processing, setProcessing] = useState(false)
   const [recordKeyRaw, setRecordKeyRaw] = useState<string>()
   const [tts, setTts] = useState(false)
-  const [onTranscript, setOnTranscript] = useState<((text: string) => void) | null>(null)
+  const [onTranscript, setTranscript] = useState<((text: string) => void) | null>(null)
+  const setOnTranscript = useCallback((fn: ((text: string) => void) | null) =>
+    setTranscript(fn ? () => fn : null), [])
 
   const recordKey = useMemo(
     () => parseVoiceRecordKey(recordKeyRaw),

--- a/src/voice/useVoice.ts
+++ b/src/voice/useVoice.ts
@@ -1,0 +1,112 @@
+// Voice mode state hook for herm TUI.
+// Manages runtime voice state: enabled/recording/processing flags,
+// record key parsing from config, and actions (toggle, record start/stop).
+
+import { useState, useCallback, useMemo } from "react"
+import type { VoiceState, VoiceToggleResponse, VoiceRecordResponse } from "./types"
+import { parseVoiceRecordKey, formatVoiceRecordKey, DEFAULT_VOICE_KEY } from "./platform"
+
+/** Shape of the gateway client's `request` method — subset needed for voice. */
+type GwRpc = <T>(method: string, params: Record<string, unknown>) => Promise<T>
+
+export type VoiceApi = {
+  state: VoiceState
+  /** Toggle voice mode (on/off/tts/status) via gateway. */
+  toggle: (action: string, sid: string) => Promise<void>
+  /** Start or stop VAD-bounded recording via gateway. */
+  record: (sid: string) => Promise<void>
+  /** Set voice enabled from event (e.g. no_speech_limit auto-off). */
+  setEnabled: (v: boolean) => void
+  /** Set recording state from voice.status event. */
+  setRecording: (v: boolean) => void
+  /** Set processing state from voice.status event. */
+  setProcessing: (v: boolean) => void
+  /** Update record key from config (called after voice.toggle response). */
+  setRecordKey: (raw: string | undefined) => void
+  /** Formatted display string for the record key (e.g. "Ctrl+B"). */
+  keyLabel: string
+  /** Callback for voice transcript — inserts text into composer. */
+  onTranscript: ((text: string) => void) | null
+  setOnTranscript: (fn: ((text: string) => void) | null) => void
+}
+
+export function useVoice(gw: GwRpc, sys: (text: string) => void): VoiceApi {
+  const [enabled, setEnabled] = useState(false)
+  const [recording, setRecording] = useState(false)
+  const [processing, setProcessing] = useState(false)
+  const [recordKeyRaw, setRecordKeyRaw] = useState<string>()
+  const [tts, setTts] = useState(false)
+  const [onTranscript, setOnTranscript] = useState<((text: string) => void) | null>(null)
+
+  const recordKey = useMemo(
+    () => parseVoiceRecordKey(recordKeyRaw),
+    [recordKeyRaw],
+  )
+
+  const keyLabel = useMemo(
+    () => formatVoiceRecordKey(recordKey),
+    [recordKey],
+  )
+
+  const state: VoiceState = useMemo(() => ({
+    enabled, recording, processing, recordKey, tts,
+  }), [enabled, recording, processing, recordKey, tts])
+
+  const toggle = useCallback(async (action: string, sid: string) => {
+    try {
+      const r = await gw<VoiceToggleResponse>("voice.toggle", {
+        action,
+        session_id: sid,
+      })
+      if (r.enabled !== undefined) setEnabled(r.enabled)
+      if (r.tts !== undefined) setTts(r.tts)
+      if (r.record_key) setRecordKeyRaw(r.record_key)
+      const label = formatVoiceRecordKey(parseVoiceRecordKey(r.record_key))
+      const ttsMsg = r.tts ? " · tts on" : ""
+      sys(`voice ${r.enabled ? "on" : "off"}${ttsMsg} [${label}]`)
+    } catch (e) {
+      sys(`voice: ${e instanceof Error ? e.message : "gateway error"}`)
+    }
+  }, [gw, sys])
+
+  const record = useCallback(async (sid: string) => {
+    if (!enabled) {
+      sys("voice: mode is off — enable with /voice on")
+      return
+    }
+    const starting = !recording
+    const action = starting ? "start" : "stop"
+    // Optimistic UI update
+    if (starting) {
+      setRecording(true)
+    } else {
+      setRecording(false)
+      setProcessing(false)
+    }
+    try {
+      const r = await gw<VoiceRecordResponse>("voice.record", {
+        action,
+        session_id: sid,
+      })
+      // Reconcile on failure
+      if (starting && r.status !== "recording") {
+        setRecording(false)
+        if (r.status === "busy") {
+          setProcessing(true)
+          sys("voice: still transcribing; try again shortly")
+        }
+      }
+    } catch (e) {
+      if (starting) setRecording(false)
+      sys(`voice error: ${e instanceof Error ? e.message : "gateway error"}`)
+    }
+  }, [enabled, recording, gw, sys])
+
+  return {
+    state, toggle, record,
+    setEnabled, setRecording, setProcessing,
+    setRecordKey: setRecordKeyRaw,
+    keyLabel,
+    onTranscript, setOnTranscript,
+  }
+}

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -711,6 +711,7 @@ describe("app", () => {
     t.destroy()
   })
 
+
   test("click user message → action menu → Rewind → N×session.undo → composer seeded", async () => {
     // History after rewind: server-authoritative via session.history.
     const hist = (n: number) => Array.from({ length: n }, (_, i) => ({

--- a/test/background.test.tsx
+++ b/test/background.test.tsx
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test"
 import { act } from "react"
-import { mount, until } from "./harness"
+import { mount, until, MockGateway } from "./harness"
 
 describe("background/btw completion", () => {
   test("background.complete → transcript marker + toast with view action → alert dialog", async () => {
@@ -41,6 +41,40 @@ describe("background/btw completion", () => {
     await t.settle()
     expect(t.frame()).toContain("◈ btw — side answer here")
     expect(t.frame()).toContain("btw")
+    t.destroy()
+  })
+
+  test("/background register → composer badge; background.complete → unregister", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),
+      "prompt.background": () => ({ task_id: "bg-42" }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    expect(t.frame()).not.toContain("▶ 1")
+
+    await act(async () => { await t.keys.typeText("/background do the thing") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("▶ 1"))
+
+    act(() => t.gw.push({ type: "background.complete", payload: { task_id: "bg-42", text: "done" } }))
+    await until(t, () => !t.frame().includes("▶ 1"))
+    t.destroy()
+  })
+
+  test("/background with no task_id in response does not register", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),
+      "prompt.background": () => ({}),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/background oops") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("background start failed"))
+    expect(t.frame()).not.toContain("▶ 1")
     t.destroy()
   })
 })

--- a/test/composer-background-fragment.test.tsx
+++ b/test/composer-background-fragment.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { act, createRef } from "react"
+import { mountNode, until } from "./harness"
+import { Composer, type ComposerHandle } from "../src/components/chat/Composer"
+import { BackgroundProvider, useBackground } from "../src/app/background"
+
+const noop = () => {}
+
+// Surface the bg API next to the Composer so the test can register/unregister
+// without reaching into provider internals.
+const Host = ({ grab, composerRef }: { grab: (api: ReturnType<typeof useBackground>) => void; composerRef: React.Ref<ComposerHandle> }) => {
+  const api = useBackground()
+  grab(api)
+  return (
+    <Composer
+      ref={composerRef}
+      focused
+      ready
+      streaming={false}
+      cmds={[]}
+      model="test-model"
+      onSend={noop}
+      onSlash={noop}
+    />
+  )
+}
+
+const mountComposer = async () => {
+  const ref = createRef<ComposerHandle>()
+  let api: ReturnType<typeof useBackground> | undefined
+  const t = await mountNode(
+    <BackgroundProvider>
+      <Host grab={a => { api = a }} composerRef={ref} />
+    </BackgroundProvider>,
+    { width: 80, height: 8 },
+  )
+  return { t, get: () => api!, ref }
+}
+
+describe("Composer background fragment", () => {
+  test("absent when no background tasks", async () => {
+    const { t } = await mountComposer()
+    expect(t.frame()).not.toContain("▶")
+    t.destroy()
+  })
+
+  test("shows ▶ 1 with one task", async () => {
+    const { t, get } = await mountComposer()
+    act(() => { get().register("task-a") })
+    await until(t, () => t.frame().includes("▶ 1"))
+    t.destroy()
+  })
+
+  test("shows ▶ 3 with three tasks", async () => {
+    const { t, get } = await mountComposer()
+    act(() => {
+      get().register("a")
+      get().register("b")
+      get().register("c")
+    })
+    await until(t, () => t.frame().includes("▶ 3"))
+    t.destroy()
+  })
+
+  test("disappears when count returns to zero", async () => {
+    const { t, get } = await mountComposer()
+    act(() => { get().register("a") })
+    await until(t, () => t.frame().includes("▶ 1"))
+    act(() => { get().unregister("a") })
+    await until(t, () => !t.frame().includes("▶"))
+    t.destroy()
+  })
+})

--- a/test/composer-parts.test.tsx
+++ b/test/composer-parts.test.tsx
@@ -89,6 +89,25 @@ describe("composer parts — submit", () => {
     expect(sent).toEqual([{ text: "no chips here", parts: [] }])
     t.destroy()
   })
+
+  test("two chips back-to-back → parts[] carries both FileParts on submit", async () => {
+    const { t, ref, sent } = await setup(fileGateway())
+    await chip(t, ref, "@file:src/a.ts")
+    await chip(t, ref, "@file:src/b.ts")
+    expect(ref.current?.value()).toBe("@file:src/a.ts @file:src/b.ts ")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("@file:src/a.ts @file:src/b.ts")
+    expect(sent[0]!.parts).toHaveLength(2)
+    const parts = sent[0]!.parts as readonly FilePart[]
+    expect(parts[0]!.type).toBe("file")
+    expect(parts[0]!.filename).toBe("@file:src/a.ts")
+    expect(parts[1]!.type).toBe("file")
+    expect(parts[1]!.filename).toBe("@file:src/b.ts")
+    t.destroy()
+  })
 })
 describe("composer parts — atomic backspace", () => {
   test("single backspace past a chip removes it whole (and drops its part on submit)", async () => {

--- a/test/composer-parts.test.tsx
+++ b/test/composer-parts.test.tsx
@@ -1,0 +1,150 @@
+// Composer ↔ PartsBuffer integration. The unit tests in parts.test.tsx
+// cover the buffer in isolation; these drive it through the <Composer>
+// surface the app actually mounts — submit emits parts[], a single
+// backspace past a chip boundary eats it whole, and history restore
+// rebuilds chips rather than dropping them to plain text.
+
+import { describe, expect, test } from "bun:test"
+import { act, createRef } from "react"
+import type { RefObject } from "react"
+import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { join } from "path"
+import { mountNode, until, MockGateway, type Harness } from "./harness"
+import { Composer, type ComposerHandle } from "../src/components/chat/Composer"
+import { LOCAL_COMMANDS } from "../src/app/slashCommands"
+import type { Part, FilePart } from "../src/app/parts"
+
+type Sent = { text: string; parts: readonly Part[] | undefined }
+
+// Gateway that resolves any `@file:<query>` word to a single item whose
+// text equals the query — so popAccept() accepts a "complete" chip
+// (not a prefix that ends in `:` or `/`) and drives the insertPart path.
+function fileGateway(): MockGateway {
+  return new MockGateway({
+    "complete.path": p => {
+      const w = String(p.word)
+      if (w.startsWith("@file:") && !w.endsWith(":") && !w.endsWith("/")) {
+        return { items: [{ text: w, display: w, meta: "file" }] }
+      }
+      return { items: [] }
+    },
+  })
+}
+
+async function setup(gw = new MockGateway()) {
+  const ref = createRef<ComposerHandle>()
+  const sent: Sent[] = []
+  const t: Harness = await mountNode(
+    <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+      <box flexGrow={1} />
+      <Composer
+        ref={ref}
+        focused ready streaming={false} cmds={LOCAL_COMMANDS}
+        onSend={(text, parts) => sent.push({ text, parts })}
+        onSlash={() => {}}
+      />
+    </box>,
+    { gw, width: 120, height: 30 },
+  )
+  await until(t, () => t.frame().includes("Ready"))
+  return { t, ref, sent }
+}
+
+// Type an @file ref and accept the popover — lands a chip via the real
+// atAccept() path (the one the user hits with Tab/Enter on the popover).
+async function chip(t: Harness, ref: RefObject<ComposerHandle | null>, word: string) {
+  await act(async () => { await t.keys.typeText(word) })
+  await until(t, () => ref.current?.popOpen() === true)
+  act(() => ref.current?.popAccept())
+  await t.settle()
+}
+
+describe("composer parts — submit", () => {
+  test("chip + text → onSend gets text with chip inlined and parts[] carrying the FilePart", async () => {
+    const { t, ref, sent } = await setup(fileGateway())
+    await chip(t, ref, "@file:src/a.ts")
+    // atAccept appends a trailing space after the chip
+    expect(ref.current?.value()).toBe("@file:src/a.ts ")
+    await act(async () => { await t.keys.typeText("and hello") })
+    await t.settle()
+    expect(ref.current?.value()).toBe("@file:src/a.ts and hello")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("@file:src/a.ts and hello")
+    expect(sent[0]!.parts).toHaveLength(1)
+    const p = sent[0]!.parts![0] as FilePart
+    expect(p.type).toBe("file")
+    expect(p.filename).toBe("@file:src/a.ts")
+    expect(p.source?.text.value).toBe("@file:src/a.ts")
+    t.destroy()
+  })
+
+  test("plain text → parts[] is empty", async () => {
+    const { t, sent } = await setup()
+    await act(async () => { await t.keys.typeText("no chips here") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toEqual([{ text: "no chips here", parts: [] }])
+    t.destroy()
+  })
+})
+describe("composer parts — atomic backspace", () => {
+  test("single backspace past a chip removes it whole (and drops its part on submit)", async () => {
+    const { t, ref, sent } = await setup(fileGateway())
+    await chip(t, ref, "@file:src/a.ts")
+    expect(ref.current?.value()).toBe("@file:src/a.ts ")
+
+    // First ⌫ eats the trailing space; the second lands on the chip
+    // boundary and deletes the whole virtual run in one keystroke.
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(ref.current?.value()).toBe("@file:src/a.ts")
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(ref.current?.value()).toBe("")
+
+    // Submit a new plain message so the previous chip doesn't ride on parts[]
+    await act(async () => { await t.keys.typeText("after") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toEqual([{ text: "after", parts: [] }])
+    t.destroy()
+  })
+})
+
+describe("composer parts — history restore", () => {
+  test("↑ into a history entry with parts rebuilds chips, submit re-emits the FilePart", async () => {
+    // Seed history with an entry that carries a FilePart. The composer's
+    // restore() dispatches to fromSnapshot when parts.length > 0 — that's
+    // the chip-rebuild path we need to exercise.
+    const dir = process.env.HERM_CONFIG_DIR!
+    mkdirSync(dir, { recursive: true })
+    const part: FilePart = {
+      type: "file",
+      mime: "text/uri-list",
+      filename: "@file:src/x.ts",
+      source: { type: "file", path: "@file:src/x.ts", text: { start: 0, end: 14, value: "@file:src/x.ts" } },
+    }
+    const entry = { input: "@file:src/x.ts tail", parts: [part] }
+    writeFileSync(join(dir, "history"), JSON.stringify(entry) + "\n", "utf-8")
+
+    const { t, ref, sent } = await setup()
+    // mountNode doesn't wire useAppKeys, so drive history via the
+    // imperative handle the shell normally binds to ArrowUp.
+    act(() => { ref.current?.historyUp() })
+    await t.settle()
+    expect(ref.current?.value()).toBe("@file:src/x.ts tail")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe("@file:src/x.ts tail")
+    expect(sent[0]!.parts).toHaveLength(1)
+    expect((sent[0]!.parts![0] as FilePart).filename).toBe("@file:src/x.ts")
+
+    rmSync(join(dir, "history"), { force: true })
+    t.destroy()
+  })
+})

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mapEvent, type Side } from "../src/context/events"
+import { formatProcessNotification, mapEvent, type Side } from "../src/context/events"
 import type { GatewayEvent } from "../src/context/wire"
 
 function map(ev: GatewayEvent, side: Partial<Side> = {}) {
@@ -74,15 +74,29 @@ describe("mapEvent", () => {
     expect(b.action).toEqual({ kind: "system", text: "HTTP 404" })
   })
 
-  test("status.update kind=process folds [IMPORTANT:...] to one-line herald", () => {
-    const done = map({ type: "status.update", payload: { kind: "process", text:
-      "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]" } })
-    expect(done.action).toEqual({ kind: "system", text: "◆ background proc_abc exited 0 · bun test" })
-    const hit = map({ type: "status.update", payload: { kind: "process", text:
-      "[IMPORTANT: Background process srv_1 matched watch pattern \"ready\".\nCommand: bun run dev\nMatched output:\nApplication startup complete]" } })
-    expect(hit.action).toEqual({ kind: "system", text: "◆ background srv_1 matched \"ready\" · bun run dev" })
-    const miss = map({ type: "status.update", payload: { kind: "process", text: "weird shape" } })
-    expect(miss.action).toEqual({ kind: "system", text: "weird shape" })
+  test("status.update kind=process routes to debounced side callback", () => {
+    const text = "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]"
+    const done = map({ type: "status.update", payload: { kind: "process", text } })
+    expect(done.action).toBeNull()
+    expect(done.calls.status).toEqual([text])
+
+    const calls: string[] = []
+    const routed = map(
+      { type: "status.update", payload: { kind: "process", text } },
+      { onProcessNotification: t => calls.push(t) },
+    )
+    expect(routed.action).toBeNull()
+    expect(calls).toEqual([text])
+  })
+
+  test("formatProcessNotification preserves completion and watch-pattern shapes", () => {
+    expect(formatProcessNotification(
+      "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]",
+    )).toBe("proc_abc exited 0 · bun test")
+    expect(formatProcessNotification(
+      "[IMPORTANT: Background process srv_1 matched watch pattern \"ready\".\nCommand: bun run dev\nMatched output:\nApplication startup complete]",
+    )).toBe("srv_1 matched \"ready\" · bun run dev")
+    expect(formatProcessNotification("weird shape")).toBe("weird shape")
   })
 
   test("gateway.stderr: errorish → system; benign → null", () => {

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -21,6 +21,7 @@ import { DialogProvider } from "../src/ui/dialog"
 import { ToastProvider } from "../src/ui/toast"
 import { CommandProvider } from "../src/ui/command"
 import { PluginProvider } from "../src/plugins/runtime"
+import { BackgroundProvider } from "../src/app/background"
 import type { HermPlugin } from "../src/plugins/types"
 import type { GatewayEvent } from "../src/context/wire"
 
@@ -150,7 +151,9 @@ export async function mountNode(node: ReactNode, opts: Opts = {}): Promise<Harne
           <KeysProvider>
             <DialogProvider>
               <CommandProvider>
-                <PluginProvider plugins={opts.plugins ?? []}>{node}</PluginProvider>
+                <PluginProvider plugins={opts.plugins ?? []}>
+                  <BackgroundProvider>{node}</BackgroundProvider>
+                </PluginProvider>
               </CommandProvider>
             </DialogProvider>
           </KeysProvider>

--- a/test/input-history.test.tsx
+++ b/test/input-history.test.tsx
@@ -3,7 +3,8 @@ import { act } from "react"
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs"
 import { join } from "path"
 import { mountNode } from "./harness"
-import { useInputHistory } from "../src/app/useInputHistory"
+import { useInputHistory, type HistEntry } from "../src/app/useInputHistory"
+import type { FilePart } from "../src/app/parts"
 
 const dir = process.env.HERM_CONFIG_DIR!
 const file = join(dir, "history")
@@ -12,14 +13,14 @@ type Hook = ReturnType<typeof useInputHistory>
 
 async function setup() {
   let hook!: Hook
-  let val = ""
+  let val: HistEntry = { input: "", parts: [] }
   const Probe = () => {
-    const h = useInputHistory(val, v => (val = v))
+    const h = useInputHistory(val.input, e => (val = e))
     hook = h
     return null
   }
   const t = await mountNode(<Probe />)
-  return { t, hook: () => hook, val: () => val }
+  return { t, hook: () => hook, val: () => val.input, entry: () => val }
 }
 
 describe("useInputHistory", () => {
@@ -27,7 +28,7 @@ describe("useInputHistory", () => {
     rmSync(file, { force: true })
   })
 
-  test("loads from disk — ↑ recalls newest-last entry", async () => {
+  test("loads legacy raw-string entries from disk — ↑ recalls newest-last", async () => {
     mkdirSync(dir, { recursive: true })
     writeFileSync(file, "old\nmid\nnew\n")
     const s = await setup()
@@ -40,18 +41,40 @@ describe("useInputHistory", () => {
     s.t.destroy()
   })
 
-  test("push appends to disk and dedupes adjacent", async () => {
+  test("push appends JSONL to disk and dedupes adjacent", async () => {
     const s = await setup()
     act(() => s.hook().push("a"))
     act(() => s.hook().push("a"))
     act(() => s.hook().push("b"))
     act(() => s.hook().push("a"))
     await s.t.settle()
-    expect(readFileSync(file, "utf-8")).toBe("a\nb\na\n")
+    expect(readFileSync(file, "utf-8")).toBe(
+      `{"input":"a"}\n{"input":"b"}\n{"input":"a"}\n`,
+    )
     act(() => s.hook().up())
     expect(s.val()).toBe("a")
     act(() => s.hook().up())
     expect(s.val()).toBe("b")
+    s.t.destroy()
+  })
+
+  test("entries with parts round-trip through disk", async () => {
+    const part: FilePart = {
+      type: "file",
+      mime: "text/uri-list",
+      filename: "@file:src/x.ts",
+      source: { type: "file", path: "@file:src/x.ts", text: { start: 0, end: 14, value: "@file:src/x.ts" } },
+    }
+    const s = await setup()
+    act(() => s.hook().push({ input: "@file:src/x.ts here", parts: [part] }))
+    await s.t.settle()
+    const line = readFileSync(file, "utf-8").trim()
+    const parsed = JSON.parse(line)
+    expect(parsed.input).toBe("@file:src/x.ts here")
+    expect(parsed.parts).toHaveLength(1)
+    expect(parsed.parts[0].type).toBe("file")
+    act(() => s.hook().up())
+    expect(s.entry().parts).toHaveLength(1)
     s.t.destroy()
   })
 
@@ -70,7 +93,7 @@ describe("useInputHistory", () => {
     const s = await setup()
     act(() => s.hook().push("over"))
     await s.t.settle()
-    const out = readFileSync(file, "utf-8").split("\n").filter(Boolean)
+    const out = readFileSync(file, "utf-8").split("\n").filter(Boolean).map(l => JSON.parse(l).input)
     expect(out.length).toBe(500)
     expect(out[0]).toBe("m1")
     expect(out[499]).toBe("over")

--- a/test/open-file.test.ts
+++ b/test/open-file.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect } from "bun:test"
+import { EventEmitter } from "node:events"
+import { openUrl, parseSafeUrl, openCommand } from "../src/utils/open-file"
+
+function makeSpawn(platformId: string, opts: { throws?: boolean } = {}) {
+  const calls: { command: string; args: string[] }[] = []
+  let child: FakeChild | null = null
+  const fn = ((command: string, args: string[]) => {
+    calls.push({ command, args })
+    if (opts.throws) throw new Error("EINVAL")
+    child = new FakeChild()
+    return child as unknown as ReturnType<typeof import("node:child_process").spawn>
+  }) as typeof import("node:child_process").spawn
+  return { spawn: fn, platform: () => platformId, calls, child: () => child }
+}
+
+class FakeChild extends EventEmitter {
+  unrefed = false
+  unref() { this.unrefed = true }
+}
+
+describe("parseSafeUrl", () => {
+  test("accepts http and https", () => {
+    expect(parseSafeUrl("http://example.com")?.href).toBe("http://example.com/")
+    expect(parseSafeUrl("https://example.com/path?q=1")?.href).toBe("https://example.com/path?q=1")
+  })
+
+  test("rejects dangerous protocols", () => {
+    expect(parseSafeUrl("file:///etc/passwd")).toBeNull()
+    expect(parseSafeUrl("javascript:alert(1)")).toBeNull()
+    expect(parseSafeUrl("data:text/html,<script>")).toBeNull()
+    expect(parseSafeUrl("vbscript:msgbox")).toBeNull()
+    expect(parseSafeUrl("chrome://settings")).toBeNull()
+  })
+
+  test("rejects malformed input", () => {
+    expect(parseSafeUrl("")).toBeNull()
+    expect(parseSafeUrl("not a url")).toBeNull()
+    expect(parseSafeUrl(null as unknown as string)).toBeNull()
+  })
+
+  test("preserves query strings with shell metacharacters", () => {
+    const url = parseSafeUrl("https://example.com/?a=1&b=2;rm")
+    expect(url?.href).toBe("https://example.com/?a=1&b=2;rm")
+  })
+})
+
+describe("openCommand", () => {
+  test("darwin → open", () => {
+    expect(openCommand("darwin")).toEqual({ command: "open", args: [] })
+  })
+
+  test("win32 → explorer.exe (not cmd /c start)", () => {
+    expect(openCommand("win32")).toEqual({ command: "explorer.exe", args: [] })
+  })
+
+  test("linux + BSDs → xdg-open", () => {
+    for (const p of ["linux", "freebsd", "openbsd", "netbsd", "dragonfly"]) {
+      expect(openCommand(p)).toEqual({ command: "xdg-open", args: [] })
+    }
+  })
+
+  test("unknown platform → null", () => {
+    expect(openCommand("aix")).toBeNull()
+    expect(openCommand("sunos")).toBeNull()
+    expect(openCommand("cygwin")).toBeNull()
+  })
+})
+
+describe("openUrl", () => {
+  test("valid https on linux → spawns xdg-open with argv (no shell)", () => {
+    const s = makeSpawn("linux")
+    expect(openUrl("https://example.com/path", s)).toBe(true)
+    expect(s.calls).toEqual([{ command: "xdg-open", args: ["https://example.com/path"] }])
+  })
+
+  test("darwin → open", () => {
+    const s = makeSpawn("darwin")
+    expect(openUrl("https://example.com", s)).toBe(true)
+    expect(s.calls[0].command).toBe("open")
+  })
+
+  test("win32 → explorer.exe", () => {
+    const s = makeSpawn("win32")
+    expect(openUrl("https://example.com", s)).toBe(true)
+    expect(s.calls[0].command).toBe("explorer.exe")
+  })
+
+  test("rejects file:// without spawning", () => {
+    const s = makeSpawn("linux")
+    expect(openUrl("file:///etc/passwd", s)).toBe(false)
+    expect(s.calls).toEqual([])
+  })
+
+  test("rejects javascript: without spawning", () => {
+    const s = makeSpawn("linux")
+    expect(openUrl("javascript:alert(1)", s)).toBe(false)
+    expect(s.calls).toEqual([])
+  })
+
+  test("rejects data: without spawning", () => {
+    const s = makeSpawn("linux")
+    expect(openUrl("data:text/html,<script>alert(1)</script>", s)).toBe(false)
+    expect(s.calls).toEqual([])
+  })
+
+  test("unknown platform → no spawn, returns false", () => {
+    const s = makeSpawn("aix")
+    expect(openUrl("https://example.com", s)).toBe(false)
+    expect(s.calls).toEqual([])
+  })
+
+  test("synchronous spawn throw → returns false", () => {
+    const s = makeSpawn("linux", { throws: true })
+    expect(openUrl("https://example.com", s)).toBe(false)
+  })
+
+  test("shell metacharacters in URL pass through argv unescaped", () => {
+    const s = makeSpawn("linux")
+    // No spaces — URL normalization percent-encodes them, which is fine
+    // but would confuse the assertion. Metacharacters like ;&`$|<> are
+    // preserved verbatim by URL parsing in the query string.
+    const url = "https://example.com/?a=1&b=;`$|"
+    expect(openUrl(url, s)).toBe(true)
+    // The URL lands as a single argv entry — the shell never sees it.
+    expect(s.calls[0].args).toHaveLength(1)
+    expect(s.calls[0].args[0]).toBe(url)
+  })
+
+  test("async 'error' event is absorbed (no throw)", () => {
+    const s = makeSpawn("linux")
+    openUrl("https://example.com", s)
+    const child = s.child()
+    expect(child).not.toBeNull()
+    expect(child!.listenerCount("error")).toBe(1)
+    expect(child!.unrefed).toBe(true)
+    // Emitting error on an EventEmitter with no listener throws; with our
+    // no-op listener it should be absorbed silently.
+    expect(() => child!.emit("error", new Error("ENOENT"))).not.toThrow()
+  })
+
+  test("error listener attached before unref", () => {
+    // If unref ran before the listener was attached and the child
+    // crashed in the same tick, Node would throw an uncaught 'error'
+    // and tear down the TUI. We encode ordering by checking both that
+    // the listener is present and that unref was called — the test
+    // above that emits 'error' post-hoc exercises the absorption path.
+    const s = makeSpawn("linux")
+    openUrl("https://example.com", s)
+    const child = s.child()!
+    expect(child.listenerCount("error")).toBe(1)
+    expect(child.unrefed).toBe(true)
+  })
+})

--- a/test/parts.test.tsx
+++ b/test/parts.test.tsx
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "bun:test"
+import { act, createRef, useImperativeHandle, forwardRef, useRef } from "react"
+import type { TextareaRenderable } from "@opentui/core"
+import { mountNode, until, type Harness } from "./harness"
+import { PartsBuffer, styles as partStyles, type FilePart, type AgentPart, type TextPart } from "../src/app/parts"
+import { useTheme } from "../src/theme"
+
+// Probe mounts a bare <textarea> inside a ThemeProvider so partStyles
+// can register against a real SyntaxStyle. Exposes the TextareaRenderable
+// and the PartsBuffer bound to it so tests drive both directly.
+type Probe = {
+  ta: TextareaRenderable
+  buf: PartsBuffer
+}
+
+const Harn = forwardRef<Probe>((_, ref) => {
+  const theme = useTheme()
+  const ta = useRef<TextareaRenderable | null>(null)
+  const buf = useRef<PartsBuffer | null>(null)
+  useImperativeHandle(ref, () => ({
+    get ta() { return ta.current! },
+    get buf() { return buf.current! },
+  }), [])
+  const sids = partStyles(theme.syntaxStyle, theme.theme)
+  return (
+    <textarea
+      ref={r => {
+        ta.current = r
+        if (r && !buf.current) buf.current = new PartsBuffer(r, sids)
+        if (!r) buf.current = null
+      }}
+      syntaxStyle={theme.syntaxStyle}
+      focused
+      minHeight={1}
+      maxHeight={6}
+      wrapMode="word"
+    />
+  )
+})
+
+async function setup(): Promise<{ t: Harness; probe: Probe }> {
+  const ref = createRef<Probe>()
+  const t = await mountNode(<Harn ref={ref} />, { width: 80, height: 10 })
+  await until(t, () => ref.current?.ta != null && ref.current?.buf != null)
+  return { t, probe: ref.current! }
+}
+
+function file(name: string): FilePart {
+  return {
+    type: "file",
+    mime: "text/uri-list",
+    filename: name,
+    source: { type: "file", path: name, text: { start: 0, end: name.length, value: name } },
+  }
+}
+
+function agent(name: string): AgentPart {
+  return { type: "agent", name }
+}
+
+function text(body: string): TextPart {
+  return { type: "text", text: body }
+}
+
+describe("PartsBuffer", () => {
+  test("insertText appends plain text, produces no parts", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("hello"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("hello")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("insertPart writes virtualText + trailing space, records part with range", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:src/a.ts"), "@file:src/a.ts"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:src/a.ts ")
+    const ps = probe.buf.parts()
+    expect(ps).toHaveLength(1)
+    const p = ps[0]!
+    expect(p.type).toBe("file")
+    if (p.type === "file") {
+      expect(p.filename).toBe("@file:src/a.ts")
+      expect(p.source?.text.start).toBe(0)
+      expect(p.source?.text.end).toBe(14)
+      expect(p.source?.text.value).toBe("@file:src/a.ts")
+    }
+    t.destroy()
+  })
+
+  test("insertText + insertPart + insertText preserves display order", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("see "))
+    act(() => probe.buf.insertPart(file("@file:a.ts"), "@file:a.ts"))
+    act(() => probe.buf.insertText("then "))
+    act(() => probe.buf.insertPart(agent("reviewer"), "@reviewer"))
+    act(() => probe.buf.insertText("done"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("see @file:a.ts then @reviewer done")
+    const ps = probe.buf.parts()
+    expect(ps.map(p => p.type)).toEqual(["file", "agent"])
+    // ranges in ascending order
+    const r0 = ps[0]!.type === "file" ? ps[0]!.source!.text : null
+    const r1 = ps[1]!.type === "agent" ? ps[1]!.source! : null
+    expect(r0!.start).toBeLessThan(r1!.start)
+    t.destroy()
+  })
+
+  test("listParts equivalent: parts() reflects kinds and ranges", async () => {
+    const { t, probe } = await setup()
+    const f = file("@file:x")
+    const a = agent("reviewer")
+    const txt = text("pasted content body")
+    act(() => probe.buf.insertPart(f, "@file:x"))
+    act(() => probe.buf.insertPart(a, "@reviewer"))
+    act(() => probe.buf.insertPart(txt, "[Pasted #1]"))
+    await t.settle()
+    const kinds = probe.buf.parts().map(p => p.type)
+    expect(kinds).toEqual(["file", "agent", "text"])
+    t.destroy()
+  })
+
+  test("chip at buffer start", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertText("after"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a after")
+    const p = probe.buf.parts()[0]!
+    if (p.type === "file") expect(p.source?.text.start).toBe(0)
+    t.destroy()
+  })
+
+  test("chip at buffer end (no trailing text after the chip's trailing space)", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("before "))
+    act(() => probe.buf.insertPart(file("@file:b"), "@file:b"))
+    await t.settle()
+    // insertPart always appends a trailing space; caret lands after it
+    expect(probe.buf.text()).toBe("before @file:b ")
+    expect(probe.buf.parts()).toHaveLength(1)
+    t.destroy()
+  })
+
+  test("adjacent chips — two chips inserted back to back", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertPart(file("@file:b"), "@file:b"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a @file:b ")
+    const ps = probe.buf.parts()
+    expect(ps).toHaveLength(2)
+    const r0 = ps[0]!.type === "file" ? ps[0]!.source!.text : null
+    const r1 = ps[1]!.type === "file" ? ps[1]!.source!.text : null
+    expect(r0!.end).toBeLessThanOrEqual(r1!.start)
+    expect(r1!.start - r0!.end).toBe(1) // the space between them
+    t.destroy()
+  })
+
+  test("inserting text immediately before a chip does NOT extend the chip's range", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    const before = probe.buf.parts()[0]!
+    const origLen = before.type === "file" ? before.source!.text.end - before.source!.text.start : 0
+    // Move caret to 0 and insert "xx" before the chip
+    act(() => { probe.ta.cursorOffset = 0 })
+    act(() => probe.buf.insertText("xx"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("xx@file:a ")
+    const after = probe.buf.parts()[0]!
+    if (after.type === "file") {
+      const newLen = after.source!.text.end - after.source!.text.start
+      expect(newLen).toBe(origLen)
+      expect(after.source!.text.start).toBe(2) // shifted, not extended
+    }
+    t.destroy()
+  })
+
+  test("inserting text immediately after a chip does NOT extend the chip's range", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    const before = probe.buf.parts()[0]!
+    const origEnd = before.type === "file" ? before.source!.text.end : 0
+    // Caret already at end of buffer after insertPart; insert more text
+    act(() => probe.buf.insertText("yy"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a yy")
+    const after = probe.buf.parts()[0]!
+    if (after.type === "file") {
+      expect(after.source!.text.end).toBe(origEnd)
+      expect(after.source!.text.start).toBe(0)
+    }
+    t.destroy()
+  })
+
+  test("atomic-chip backspace: one keystroke removes the whole chip + its part", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    // caret sits just past the trailing space; remove the space first so
+    // the next backspace lands on the chip boundary
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("@file:a")
+    expect(probe.buf.parts()).toHaveLength(1)
+    // Now a single backspace deletes the entire chip atomically
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("backspace inside plain text deletes one char (regression guard)", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("hello"))
+    await t.settle()
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("hell")
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    expect(probe.buf.text()).toBe("hel")
+    t.destroy()
+  })
+
+  test("deleteRange spanning a chip removes it cleanly", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("prefix "))
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertText("suffix"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("prefix @file:a suffix")
+    // Delete everything from end of "prefix " through "@file:a" (cols 7..14
+    // inclusive) by replacing the whole buffer — setText + sync mirrors
+    // what a selection+delete via the textarea would do.
+    act(() => {
+      probe.ta.deleteRange(0, 7, 0, 15)
+    })
+    await t.settle()
+    expect(probe.buf.text()).toBe("prefix suffix")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("toSnapshot() + fromSnapshot() round-trip is lossless", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("look "))
+    act(() => probe.buf.insertPart(file("@file:src/z.ts"), "@file:src/z.ts"))
+    act(() => probe.buf.insertText("and "))
+    act(() => probe.buf.insertPart(agent("reviewer"), "@reviewer"))
+    await t.settle()
+    const snap = probe.buf.toSnapshot()
+    expect(snap.v).toBe(1)
+    expect(snap.input).toBe(probe.buf.text())
+    expect(snap.parts).toHaveLength(2)
+
+    // Clear, then restore; text + parts must match exactly.
+    act(() => probe.buf.clear())
+    await t.settle()
+    expect(probe.buf.text()).toBe("")
+    expect(probe.buf.parts()).toEqual([])
+
+    act(() => probe.buf.fromSnapshot(snap))
+    await t.settle()
+    expect(probe.buf.text()).toBe(snap.input)
+    // Deep-equal parts
+    expect(probe.buf.parts()).toEqual(snap.parts)
+
+    // Second snapshot must deep-equal the first.
+    const snap2 = probe.buf.toSnapshot()
+    expect(snap2).toEqual(snap)
+    t.destroy()
+  })
+
+  test("clear() wipes text, marks, and parts", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("x "))
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    await t.settle()
+    expect(probe.buf.parts()).toHaveLength(1)
+    act(() => probe.buf.clear())
+    await t.settle()
+    expect(probe.buf.text()).toBe("")
+    expect(probe.buf.parts()).toEqual([])
+    t.destroy()
+  })
+
+  test("expand() inlines text parts, keeps file/agent parts in emitted list", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertText("here "))
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertText(" and "))
+    act(() => probe.buf.insertPart(text("the real pasted body"), "[Pasted #1]"))
+    await t.settle()
+    expect(probe.buf.text()).toBe("here @file:a  and [Pasted #1] ")
+    const exp = probe.buf.expand()
+    // [Pasted #1] replaced by its source text, @file:a chip preserved as-is
+    expect(exp.text).toBe("here @file:a  and the real pasted body ")
+    expect(exp.parts).toHaveLength(1)
+    expect(exp.parts[0]!.type).toBe("file")
+    t.destroy()
+  })
+
+  test("sync() drops parts whose marks were deleted (atomic backspace case)", async () => {
+    const { t, probe } = await setup()
+    act(() => probe.buf.insertPart(file("@file:a"), "@file:a"))
+    act(() => probe.buf.insertPart(file("@file:b"), "@file:b"))
+    await t.settle()
+    expect(probe.buf.parts()).toHaveLength(2)
+    // Delete the trailing space, then the second chip via backspace.
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    act(() => t.keys.pressBackspace())
+    await t.settle()
+    const ps = probe.buf.parts()
+    expect(ps).toHaveLength(1)
+    if (ps[0]!.type === "file") expect(ps[0]!.filename).toBe("@file:a")
+    t.destroy()
+  })
+})

--- a/test/use-background.test.tsx
+++ b/test/use-background.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mountNode, until } from "./harness"
+import { BackgroundProvider, useBackground } from "../src/app/background"
+
+type Api = ReturnType<typeof useBackground>
+
+const Host = ({ grab }: { grab: (api: Api) => void }) => {
+  const api = useBackground()
+  grab(api)
+  return (
+    <box flexDirection="column">
+      <text>{`count:${api.count}`}</text>
+      <text>{`ids:${api.ids.join(",")}`}</text>
+    </box>
+  )
+}
+
+const mountHost = async () => {
+  let api: Api | undefined
+  const t = await mountNode(
+    <BackgroundProvider><Host grab={a => { api = a }} /></BackgroundProvider>,
+    { width: 40, height: 6 },
+  )
+  return { t, get: () => api! }
+}
+
+describe("BackgroundProvider", () => {
+  test("starts empty", async () => {
+    const { t } = await mountHost()
+    expect(t.frame()).toContain("count:0")
+    expect(t.frame()).toContain("ids:")
+    t.destroy()
+  })
+
+  test("register adds ids and bumps count reactively", async () => {
+    const { t, get } = await mountHost()
+    act(() => { get().register("a"); get().register("b") })
+    await until(t, () => t.frame().includes("count:2"))
+    expect(t.frame()).toContain("ids:a,b")
+    t.destroy()
+  })
+
+  test("register is a no-op for falsy or duplicate ids", async () => {
+    const { t, get } = await mountHost()
+    act(() => { get().register("a"); get().register("a"); get().register("") })
+    await until(t, () => t.frame().includes("count:1"))
+    expect(t.frame()).toContain("ids:a")
+    t.destroy()
+  })
+
+  test("unregister removes present ids and is a no-op for absent", async () => {
+    const { t, get } = await mountHost()
+    act(() => { get().register("a"); get().register("b") })
+    await until(t, () => t.frame().includes("count:2"))
+    act(() => { get().unregister("a"); get().unregister("missing") })
+    await until(t, () => t.frame().includes("count:1"))
+    expect(t.frame()).toContain("ids:b")
+    t.destroy()
+  })
+})


### PR DESCRIPTION
**Chat & composer**
- @-refs accepted from the popover land as styled chips with atomic backspace; pasted-content placeholders get the same treatment; prompt history restores chips and persists as JSONL with legacy lines still loading. Submit emits a structured parts list alongside the text for a future wire migration; the `prompt.submit` payload is unchanged. (#73)
- Show a `▶ N` indicator in the composer status bar while `/background` tasks are running; clears as each task completes. (#74)
- Voice mode: Ctrl+B records, transcribes via the gateway STT pipeline, and auto-sends; recording/transcribing state shows in the composer bar and `/voice` reports the record key. (#71)
- Rapid background-process completions coalesce into one debounced system line instead of one full re-render each. (#71)

**Security**
- New `openUrl` opener: http(s)-only protocol allowlist, argv spawn with no shell, per-platform handlers, and crash-safe error handling for missing openers. Groundwork for clickable URLs in chat. (#72)

**Tests**
- 1037 pass / 0 fail · `bunx tsc --noEmit` clean · `bun run build` clean