### PR TITLE
fix: add missing aux model slots to model picker

### DIFF
--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -27,8 +27,11 @@ export const AUX_TASKS = [
   { key: "skills_hub",       label: "Skills Hub",     hint: "Skill search" },
   { key: "approval",         label: "Approval",       hint: "Smart auto-approve" },
   { key: "mcp",              label: "MCP",            hint: "MCP tool routing" },
-  { key: "title_generation", label: "Title Gen",      hint: "Session titles" },
-  { key: "curator",          label: "Curator",        hint: "Skill-usage review" },
+  { key: "title_generation",  label: "Title Gen",         hint: "Session titles" },
+  { key: "triage_specifier",  label: "Triage Specifier",  hint: "Kanban spec fleshing" },
+  { key: "kanban_decomposer", label: "Kanban Decomposer", hint: "Task decomposition" },
+  { key: "profile_describer", label: "Profile Describer", hint: "Auto profile descriptions" },
+  { key: "curator",           label: "Curator",           hint: "Skill-usage review" },
 ] as const
 
 export type AuxKey = typeof AUX_TASKS[number]["key"]
@@ -45,7 +48,7 @@ const dig = (o: unknown, ...path: string[]): unknown =>
 
 const str = (v: unknown) => typeof v === "string" ? v : ""
 
-/** Project config.yaml → 1 main + 9 aux slots. */
+/** Project config.yaml → 1 main + 12 aux slots. */
 export const readSlots = (raw: Record<string, unknown>): Slot[] => {
   const main: Slot = {
     kind: "main", key: "main", label: "Main model", hint: "Primary agent model",

--- a/test/config-models.test.tsx
+++ b/test/config-models.test.tsx
@@ -79,7 +79,7 @@ describe("Config → models category", () => {
       "cli.exec": (p) => { cli.push(p.argv as string[]); return { code: 0, output: "" } },
     })
     const t = await mountNode(<Config focused />, { gw, width: 160, height: 40 })
-    await until(t, () => t.frame().includes("models (10)"))
+    await until(t, () => t.frame().includes("models (13)"))
 
     // ↓ to 'models', → into slots
     act(() => t.keys.pressArrow("down"))
@@ -124,7 +124,7 @@ describe("Config → models category", () => {
       "config.set": (p) => { sets.push(p); return { value: p.value } },
     })
     const t = await mountNode(<Config focused />, { gw, width: 160, height: 40 })
-    await until(t, () => t.frame().includes("models (10)"))
+    await until(t, () => t.frame().includes("models (13)"))
     act(() => t.keys.pressArrow("down"))
     act(() => t.keys.pressTab())
     act(() => t.keys.pressEnter())


### PR DESCRIPTION
triage_specifier, kanban_decomposer, profile_describer exist in hermes-agent DEFAULT_CONFIG auxiliary section but weren't exposed in herm's AUX_TASKS array, so users couldn't configure them through the TUI model picker.

9→12 aux slots, matching the full DEFAULT_CONFIG auxiliary section from hermes-agent.

### what changed
- `src/config/models.ts`: added 3 missing aux slots to `AUX_TASKS` array
- `test/config-models.test.tsx`: updated slot count from 10→13

### verification
- `bunx tsc --noEmit` — clean
- `bun test test/config-models.test.tsx` — 5/5 pass