### PR TITLE
fix(build): include theme JSON assets in published dist

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -131,6 +131,10 @@ await Bun.write("dist/package.json", JSON.stringify({
 }, null, 2) + "\n")
 
 await $`cp README.md LICENSE dist/`
+// Runtime dynamic-import assets. Bun does not include variable imports
+// like import(`./themes/${name}.json`) in the bundle, so the published
+// package must ship the JSON bodies beside index.js.
+await $`cp -r src/theme/themes dist/themes`
 // Runtime fs-read assets (eikon avatars). These aren't `with {type:
 // "file"}` imports — listEikons() readdirs the directory — so the
 // directory has to ship alongside index.js. bundled.ts resolves it


### PR DESCRIPTION
Bun does not include variable dynamic imports (import(`./themes/${name}.json`)) in the bundle. The published package was missing theme JSON bodies, causing ThemeProvider to return null and paint a blank TUI.

Copy src/theme/themes to dist/themes alongside README/LICENSE, matching the pattern already used for eikon assets. Related #79 