### PR TITLE
fix(slash): route /browser through browser.manage RPC (fix #82)

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -376,6 +376,35 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           return
         }
         case "redraw": redraw(renderer); return
+        case "browser": {
+          // Route /browser through browser.manage RPC instead of slash.exec
+          // so BROWSER_CDP_URL is set in the gateway process where AIAgent runs.
+          // Mirrors ui-tui/src/app/slash/commands/ops.ts (issue #82).
+          const parts = arg.trim().split(/\s+/)
+          const sub = parts[0]?.toLowerCase() || "connect"
+          const url = parts[1]
+          if (!["connect", "disconnect", "status"].includes(sub)) {
+            toast.show({ variant: "error", message: "usage: /browser [connect|disconnect|status] [url]" })
+            return
+          }
+          const payload: Record<string, string> = { action: sub }
+          if (sub === "connect" && url) payload.url = url
+          gw.request<{ connected: boolean; url?: string; messages?: string[] }>("browser.manage", payload)
+            .then(r => {
+              for (const m of r.messages ?? []) {
+                x.dispatch({ kind: "system", text: m })
+              }
+              if (r.connected) {
+                x.dispatch({ kind: "system", text: `Browser connected${r.url ? ` → ${r.url}` : ""}` })
+              } else if (sub === "disconnect") {
+                x.dispatch({ kind: "system", text: "Browser disconnected" })
+              } else if (sub === "status") {
+                x.dispatch({ kind: "system", text: r.url ?? "No browser connected" })
+              }
+            })
+            .catch((e: Error) => toast.show({ variant: "error", message: `browser: ${e.message}` }))
+          return
+        }
         case "compact":
         case "setup":
           x.dispatch({ kind: "system",

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -42,6 +42,8 @@ export const LOCAL_NAMES = new Set([
   "stash",
   // Ink-only UI toggles — local no-op with a note
   "compact", "setup",
+  // browser: use browser.manage RPC, not slash.exec (issue #82)
+  "browser",
 ])
 
 /**
@@ -73,6 +75,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "voice",  description: "Toggle voice recording",               category: "Client",  aliases: [], argsHint: "[on|off|status|tts]", subcommands: ["on", "off", "status", "tts"], source: "local", target: "local" },
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "browser", description: "Connect/disconnect a CDP browser",      category: "Session", aliases: [], argsHint: "[connect|disconnect|status] [url]", subcommands: ["connect", "disconnect", "status"], source: "local", target: "local" },
 ]
 
 /** Filter commands by prefix (text after `/`). Searches names + aliases. */

--- a/test/slash.test.ts
+++ b/test/slash.test.ts
@@ -53,7 +53,7 @@ describe("slash", () => {
   test("LOCAL_NAMES covers session-mutating commands", () => {
     for (const n of ["resume", "branch", "compress", "undo", "retry", "model",
                      "quit", "copy", "paste", "image", "background", "voice",
-                     "mouse", "redraw", "save"])
+                     "mouse", "redraw", "save", "browser"])
       expect(LOCAL_NAMES.has(n)).toBe(true)
   })
 


### PR DESCRIPTION
## What

`/browser` is now handled client-side via the `browser.manage` JSON-RPC instead of being forwarded to `slash.exec` (which runs in an ephemeral HermesCLI subprocess that discards environment mutations).

This mirrors the official Ink TUI (`ui-tui/`) which bypasses `slash.exec` for `/browser` and calls `browser.manage` directly — ensuring `BROWSER_CDP_URL` is set in the gateway process where AIAgent runs.

## Why

Fixes #82 — `/browser connect` appeared to succeed but subsequent browser tool calls used the headless browser because the CDP URL was lost across the subprocess boundary.

## Changes

- **src/app/slashCommands.ts** — add `"browser"` to `LOCAL_NAMES` and `LOCAL_COMMANDS`
- **src/app/slash.tsx** — `case "browser"` handler calling `browser.manage` RPC
- **test/slash.test.ts** — add `"browser"` to session-mutating commands guard

## Testing

- `bun test` passes (all tests)
- `bunx tsc --noEmit` passes (no type errors)