### PR TITLE
fix: bring upstream parity fixes into Herm

### DIFF
--- a/assets/skills/eikon-create/SKILL.md
+++ b/assets/skills/eikon-create/SKILL.md
@@ -81,9 +81,11 @@ chafa --size=48x24 --symbols=braille --colors=none --format=symbols --stretch "<
 ```
 
 Ask: **keep, regenerate, or adjust?** On adjust, fold their note into
-the subject line (leave the suffix alone). Loop. If two rounds fail on
-background clutter, silently append `, isolated on pure black, no
-floor, no environment` and try again.
+the subject line (leave the suffix alone). Loop. **Always overwrite the
+same `<state>.<ext>` in `source/` on every iteration** — Studio reads
+that path live, so a new candidate that lives only in cache is invisible
+to the user. If two rounds fail on background clutter, silently append
+`, isolated on pure black, no floor, no environment` and try again.
 
 ### 3. Adopt
 

--- a/assets/skills/eikon-create/SKILL.md
+++ b/assets/skills/eikon-create/SKILL.md
@@ -66,12 +66,14 @@ Call `image_generate` with the subject on line 1 and the fixed suffix
 on line 2 — same suffix Studio seeds:
 
 ```
-<subject>
+<subject>, close-up portrait emphasizing the face/head, looking slightly left, stark black and white, bold silhouette, simple uncluttered shape
 high contrast, light subject on dark, black background
 ```
 
-Prefer square if the tool takes `aspect_ratio`; if it doesn't, don't
-worry — Studio crops. Show the result inline with `![base](<path>)`
+Keep this general: replace `face/head` with the subject's most readable
+feature if it is not a character or creature. Prefer square if the tool
+takes `aspect_ratio`; if it doesn't, don't worry — Studio crops. Show
+the result inline with `![base](<path>)`
 and a 48-wide terminal preview:
 
 ```bash

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -363,6 +363,42 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setSwitching(false)
     }
   }, [reset, session, goToTab])
+
+  const liveStatus = (state?: string, running = false) => {
+    if (state === "waiting") return "waiting for input…"
+    if (state === "starting") return "starting agent…"
+    return running || state === "working" ? "running…" : "ready"
+  }
+
+  const activateSession = useCallback(async (target: string) => {
+    const prev = sidRef.current
+    reset()
+    summoned.current = true
+    setSplash(true)
+    setSwitching(true)
+    goToTab(CHAT_TAB)
+    try {
+      const res = await session.activate(target)
+      setSid(res.id)
+      if (res.info) {
+        setInfo(res.info)
+        setUsage(res.info.usage)
+      }
+      sessionStart.current = res.startedAt ?? Date.now()
+      dispatch({ kind: "load.live", messages: res.messages, streaming: res.running })
+      setStatus(liveStatus(res.status, res.running))
+      setReady(true)
+      setSplash(false)
+      summoned.current = false
+      if (prev && prev !== res.id) toast.show({ variant: "info", message: "switched live session" })
+    } catch (err) {
+      dispatch({ kind: "system", text: `Failed to activate: ${err instanceof Error ? err.message : String(err)}` })
+      setSplash(false)
+      summoned.current = false
+    } finally {
+      setSwitching(false)
+    }
+  }, [reset, session, goToTab, toast])
   // Rebind every HERMES_HOME reader, respawn the gateway subprocess
   // under the new env, and re-run the boot path. prefs.reload (inside
   // rehome) retints theme/eikon/keys via usePref; home.reset repaints
@@ -695,7 +731,9 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
         case SESSIONS_TAB: return <SessionsGroup focused={contentFocused}
                                                  sub={subTabs[SESSIONS_TAB] ?? 0}
                                                  setSub={sessSub}
-                                                 onSwitch={switchSession} currentId={sid}
+                                                 onSwitch={switchSession}
+                                                 onActivateLive={activateSession}
+                                                 currentId={sid}
                                                  messages={turn.messages}
                                                  sessionStart={sessionStart.current}
                                                  info={info ?? undefined} />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -54,13 +54,13 @@ import { BackgroundProvider } from "./app/background"
 import { useVoice } from "./voice/useVoice"
 import { VoiceIndicator } from "./voice/Indicator"
 
-type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch }
+type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch; keyOverrides?: Record<string, string> }
 
 export const App = (props: AppProps) => (
   <ThemeProvider initial={props.initialTheme}>
     <GatewayProvider client={props.gateway}>
       <ToastProvider>
-        <KeysProvider>
+        <KeysProvider overrides={props.keyOverrides}>
           <DialogProvider>
             <CommandProvider>
               <PluginProvider>

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -376,6 +376,35 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           return
         }
         case "redraw": redraw(renderer); return
+        case "browser": {
+          // Route /browser through browser.manage RPC instead of slash.exec
+          // so BROWSER_CDP_URL is set in the gateway process where AIAgent runs.
+          // Mirrors ui-tui/src/app/slash/commands/ops.ts (issue #82).
+          const parts = arg.trim().split(/\s+/)
+          const sub = parts[0]?.toLowerCase() || "connect"
+          const url = parts[1]
+          if (!["connect", "disconnect", "status"].includes(sub)) {
+            toast.show({ variant: "error", message: "usage: /browser [connect|disconnect|status] [url]" })
+            return
+          }
+          const payload: Record<string, string> = { action: sub }
+          if (sub === "connect" && url) payload.url = url
+          gw.request<{ connected: boolean; url?: string; messages?: string[] }>("browser.manage", payload)
+            .then(r => {
+              for (const m of r.messages ?? []) {
+                x.dispatch({ kind: "system", text: m })
+              }
+              if (r.connected) {
+                x.dispatch({ kind: "system", text: `Browser connected${r.url ? ` → ${r.url}` : ""}` })
+              } else if (sub === "disconnect") {
+                x.dispatch({ kind: "system", text: "Browser disconnected" })
+              } else if (sub === "status") {
+                x.dispatch({ kind: "system", text: r.url ?? "No browser connected" })
+              }
+            })
+            .catch((e: Error) => toast.show({ variant: "error", message: `browser: ${e.message}` }))
+          return
+        }
         case "compact":
         case "setup":
           x.dispatch({ kind: "system",

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -2,9 +2,9 @@
  * Slash command definitions for the chat input.
  *
  * Commands are fetched dynamically from Hermes `GET /api/commands` — the
- * unified registry of built-ins + skills + plugins + MCP prompts. There is
- * no static fallback: if the gateway is unreachable, no slash commands are
- * available (the popover simply won't open).
+ * unified registry of built-ins + skills + plugins + MCP prompts. Local
+ * commands are kept as a fallback while the gateway is unreachable and are
+ * merged with the gateway catalog once it is ready.
  *
  * `target` is derived: "local" if the name is a client-handled command,
  * otherwise "gateway" (forwarded as /{name} to the Hermes API).
@@ -71,6 +71,8 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "goal",   description: "Set/control the session goal",        category: "Session", aliases: [], argsHint: "[text|done|pause|resume|clear|status]", subcommands: ["done", "pause", "resume", "clear", "status"], source: "command", target: "gateway" },
   { name: "skin",   description: "Switch Hermes skin (+ theme + eikon)", category: "Client",  aliases: [], argsHint: "[name]", subcommands: [...SKINS], source: "local", target: "local" },
   { name: "voice",  description: "Toggle voice recording",               category: "Client",  aliases: [], argsHint: "[on|off|status|tts]", subcommands: ["on", "off", "status", "tts"], source: "local", target: "local" },
+  { name: "queue",  description: "Queue a prompt for the next idle turn", category: "Session", aliases: ["q"], argsHint: "[text]", subcommands: [], source: "local", target: "local" },
+  { name: "quit",   description: "Exit herm",                             category: "Exit",    aliases: ["exit"], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
 ]

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -42,6 +42,8 @@ export const LOCAL_NAMES = new Set([
   "stash",
   // Ink-only UI toggles — local no-op with a note
   "compact", "setup",
+  // browser: use browser.manage RPC, not slash.exec (issue #82)
+  "browser",
 ])
 
 /**
@@ -75,6 +77,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "quit",   description: "Exit herm",                             category: "Exit",    aliases: ["exit"], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "browser", description: "Connect/disconnect a CDP browser",      category: "Session", aliases: [], argsHint: "[connect|disconnect|status] [url]", subcommands: ["connect", "disconnect", "status"], source: "local", target: "local" },
 ]
 
 /** Filter commands by prefix (text after `/`). Searches names + aliases. */

--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -149,7 +149,7 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
     }
 
     case "thinking":
-      return { ...state, messages: upsertThinking(state.messages, sanitize(a.text), a.final) }
+      return { ...state, messages: upsertThinking(state.messages, sanitize(a.text), a.final, a.verbose) }
 
     case "subagent":
       return { ...state, messages: renderSubagent(state.messages, a.event, a.payload) }
@@ -351,7 +351,7 @@ function updatePrompt(messages: Message[], id: string, fn: (p: PromptPart) => Pr
   })
 }
 
-function upsertThinking(messages: Message[], text: string, final: boolean): Message[] {
+function upsertThinking(messages: Message[], text: string, final: boolean, verbose?: boolean): Message[] {
   return withLastAssistant(
     messages,
     m => {
@@ -363,12 +363,12 @@ function upsertThinking(messages: Message[], text: string, final: boolean): Mess
         // have one. Matches Ink turnController.recordReasoningAvailable.
         const content = final ? prev.content.trim() || text : prev.content + text
         const parts = [...m.parts]
-        parts[idx] = { ...prev, content, streaming: !final }
+        parts[idx] = { ...prev, content, streaming: !final, verbose: prev.verbose || verbose || undefined }
         return { ...m, parts }
       }
-      return { ...m, parts: [{ type: "thinking" as const, key: pid(), content: text, streaming: !final }, ...m.parts] }
+      return { ...m, parts: [{ type: "thinking" as const, key: pid(), content: text, streaming: !final, verbose }, ...m.parts] }
     },
-    () => assistant([{ type: "thinking", key: pid(), content: text, streaming: !final }]),
+    () => assistant([{ type: "thinking", key: pid(), content: text, streaming: !final, verbose }]),
   )
 }
 

--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -24,6 +24,7 @@ export const initialTurn: TurnState = {
 export type Action =
   | { kind: "reset" }
   | { kind: "load"; messages: Message[] }
+  | { kind: "load.live"; messages: Message[]; streaming: boolean }
   | { kind: "push"; message: Message }
   | { kind: "user"; text: string }
   | { kind: "system"; text: string }
@@ -48,6 +49,14 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
 
     case "load":
       return { ...initialTurn, messages: a.messages }
+
+    case "load.live":
+      return {
+        ...initialTurn,
+        messages: a.messages,
+        streaming: a.streaming,
+        hasContent: a.streaming && Boolean(joinText(a.messages.at(-1)?.parts ?? [])),
+      }
 
     case "push":
       return { ...state, messages: [...state.messages, a.message] }

--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -30,11 +30,11 @@ export type Action =
   | { kind: "message.start" }
   | { kind: "message.delta"; chunk: string }
   | { kind: "message.complete"; text?: string; usage?: Usage }
-  | { kind: "tool.start"; id: string; name: string; preview?: string }
+  | { kind: "tool.start"; id: string; name: string; preview?: string; args?: string }
   | { kind: "tool.progress"; name?: string; preview?: string }
   | { kind: "tool.generating"; name?: string }
-  | { kind: "tool.complete"; id: string; summary?: string; error?: string; inline_diff?: string }
-  | { kind: "thinking"; text: string; final: boolean }
+  | { kind: "tool.complete"; id: string; summary?: string; error?: string; inline_diff?: string; duration?: number; result?: string }
+  | { kind: "thinking"; text: string; final: boolean; verbose?: boolean }
   | { kind: "subagent"; event: "start" | "thinking" | "tool" | "progress" | "complete"; payload: SubagentPayload }
   | { kind: "prompt"; id: string; req: PromptReq }
   | { kind: "prompt.answered"; id: string; label: string; ok: boolean }
@@ -85,12 +85,15 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
       // `context` carries the raw tool input; when JSON-shaped we keep it
       // as args so the UI can render KV lines on expand.
       const preview = sanitize(a.preview)
-      const json = preview && /^\s*\{/.test(preview)
+      const args = sanitize(a.args)
+      const raw = args || preview
+      const json = raw && /^\s*\{/.test(raw)
       const part: ToolPart = {
         type: "tool", id: a.id, name: a.name,
-        args: json ? preview : "",
+        args: json ? raw : "",
         status: "running", startedAt: Date.now(),
         preview: preview || undefined,
+        verboseArgs: args || undefined,
       }
       return {
         ...state,
@@ -120,15 +123,17 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
       const summary = sanitize(a.summary)
       const error = sanitize(a.error)
       const diff = sanitize(a.inline_diff)
+      const result = sanitize(a.result)
       return {
         ...state,
         toolActive: false,
         messages: updateToolById(state.messages, a.id, p => ({
           ...p,
           status: (a.error ? "error" : "done") as ToolPart["status"],
-          duration: p.startedAt ? Date.now() - p.startedAt : undefined,
+          duration: a.duration ?? (p.startedAt ? Date.now() - p.startedAt : undefined),
           preview: summary || diff || p.preview,
           result: error || summary || undefined,
+          verboseResult: result || undefined,
           diff: diff || undefined,
         })),
       }

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -8,8 +8,10 @@ import { transcriptToMessages } from "./turnReducer"
 import type { Launch } from "./launch"
 import type {
   SessionResumeResponse,
+  SessionActivateResponse,
   SessionCreateResponse,
   SessionInfo,
+  SessionInflightTurn,
   TranscriptMessage,
 } from "../context/wire"
 import type { Message, Usage } from "../types/message"
@@ -47,6 +49,7 @@ export type CompressResult = {
 }
 
 type Booted = { id: string; messages: Message[]; note?: string }
+type Activated = { id: string; messages: Message[]; info?: SessionInfo; running: boolean; status?: string; startedAt?: number }
 
 export const normalize = (sid: string): string =>
   sid.trim().replace(/\.json$/i, "").replace(/^session_(?=\d{8}_)/, "")
@@ -56,6 +59,7 @@ type SessionOps = {
   boot: (launch: Launch) => Promise<Booted>
   create: () => Promise<string>
   resume: (sid: string) => Promise<{ id: string; messages: Message[] }>
+  activate: (sid: string) => Promise<Activated>
   /** Finalize a gateway session (best-effort — swallows errors). */
   close: (sid: string) => Promise<void>
   interrupt: () => Promise<void>
@@ -66,6 +70,15 @@ type SessionOps = {
 
 export function useSession(): SessionOps {
   const gw = useGateway()
+
+  const inflightMessages = (inflight?: SessionInflightTurn | null): Message[] => {
+    const user = String(inflight?.user ?? "").trim()
+    const assistant = String(inflight?.assistant ?? "")
+    const messages: Message[] = []
+    if (user) messages.push(...transcriptToMessages([{ role: "user", text: user }]))
+    if (assistant || inflight?.streaming) messages.push(...transcriptToMessages([{ role: "assistant", text: assistant }]))
+    return messages
+  }
 
   const resume = useCallback(async (sid: string) => {
     // Normalize at the edge (argv / slash-arg can be `session_*.json`).
@@ -93,6 +106,24 @@ export function useSession(): SessionOps {
     const res = await gw.request<SessionCreateResponse>("session.create", {})
     gw.setSession(res.session_id)
     return res.session_id
+  }, [gw])
+
+  const activate = useCallback(async (sid: string): Promise<Activated> => {
+    const target = normalize(sid)
+    const res = await gw.request<SessionActivateResponse>("session.activate", { session_id: target })
+    const id = res.session_id
+    gw.setSession(id)
+    preferences.set("lastSessionId", res.session_key ?? id)
+    const history = res.messages?.length ? transcriptToMessages(res.messages) : []
+    const running = Boolean(res.running || res.status === "working" || res.status === "waiting")
+    return {
+      id,
+      info: res.info,
+      messages: [...history, ...inflightMessages(res.inflight)],
+      running,
+      startedAt: res.started_at ? res.started_at * 1000 : undefined,
+      status: res.status,
+    }
   }, [gw])
 
   // Finalize a gateway session: marks the DB row ended, tears down the
@@ -156,7 +187,7 @@ export function useSession(): SessionOps {
   }, [gw])
 
   return useMemo(
-    () => ({ boot, create, resume, close, interrupt, branch, compress, undo }),
-    [boot, create, resume, close, interrupt, branch, compress, undo],
+    () => ({ boot, create, resume, activate, close, interrupt, branch, compress, undo }),
+    [boot, create, resume, activate, close, interrupt, branch, compress, undo],
   )
 }

--- a/src/app/useSlashCommands.ts
+++ b/src/app/useSlashCommands.ts
@@ -37,11 +37,16 @@ export function useSlashCommands() {
 
     // canonical → aliases[] (invert canon)
     const alias = new Map<string, string[]>()
-    for (const [a, c] of Object.entries(res.canon ?? {})) {
-      const k = bare(c), v = bare(a)
-      if (k === v) continue
-      ;(alias.get(k) ?? alias.set(k, []).get(k)!).push(v)
+    const addAlias = (name: string, value: string) => {
+      const k = bare(name), v = bare(value)
+      if (k === v) return
+      const list = alias.get(k) ?? []
+      if (!list.includes(v)) alias.set(k, [...list, v])
     }
+    for (const l of LOCAL_COMMANDS)
+      for (const a of l.aliases) addAlias(l.name, a)
+    for (const [a, c] of Object.entries(res.canon ?? {}))
+      addAlias(c, a)
 
     const sub = new Map(Object.entries(res.sub ?? {}).map(([k, v]) => [bare(k), v]))
     const local = new Map(LOCAL_COMMANDS.map(c => [c.name, c]))

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -103,6 +103,7 @@ export function useStream(c: Ctx) {
 
   const handle = useCallback((ev: GatewayEvent) => {
     const x = ctx.current
+    if (ev.session_id && x.sidRef.current && ev.session_id !== x.sidRef.current && !ev.type.startsWith("gateway.")) return
     // The agent's stream-retry loop (run_agent._call) classifies the
     // force-closed httpx socket from an interrupt as a transient drop
     // and emits "Reconnecting…" lifecycle status before the top-of-loop

--- a/src/components/chat/tool/frame.tsx
+++ b/src/components/chat/tool/frame.tsx
@@ -16,12 +16,15 @@ function ms(d?: number): string {
   return `${Math.floor(d / 60000)}m${Math.round((d % 60000) / 1000)}s`
 }
 
+export type Detail = { label: string; text: string }
+
 type InlineProps = {
   part: ToolPart
   /** Content for the collapsed row; usually preview text. */
   children: ReactNode
   /** True once enough input exists to show `children` instead of pending. */
   complete?: boolean
+  details?: Detail[]
   iconColor?: RGBA
   onClick?: () => void
 }
@@ -63,6 +66,12 @@ export const InlineTool = memo((p: InlineProps) => {
           <text fg={theme.error} wrapMode="word">{p.part.result}</text>
         </box>
       ) : null}
+      {p.details?.map(d => (
+        <box key={d.label} flexDirection="column" paddingLeft={2} marginTop={1}>
+          <box height={1}><text fg={theme.textMuted}>{d.label}</text></box>
+          <box minHeight={1}><text fg={theme.textMuted} wrapMode="word">{d.text}</text></box>
+        </box>
+      ))}
     </box>
   )
 })

--- a/src/components/chat/tool/index.tsx
+++ b/src/components/chat/tool/index.tsx
@@ -1,18 +1,14 @@
 // Per-tool dispatch — oc's `<Switch>` over part.tool. Each hermes
 // tool name maps to either an InlineTool row or a BlockTool card.
 //
-// Data constraint: the stock tui_gateway emits only
-//   tool.start    {name, context: build_tool_preview() string ≤80ch}
-//   tool.complete {summary, inline_diff?, error?, duration_s}
-// — NOT the raw args JSON or the tool result body. So per-tool
-// *bodies* (bash stdout, todo checklist, grep matches) are blocked
-// on the wire carrying more (→ docs/UPSTREAM.md). The dispatch and
-// frame grammar here are ready for them.
+// Gateway rows stay compact by default: context/summary/inline_diff
+// feed the one-line row, while redacted verbose args/results render
+// only when the existing detail mode is expanded.
 
 import { memo } from "react"
 import type { ToolPart as Part } from "../../../types/message"
 import type { DetailMode } from "../../../context/preferences"
-import { InlineTool } from "./frame"
+import { InlineTool, type Detail } from "./frame"
 import { Subagent } from "./Subagent"
 import { spec } from "./preview"
 
@@ -35,5 +31,16 @@ const Inline = memo(({ tool }: { tool: Part }) => {
 export const Tool = memo(({ tool, detail = "expanded" }: { tool: Part; detail?: DetailMode }) => {
   if (detail === "hidden" && tool.status !== "running") return null
   if (tool.trail || tool.name === "delegate_task") return <Subagent tool={tool} />
-  return <Inline tool={tool} />
+  if (detail !== "expanded") return <Inline tool={tool} />
+  const details = [
+    tool.verboseArgs ? { label: "Args", text: tool.verboseArgs } : undefined,
+    tool.verboseResult ? { label: tool.status === "error" ? "Error" : "Result", text: tool.verboseResult } : undefined,
+  ].filter((d): d is Detail => !!d)
+  const s = spec(tool.name)
+  const body = tool.preview ? short(tool.preview) : ""
+  return (
+    <InlineTool part={tool} complete={!!body || tool.status !== "running"} details={details}>
+      {s.verb ? `${s.verb} ${body}` : body || tool.name}
+    </InlineTool>
+  )
 })

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -87,6 +87,7 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
         id: ev.payload.tool_id,
         name: ev.payload.name ?? "unknown",
         preview: ev.payload.context,
+        args: ev.payload.args_text,
       }
 
     case "tool.progress":
@@ -102,6 +103,8 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
         summary: ev.payload.summary,
         error: ev.payload.error,
         inline_diff: ev.payload.inline_diff,
+        duration: typeof ev.payload.duration_s === "number" ? ev.payload.duration_s * 1000 : undefined,
+        result: ev.payload.result_text,
       }
 
     case "thinking.delta":
@@ -114,7 +117,7 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
     case "reasoning.available": {
       const text = ev.payload?.text
       if (!text) return null
-      return { kind: "thinking", text, final: ev.type === "reasoning.available" }
+      return { kind: "thinking", text, final: ev.type === "reasoning.available", verbose: ev.payload?.verbose }
     }
 
     case "subagent.start":

--- a/src/context/gateway-client.ts
+++ b/src/context/gateway-client.ts
@@ -14,11 +14,16 @@ const REQUEST_MS = 120_000
 
 /** Locate the hermes-agent source tree (gateway + hermes_cli live here).
  *  Default: ~/.hermes/hermes-agent (where `hermes update` installs it).
+ *  Fallback: /usr/local/lib/hermes-agent (FHS layout for root Linux installs).
  *  Override with HERMES_AGENT_ROOT for dev clones / exotic layouts. */
 export function hermesAgentRoot(): string {
   if (process.env.HERMES_AGENT_ROOT) return process.env.HERMES_AGENT_ROOT
   const home = process.env.HOME || homedir()
-  return `${home}/.hermes/hermes-agent`
+  const homePath = `${home}/.hermes/hermes-agent`
+  if (existsSync(homePath)) return homePath
+  const fhs = "/usr/local/lib/hermes-agent"
+  if (existsSync(fhs)) return fhs
+  return homePath
 }
 
 type Pending = {

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -146,6 +146,12 @@ export type SessionInfo = {
   model?: string
   cwd?: string
   session_id?: string
+  /**
+   * Live tool catalog from gateway session.info. state.db is canonical for
+   * historical sessions, while legacy sessions/session_*.json snapshots are
+   * optional debug files; current tool counts should come from this wire
+   * payload when available.
+   */
   tools?: Record<string, string[]>
   skills?: Record<string, string[]>
   version?: string

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -2,7 +2,9 @@
 
 import type { Usage } from "../types/message"
 
-export type GatewayEvent =
+export type GatewayEvent = ({
+  session_id?: string
+} & (
   | { type: "gateway.ready"; payload?: { skin?: GatewaySkin } }
   | { type: "gateway.stderr"; payload: { line: string } }
   | { type: "gateway.start_timeout"; payload?: { cwd?: string; python?: string } }
@@ -36,6 +38,7 @@ export type GatewayEvent =
   | { type: "subagent.progress"; payload: SubagentPayload }
   | { type: "subagent.complete"; payload: SubagentPayload }
   | { type: "error"; payload?: { message?: string } }
+))
 
 export type SubagentPayload = {
   task_index: number

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -13,13 +13,13 @@ export type GatewayEvent =
   | { type: "message.delta"; payload?: { text?: string; rendered?: string } }
   | { type: "message.complete"; payload?: { text?: string | null; rendered?: string; reasoning?: string; status?: "complete" | "error" | "interrupted"; usage?: Usage } }
   | { type: "thinking.delta"; payload?: { text?: string } }
-  | { type: "reasoning.delta"; payload?: { text?: string } }
-  | { type: "reasoning.available"; payload?: { text?: string } }
+  | { type: "reasoning.delta"; payload?: { text?: string; verbose?: boolean } }
+  | { type: "reasoning.available"; payload?: { text?: string; verbose?: boolean } }
   | { type: "status.update"; payload?: { text?: string; kind?: string } }
-  | { type: "tool.start"; payload: { tool_id: string; name?: string; context?: string } }
+  | { type: "tool.start"; payload: { tool_id: string; name?: string; context?: string; args_text?: string; todos?: unknown[] } }
   | { type: "tool.progress"; payload: { name?: string; preview?: string } }
   | { type: "tool.generating"; payload: { name?: string } }
-  | { type: "tool.complete"; payload: { tool_id: string; name?: string; summary?: string; error?: string; inline_diff?: string } }
+  | { type: "tool.complete"; payload: { tool_id: string; name?: string; summary?: string; error?: string; inline_diff?: string; duration_s?: number; result_text?: string; todos?: unknown[] } }
   | { type: "clarify.request"; payload: { request_id: string; question: string; choices: string[] | null } }
   | { type: "approval.request"; payload: { command: string; description: string; pattern_keys?: string[] } }
   | { type: "sudo.request"; payload: { request_id: string } }

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -197,6 +197,43 @@ export type SessionResumeResponse = {
   info?: SessionInfo
 }
 
+export type LiveSessionStatus = "idle" | "starting" | "waiting" | "working"
+
+export type SessionActiveItem = {
+  id: string
+  session_key?: string
+  title?: string
+  preview?: string
+  model?: string
+  status: LiveSessionStatus
+  current?: boolean
+  message_count?: number
+  started_at?: number
+  last_active?: number
+}
+
+export type SessionActiveListResponse = {
+  sessions?: SessionActiveItem[]
+}
+
+export type SessionInflightTurn = {
+  user?: string
+  assistant?: string
+  streaming?: boolean
+}
+
+export type SessionActivateResponse = {
+  session_id: string
+  session_key?: string
+  messages: TranscriptMessage[]
+  message_count?: number
+  info?: SessionInfo
+  running?: boolean
+  status?: LiveSessionStatus
+  started_at?: number
+  inflight?: SessionInflightTurn | null
+}
+
 export type SessionListItem = {
   id: string
   title: string

--- a/src/home/store.ts
+++ b/src/home/store.ts
@@ -100,6 +100,8 @@ const SLICES: Slices = {
     watch: () => [hermesPath("SOUL.md")],
   },
   liveSessions: {
+    // Optional legacy/debug file. state.db is the persisted session source;
+    // current runtime facts come from gateway session.info.
     read: () => readLiveSessions(),
     watch: () => [hermesPath("sessions/sessions.json")],
   },
@@ -123,8 +125,9 @@ const SLICES: Slices = {
     }).catch(() => null),
   },
   toolsInfo: {
-    // Scans sessions/ for newest session_*.json — watching the dir picks
-    // up new files without tracking a specific one.
+    // Optional legacy/debug snapshot fallback. Context prefers live
+    // gateway session.info; this only preserves older profiles that still
+    // emit session_*.json tool schemas.
     read: () => readToolsFromLatestSession(),
     watch: () => [hermesPath("sessions")],
   },

--- a/src/keys/context.tsx
+++ b/src/keys/context.tsx
@@ -40,9 +40,10 @@ const Ctx = createContext<Keys | null>(null)
 
 const NO_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({})
 
-export const KeysProvider = ({ children }: { children: ReactNode }) => {
+export const KeysProvider = ({ children, overrides: fixedOverrides }: { children: ReactNode; overrides?: Record<string, string> }) => {
   const renderer = useRenderer()
-  const overrides = usePref("keys") ?? NO_OVERRIDES
+  const prefOverrides = usePref("keys")
+  const overrides = fixedOverrides ?? prefOverrides ?? NO_OVERRIDES
 
   // id → Chord[] computed once per overrides identity. Leader's own chord
   // is looked up from the same table so it's rebindable.

--- a/src/service/hermes-home.ts
+++ b/src/service/hermes-home.ts
@@ -10,7 +10,7 @@
 
 import { Database } from "bun:sqlite";
 import { readdir, stat } from "node:fs/promises";
-import { openSync, readSync, closeSync, readdirSync, readFileSync } from "node:fs";
+import { openSync, readSync, closeSync, readdirSync, readFileSync, existsSync } from "node:fs";
 import { homedir } from "os";
 import { parse as parseYaml } from "yaml";
 import { count as tokenCount } from "../utils/tokens";
@@ -127,7 +127,7 @@ export interface MemoryFileInfo {
 /** A row from the sessions table in state.db — see sessions-db.ts. */
 export type { SessionRow } from "./sessions-db"
 
-/** Live session entry from sessions/sessions.json */
+/** Legacy live session entry from optional sessions/sessions.json. */
 export interface LiveSession {
   session_key: string;
   session_id: string;
@@ -154,7 +154,7 @@ export interface LiveSession {
   };
 }
 
-/** A tool schema from the session JSON */
+/** A tool schema from live session.info or a legacy debug session JSON. */
 export interface ToolInfo {
   name: string;
   descriptionLength: number;
@@ -442,7 +442,7 @@ export interface SystemPromptInfo {
   tokenEstimate: number;
 }
 
-/** Tool list with its source session file */
+/** Tool list with its source. */
 export interface ToolsInfo {
   source: Source;
   tools: ToolInfo[];
@@ -530,12 +530,19 @@ export async function readMemoryFile(
   }
 }
 
-/** Read sessions/sessions.json (live session index) */
+/**
+ * Read optional legacy sessions/sessions.json.
+ *
+ * state.db is canonical for persisted sessions. This file is only present
+ * when Hermes is configured to emit debug/legacy snapshots, so absence is
+ * expected and must read as an empty map.
+ */
 export async function readLiveSessions(): Promise<
   Record<string, LiveSession>
 > {
   try {
     const file = Bun.file(hermesPath("sessions/sessions.json"));
+    if (!(await file.exists())) return {};
     const text = await file.text();
     return JSON.parse(text);
   } catch {
@@ -642,14 +649,16 @@ export async function readSoul(): Promise<SoulInfo | null> {
   }
 }
 
-/** Read tool list from the most recent session JSON */
+/** Read tool list from the most recent optional legacy session JSON. */
 export async function readToolsFromLatestSession(): Promise<ToolsInfo | null> {
   try {
+    const dir = hermesPath("sessions");
+    if (!existsSync(dir)) return null;
     const glob = new Bun.Glob("session_*.json");
     let latestPath = "";
     let latestTime = 0;
 
-    for await (const path of glob.scan({ cwd: hermesPath("sessions") })) {
+    for await (const path of glob.scan({ cwd: dir })) {
       const file = Bun.file(hermesPath(`sessions/${path}`));
       const stat = await file.stat();
       if (stat && stat.mtimeMs > latestTime) {

--- a/src/service/hermes-kanban.ts
+++ b/src/service/hermes-kanban.ts
@@ -34,7 +34,7 @@
 //   create-time-only.
 
 import { Database } from "bun:sqlite"
-import { existsSync, readdirSync, statSync, openSync, readSync, closeSync, readFileSync } from "node:fs"
+import { existsSync, readdirSync, statSync, openSync, readSync, closeSync, readFileSync, fstatSync } from "node:fs"
 import { hermesPath } from "./hermes-home"
 
 // Order matches the CLI's status enumeration so columns line up
@@ -274,9 +274,16 @@ const rwOf = (s: string): Database | null => {
   if (!existsSync(dbPath(s))) return null
   try {
     const db = new Database(dbPath(s))
-    // Match kanban_db.connect() pragmas. WAL is a no-op after the first
-    // time but cheap; synchronous=NORMAL matches upstream.
-    db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA foreign_keys=ON")
+    const mode = db.query("PRAGMA journal_mode").get() as Record<string, unknown> | null
+    if (String(Object.values(mode ?? {})[0] ?? "").toLowerCase() !== "wal")
+      db.exec("PRAGMA journal_mode=WAL")
+    db.exec([
+      "PRAGMA synchronous=FULL",
+      "PRAGMA wal_autocheckpoint=100",
+      "PRAGMA secure_delete=ON",
+      "PRAGMA cell_size_check=ON",
+      "PRAGMA foreign_keys=ON",
+    ].join(";"))
     h.rw = db
     return db
   } catch { return null }
@@ -552,6 +559,50 @@ export function assignees(s: string = slug): string[] {
 // states only; herm doesn't have a drag affordance, so the simpler
 // "verbs for status, raw for fields" split is enough.
 
+export function kanbanWritePragmas(s: string = slug): Record<string, string | number | null> | null {
+  const conn = rwOf(s)
+  if (!conn) return null
+  const read = (sql: string): string | number | null => {
+    const row = conn.query(sql).get() as Record<string, unknown> | null
+    const val = Object.values(row ?? {})[0]
+    return typeof val === "string" || typeof val === "number" ? val : null
+  }
+  return {
+    journal_mode: read("PRAGMA journal_mode"),
+    synchronous: read("PRAGMA synchronous"),
+    wal_autocheckpoint: read("PRAGMA wal_autocheckpoint"),
+    secure_delete: read("PRAGMA secure_delete"),
+    cell_size_check: read("PRAGMA cell_size_check"),
+    foreign_keys: read("PRAGMA foreign_keys"),
+  }
+}
+
+function checkFileLength(conn: Database) {
+  try {
+    const row = conn.query("PRAGMA database_list").get() as Record<string, unknown> | null
+    const path = String(row?.file ?? row?.[2] ?? "")
+    if (!path) return
+    const pageRow = conn.query("PRAGMA page_size").get() as Record<string, unknown> | null
+    const pageSize = Number(Object.values(pageRow ?? {})[0])
+    if (!pageSize) return
+    const fd = openSync(path, "r")
+    try {
+      const buf = Buffer.alloc(4)
+      if (readSync(fd, buf, 0, 4, 28) < 4) return
+      const headerPages = buf.readUInt32BE(0)
+      if (!headerPages) return
+      const actualPages = Math.floor(fstatSync(fd).size / pageSize)
+      if (actualPages < headerPages)
+        throw new Error(
+          `torn-extend detected: page count mismatch on ${path}: ` +
+          `header claims ${headerPages} pages, file has ${actualPages} pages`,
+        )
+    } finally { closeSync(fd) }
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("torn-extend detected")) throw err
+  }
+}
+
 /** Wrap `fn` in a BEGIN IMMEDIATE txn on `conn`. Mirrors
  *  kanban_db.write_txn — IMMEDIATE takes the reserved lock up front so
  *  concurrent writers fail fast instead of racing mid-txn. */
@@ -560,6 +611,7 @@ function writeTxn<T>(conn: Database, fn: () => T): T {
   try {
     const out = fn()
     conn.exec("COMMIT")
+    checkFileLength(conn)
     return out
   } catch (err) {
     try { conn.exec("ROLLBACK") } catch {}

--- a/src/service/hermes-kanban.ts
+++ b/src/service/hermes-kanban.ts
@@ -85,6 +85,18 @@ export type Detail = Task & {
 }
 
 export type Board = { slug: string; name: string }
+
+export type BoardErrorKind = "corrupt" | "unreadable" | "query"
+export type BoardError = {
+  kind: BoardErrorKind
+  path: string
+  message: string
+}
+export type BoardState = {
+  columns: Map<Status, Task[]>
+  error: BoardError | null
+  corruptBackups: string[]
+}
 // Fetched by shelling `hermes kanban --board <slug> diagnostics --json`.
 // Parsed here so Kanban.tsx holds only the UI shape. The Python rule
 // engine (hermes_cli/kanban_diagnostics.py, ~650 LOC) owns all rule
@@ -235,12 +247,19 @@ let slug = resolve()
  *  the WAL/foreign_keys pragmas and serves patches. */
 type Handles = { ro: Database | null; rw: Database | null }
 const handles = new Map<string, Handles>()
+const errors = new Map<string, BoardError>()
+
+const SQLITE_HEADER = Buffer.from("SQLite format 3\0", "binary")
+const CORRUPT_BACKUP = /^kanban\.db\.corrupt\..+\.bak$/
 
 export const currentBoard = () => slug
 
 /** default keeps legacy <root>/kanban.db; others live under boards/<slug>/. */
 const dbPath = (s: string) =>
   kp(s === DEFAULT ? "kanban.db" : `kanban/boards/${s}/kanban.db`)
+
+const dbDir = (s: string) =>
+  kp(s === DEFAULT ? "" : `kanban/boards/${s}`)
 
 const logsDir = (s: string) =>
   kp(s === DEFAULT ? "kanban/logs" : `kanban/boards/${s}/logs`)
@@ -253,14 +272,62 @@ const pair = (s: string): Handles => {
   return next
 }
 
+const emptyBoard = (): Map<Status, Task[]> =>
+  new Map<Status, Task[]>(STATUSES.map(k => [k, []]))
+
+const boardErr = (kind: BoardErrorKind, path: string, msg: string): BoardError => ({
+  kind, path, message: msg,
+})
+
+const isCorrupt = (err: unknown): boolean => {
+  const msg = String((err as Error)?.message ?? err).toLowerCase()
+  return msg.includes("not a database")
+    || msg.includes("malformed")
+    || msg.includes("database disk image")
+    || msg.includes("file is not a database")
+}
+
+const headerError = (path: string): BoardError | null => {
+  let st
+  try { st = statSync(path) }
+  catch (e) {
+    const code = (e as NodeJS.ErrnoException).code
+    return code === "ENOENT" ? null : boardErr("unreadable", path, String((e as Error).message ?? e))
+  }
+  if (st.size === 0) return null
+  let fd = -1
+  try {
+    fd = openSync(path, "r")
+    const head = Buffer.alloc(SQLITE_HEADER.length)
+    const n = readSync(fd, head, 0, head.length, 0)
+    if (n >= SQLITE_HEADER.length && head.subarray(0, SQLITE_HEADER.length).equals(SQLITE_HEADER)) return null
+    return boardErr("corrupt", path,
+      `invalid SQLite header; first_32=${head.subarray(0, Math.min(32, n)).toString("hex").match(/../g)?.join(" ") ?? ""}`)
+  } catch (e) {
+    return boardErr("unreadable", path, String((e as Error).message ?? e))
+  } finally {
+    if (fd >= 0) try { closeSync(fd) } catch {}
+  }
+}
+
 const dbOf = (s: string): Database | null => {
   const h = pair(s)
   if (h.ro) return h.ro
+  const path = dbPath(s)
+  if (!existsSync(path)) { errors.delete(s); return null }
+  const hdr = headerError(path)
+  if (hdr) { errors.set(s, hdr); return null }
   // Not { readonly: true } — Bun 1.3.x readonly mode can fail with
   // "unable to open database file" on WAL DBs whose sidecars don't
   // exist yet (gh#29). RW-no-create is safe: we only SELECT on this
   // handle, and create:false still throws when the file is absent.
-  try { h.ro = new Database(dbPath(s), { readwrite: true, create: false }) } catch { h.ro = null }
+  try {
+    h.ro = new Database(path, { readwrite: true, create: false })
+    errors.delete(s)
+  } catch (e) {
+    h.ro = null
+    errors.set(s, boardErr(isCorrupt(e) ? "corrupt" : "unreadable", path, String((e as Error).message ?? e)))
+  }
   return h.ro
 }
 
@@ -271,15 +338,22 @@ const dbOf = (s: string): Database | null => {
 const rwOf = (s: string): Database | null => {
   const h = pair(s)
   if (h.rw) return h.rw
-  if (!existsSync(dbPath(s))) return null
+  const path = dbPath(s)
+  if (!existsSync(path)) return null
+  const hdr = headerError(path)
+  if (hdr) { errors.set(s, hdr); return null }
   try {
-    const db = new Database(dbPath(s))
+    const db = new Database(path)
     // Match kanban_db.connect() pragmas. WAL is a no-op after the first
     // time but cheap; synchronous=NORMAL matches upstream.
     db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA foreign_keys=ON")
     h.rw = db
+    errors.delete(s)
     return db
-  } catch { return null }
+  } catch (e) {
+    errors.set(s, boardErr(isCorrupt(e) ? "corrupt" : "unreadable", path, String((e as Error).message ?? e)))
+    return null
+  }
 }
 
 /** Close every cached handle and re-resolve the active board.
@@ -287,7 +361,18 @@ const rwOf = (s: string): Database | null => {
 export const resetKanban = () => {
   for (const h of handles.values()) { h.ro?.close(); h.rw?.close() }
   handles.clear()
+  errors.clear()
   slug = resolve()
+}
+
+export function corruptBackupsOf(s: string): string[] {
+  const dir = dbDir(s) || kanbanRoot()
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter(e => e.isFile() && CORRUPT_BACKUP.test(e.name))
+      .map(e => `${dir}/${e.name}`)
+      .sort()
+  } catch { return [] }
 }
 
 /** Enumerate boards on disk. 'default' always first; others sorted. */
@@ -420,7 +505,7 @@ const toEvent = (r: Record<string, unknown>): Event => {
  *  dispatcher's pick-next ordering roughly matches the top of
  *  `ready`. */
 export function boardOf(s: string): Map<Status, Task[]> {
-  const out = new Map<Status, Task[]>(STATUSES.map(k => [k, []]))
+  const out = emptyBoard()
   const conn = dbOf(s)
   if (!conn) return out
   try {
@@ -433,8 +518,23 @@ export function boardOf(s: string): Map<Status, Task[]> {
       const t = toTask(r)
       out.get(t.status)?.push(t)
     }
-  } catch {}
+    errors.delete(s)
+  } catch (e) {
+    errors.set(s, boardErr(isCorrupt(e) ? "corrupt" : "query", dbPath(s), String((e as Error).message ?? e)))
+  }
   return out
+}
+
+export function boardStateOf(s: string): BoardState {
+  const columns = boardOf(s)
+  return { columns, error: errors.get(s) ?? null, corruptBackups: corruptBackupsOf(s) }
+}
+
+export function boardErrors(): Array<{ slug: string; error: BoardError }> {
+  return listBoards().flatMap(b => {
+    const state = boardStateOf(b.slug)
+    return state.error ? [{ slug: b.slug, error: state.error }] : []
+  })
 }
 
 const EVENT_TAIL = 20

--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -68,6 +68,7 @@ export const stateDb = (): Database | null => {
 export const resetDb = () => {
   for (const s of stmts.values()) s.finalize()
   stmts.clear()
+  msgCols.clear()
   conn.ro?.close()
   conn.ro = null
 }
@@ -76,12 +77,25 @@ export const resetDb = () => {
 // memoises internally, but holding our own map lets stats()/perf
 // count distinct statements and makes the no-db path trivially cheap.
 const stmts = new Map<string, Statement>()
+const msgCols = new Map<string, boolean>()
 const q = (sql: string): Statement | null => {
   const db = stateDb()
   if (!db) return null
   let s = stmts.get(sql)
   if (!s) stmts.set(sql, (s = db.query(sql)))
   return s
+}
+
+const hasMsgCol = (name: string): boolean => {
+  const hit = msgCols.get(name)
+  if (hit !== undefined) return hit
+  const db = stateDb()
+  const ok = db
+    ? db.query("PRAGMA table_info(messages)").all()
+        .some(r => (r as { name?: string }).name === name)
+    : false
+  msgCols.set(name, ok)
+  return ok
 }
 
 /** A row from the sessions table enriched for the list/detail view. */
@@ -137,6 +151,12 @@ export interface PeekMsg {
   /** JSON string of tool_calls when role='assistant' and the model
    *  invoked tools instead of / as well as emitting content. */
   tool_calls: string | null
+  /** External messaging platform's original message id. Present only
+   *  on Hermes Agent state.db schema v13+. */
+  platform_message_id?: string | null
+  /** 1 for group-context messages observed but not dispatched to the
+   *  agent. Present only on Hermes Agent state.db schema v13+. */
+  observed?: number | null
   at: number
 }
 //
@@ -381,13 +401,28 @@ function tip(sid: string): string {
 export function peek(sid: string, n = 60): PeekMsg[] {
   const end = perf.mark("io:sessions.peek")
   try {
+    const ext = [
+      hasMsgCol("platform_message_id")
+        ? "platform_message_id"
+        : "NULL AS platform_message_id",
+      hasMsgCol("observed") ? "observed" : "NULL AS observed",
+    ]
     return ((q(
       `SELECT role, SUBSTR(content,1,400) AS content, tool_name,
-              SUBSTR(tool_calls,1,400) AS tool_calls, timestamp AS at
+              SUBSTR(tool_calls,1,400) AS tool_calls, timestamp AS at,
+              ${ext.join(", ")}
        FROM (SELECT * FROM messages WHERE session_id = ?
              ORDER BY id DESC LIMIT ?)
        ORDER BY id ASC`,
-    )?.all(sid, n) ?? []) as PeekMsg[])
+    )?.all(sid, n) ?? []) as PeekMsg[]).map((r) => ({
+      role: r.role,
+      content: r.content,
+      tool_name: r.tool_name,
+      tool_calls: r.tool_calls,
+      ...(r.platform_message_id !== null && { platform_message_id: r.platform_message_id }),
+      ...(r.observed !== null && { observed: r.observed }),
+      at: r.at,
+    }))
   } finally { end() }
 }
 

--- a/src/tabs/Context.tsx
+++ b/src/tabs/Context.tsx
@@ -17,7 +17,7 @@ import { useKeyboard } from "@opentui/react"
 
 import type { Message } from "../types/message"
 import { text as msgText } from "../types/message"
-import type { ToolInfo, HermesConfig } from "../service/hermes-home"
+import { makeSource, type ToolInfo, type HermesConfig, type ToolsInfo } from "../service/hermes-home"
 import type { SessionInfo } from "../context/wire"
 import { useHome, home } from "../home"
 import { useGateway } from "../context/gateway"
@@ -285,6 +285,19 @@ const FreePanel = memo(({ seg, theme, ctxLen, comp, onEditThreshold }: {
 // deps don't see a fresh [] reference on every render.
 const NO_MESSAGES: readonly Message[] = Object.freeze([])
 
+const toolsFromInfo = (info?: SessionInfo | null): ToolsInfo | null => {
+  if (!info?.tools) return null
+  const tools = Object.entries(info.tools).flatMap(([group, names]) =>
+    names.map(name => ({
+      name,
+      descriptionLength: 0,
+      paramsLength: group.length,
+    })),
+  )
+  if (tools.length === 0) return null
+  return { source: makeSource("state.db", "session.info"), tools }
+}
+
 export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focused }: Props) => {
   const config = useHome("config")
   const memory = useHome("memory")
@@ -354,13 +367,15 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
   const sections = useMemo(() => parse(promptText), [promptText])
   const convTok = useMemo(() => est(messages.filter(m => m.role !== "system").map(m => msgText(m)).join("")), [messages])
 
+  const currentTools = useMemo(() => toolsFromInfo(info) ?? toolsInfo, [info, toolsInfo])
+
   const top = useMemo(() => build({
     contextLength: ctxLen,
     inputTokens: fill,
     sections,
     conversationTokens: convTok,
-    tools: toolsInfo?.tools ?? [],
-  }), [ctxLen, fill, sections, convTok, toolsInfo?.tools])
+    tools: currentTools?.tools ?? [],
+  }), [ctxLen, fill, sections, convTok, currentTools])
 
   // Current view: top-level or drilled
   const drilledGroup = drilled ? top.find(s => s.id === drilled) : null
@@ -463,12 +478,12 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
       return <MemoryPanel seg={seg} theme={theme} label="User Profile" chars={userProfile.charCount} limit={userProfile.charLimit} pct={userProfile.usagePercent} entries={userEntries} source={userProfile.source} />
     }
     if (selected === "skills") return <SkillsPanel seg={seg} theme={theme} />
-    if (selected === "system_tools" && toolsInfo) {
-      const { system } = classifyTools(toolsInfo.tools)
+    if (selected === "system_tools" && currentTools) {
+      const { system } = classifyTools(currentTools.tools)
       return <ToolsPanel seg={seg} theme={theme} tools={system} kind="system_tools" />
     }
-    if (selected === "mcp_tools" && toolsInfo) {
-      const { mcp } = classifyTools(toolsInfo.tools)
+    if (selected === "mcp_tools" && currentTools) {
+      const { mcp } = classifyTools(currentTools.tools)
       return <ToolsPanel seg={seg} theme={theme} tools={mcp} kind="mcp_tools" />
     }
     // SOUL drill: prefer the file-backed slice (authoritative read) over

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -2,11 +2,11 @@ import { useState, useEffect, useCallback, useMemo, useRef, memo } from "react"
 import { useKeyboard, useTerminalDimensions } from "@opentui/react"
 import type { BorderSides, ScrollBoxRenderable } from "@opentui/core"
 import {
-  boardOf, detailOf, tailLogOf, assignees, q, STATUSES,
+  boardStateOf, detailOf, tailLogOf, assignees, q, STATUSES,
   currentBoard, listBoards, resetKanban, patchTask,
   parseDiagnostics, maxSeverity, sortDiags,
   type Task, type Status, type Detail, type Board,
-  type Diag, type Severity,
+  type Diag, type Severity, type BoardError,
 } from "../service/hermes-kanban"
 import { useKeys } from "../keys"
 import { useTheme } from "../theme"
@@ -243,6 +243,28 @@ const Column = memo((p: {
   )
 })
 
+
+const ErrorBanner = memo((p: { error: BoardError; backups: string[] }) => {
+  const theme = useTheme().theme
+  return (
+    <box flexDirection="column" marginLeft={2} marginBottom={1}
+         paddingLeft={1} border borderColor={theme.error}>
+      <box height={1}>
+        <text>
+          <span fg={theme.error}><strong>Kanban DB {p.error.kind}</strong></span>
+          <span fg={theme.textMuted}>{`  ${p.error.path}`}</span>
+        </text>
+      </box>
+      <text wrapMode="word" fg={theme.textMuted}>{p.error.message}</text>
+      {p.backups.length > 0 ? (
+        <text wrapMode="word" fg={theme.warning}>
+          {`quarantine backup${p.backups.length === 1 ? "" : "s"}: ${p.backups.join(", ")}`}
+        </text>
+      ) : null}
+    </box>
+  )
+})
+
 const FilterBar = memo((p: {
   chips: Chip[]; mask: Mask; on: boolean; sel: number
   onPick: (i: number) => void
@@ -272,6 +294,7 @@ type ColSpec = { status: Status; tasks: Task[] }
 type Section = {
   board: Board; cols: ColSpec[]; chips: Chip[]
   total: number; shown: number; running: number; cap: number
+  error: BoardError | null; corruptBackups: string[]
 }
 // Fields are ordered top-to-bottom to match the layout. The
 // `editable` flag gates whether Tab/↑↓ can land on a row and whether
@@ -597,8 +620,8 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const keys = useKeys()
 
   const [boards, setBoards] = useState<Board[]>(listBoards)
-  const [data, setData] = useState<Map<string, Map<Status, Task[]>>>(
-    () => new Map(boards.map(b => [b.slug, boardOf(b.slug)])),
+  const [data, setData] = useState<Map<string, ReturnType<typeof boardStateOf>>>(
+    () => new Map(boards.map(b => [b.slug, boardStateOf(b.slug)])),
   )
   // diag[slug][taskId] = Diag[]. Shape keeps card lookup O(1) and
   // lets the SidePane pull the current task's diagnostics without a
@@ -614,8 +637,10 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     // First-run fallback: current board + any non-empty board.
     const init = currentBoard()
     return new Set(listBoards()
-      .filter(b => b.slug === init
-        || [...boardOf(b.slug).values()].some(v => v.length > 0))
+      .filter(b => {
+        const state = boardStateOf(b.slug)
+        return b.slug === init || [...state.columns.values()].some(v => v.length > 0) || !!state.error
+      })
       .map(b => b.slug))
   })
   const [at, setAt] = useState<string>(currentBoard)
@@ -631,7 +656,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const load = useCallback(() => {
     const bs = listBoards()
     setBoards(bs)
-    setData(new Map(bs.map(b => [b.slug, boardOf(b.slug)])))
+    setData(new Map(bs.map(b => [b.slug, boardStateOf(b.slug)])))
     setPane(p => p?.kind === "detail"
       ? (d => d ? { ...p, d } : null)(detailOf(p.slug, p.d.id)) : p)
     // Diagnostics: one shell.exec per board. Compute in parallel; any
@@ -661,7 +686,8 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const maxH = Math.max(8, dims.height - 16)
   const sections = useMemo<Section[]>(() => {
     const built = boards.map(b => {
-      const d = data.get(b.slug) ?? new Map<Status, Task[]>()
+      const state = data.get(b.slug) ?? boardStateOf(b.slug)
+      const d = state.columns
       const flat = STATUSES.flatMap(s => d.get(s) ?? [])
       const total = flat.length
       const who = [...new Set(flat.map(t => t.assignee).filter((v): v is string => !!v))].sort()
@@ -682,6 +708,8 @@ export const Kanban = memo((props: { focused?: boolean }) => {
         board: b, cols, chips, total, shown,
         running: d.get("running")?.length ?? 0,
         cap: Math.min(maxH, Math.max(5, 3 + 2 * tall)),
+        error: state.error,
+        corruptBackups: state.corruptBackups,
       }
     })
     // Non-empty boards first; empties sink. Stable partition so Tab
@@ -1055,7 +1083,8 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     // link_tasks (server rejects with "would cycle"), so we don't
     // need to second-guess here — just show everything usable and
     // let the linker toast the error if it fires.
-    const d = data.get(at) ?? new Map<Status, Task[]>()
+    const state = data.get(at) ?? boardStateOf(at)
+    const d = state.columns
     const all = STATUSES.flatMap(s => d.get(s) ?? [])
     const opts = all
       .filter(x => x.id !== t.id)
@@ -1255,13 +1284,21 @@ export const Kanban = memo((props: { focused?: boolean }) => {
                       <span fg={on ? theme.accent : theme.textMuted}>{secOpen ? "▾ " : "▸ "}</span>
                       <span fg={on ? theme.primary : theme.text}><strong>{s.board.name}</strong></span>
                       <span fg={theme.textMuted}>
-                        {s.total === 0 ? "  ·  empty"
+                        {s.error ? `  ·  ${s.error.kind}`
+                          : s.corruptBackups.length > 0 ? `  ·  ${s.corruptBackups.length} corrupt backup${s.corruptBackups.length === 1 ? "" : "s"}`
+                          : s.total === 0 ? "  ·  empty"
                           : `  ·  ${filt ? `${s.shown}/` : ""}${s.total} task${s.total === 1 ? "" : "s"}${s.running ? ` · ${s.running} running` : ""}`}
                       </span>
                     </text>
                   </box>
                   {secOpen ? (
-                    s.total === 0 ? (
+                    s.error ? (
+                      <ErrorBanner error={s.error} backups={s.corruptBackups} />
+                    ) : s.corruptBackups.length > 0 && s.total === 0 ? (
+                      <box height={1} marginLeft={2}>
+                        <text fg={theme.warning}>{`corrupt backup found: ${s.corruptBackups[0]}`}</text>
+                      </box>
+                    ) : s.total === 0 ? (
                       <box height={1} marginLeft={2}>
                         <text fg={theme.textMuted}>
                           no tasks — <span fg={theme.accent}>n</span> to create one here

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -7,7 +7,7 @@ import { sdb } from "../service/sessions-db"
 import type { SessionRow, SessionHit, LineageInfo, PeekMsg } from "../service/sessions-db"
 import { io as dbio } from "../io"
 import type {
-  SessionListItem, SessionListResponse,
+  SessionListItem, SessionListResponse, SessionActiveItem, SessionActiveListResponse,
 } from "../context/wire"
 import { useGateway } from "../context/gateway"
 import { useTheme } from "../theme"
@@ -36,8 +36,9 @@ import type { SessionsPrefs } from "../context/preferences"
 // gateway, separate profile), enrichment is absent and rows render
 // un-enriched; the tab keeps working at session.list fidelity.
 
-type Row = SessionListItem & { detail?: SessionRow }
+type Row = SessionListItem & { detail?: SessionRow; live?: SessionActiveItem }
 
+type View = "live" | "history"
 type Sort = NonNullable<SessionsPrefs["sort"]>
 
 /** Row comparator for the chosen sort. "active" keys on the tip's
@@ -429,7 +430,13 @@ type IO = {
   rename: typeof sdb.rename
 }
 
-type Props = { focused?: boolean; currentId?: string; onSwitch?: (sid: string) => void; io?: Partial<IO> }
+type Props = {
+  focused?: boolean
+  currentId?: string
+  onSwitch?: (sid: string) => void
+  onActivateLive?: (sid: string) => void
+  io?: Partial<IO>
+}
 
 // Module-level cache so revisiting the tab paints the previous list on
 // frame 1 while load() refreshes in place. Tests that inject `io` don't
@@ -455,6 +462,8 @@ export const Sessions = memo((props: Props) => {
   }
 
   const [rows, setRows] = useState<Row[]>(cached ? last.rows : [])
+  const [liveRows, setLiveRows] = useState<Row[]>([])
+  const [view, setView] = useState<View>("live")
   const [warn, setWarn] = useState("")
   const [pending, setPending] = useState(rows.length === 0)
   // Persisted, user-toggleable list ordering. roots() always returns
@@ -462,7 +471,9 @@ export const Sessions = memo((props: Props) => {
   // without re-hitting state.db.
   const sort: Sort = prefs.usePref("sessions")?.sort ?? "active"
   const setSort = useCallback((s: Sort) => prefs.set("sessions", { sort: s }), [])
-  const sorted = useMemo(() => [...rows].sort(cmp(sort)), [rows, sort])
+  const showingLive = view === "live" && liveRows.length > 0
+  const listed = showingLive ? liveRows : rows
+  const sorted = useMemo(() => showingLive ? liveRows : [...rows].sort(cmp(sort)), [showingLive, liveRows, rows, sort])
   // Selection is tracked by row identity so that collapsing children
   // (which changes the flat index of every row below) never lands sel
   // on the wrong row. The numeric index consumers use (handleListKey,
@@ -506,8 +517,8 @@ export const Sessions = memo((props: Props) => {
   // Latest-value refs so the stable row callbacks below don't close
   // over stale arrays (and therefore don't need to be in their deps,
   // which would defeat the memo).
-  const live = useRef({ rows, visible, anchor, results, searching, onSwitch: props.onSwitch, currentId: props.currentId })
-  live.current = { rows, visible, anchor, results, searching, onSwitch: props.onSwitch, currentId: props.currentId }
+  const live = useRef({ rows: listed, visible, anchor, results, searching, showingLive, onSwitch: props.onSwitch, onActivateLive: props.onActivateLive, currentId: props.currentId })
+  live.current = { rows: listed, visible, anchor, results, searching, showingLive, onSwitch: props.onSwitch, onActivateLive: props.onActivateLive, currentId: props.currentId }
 
   // Adapter for handleListKey, which speaks numeric sel. Translating
   // through the anchor means the target row is resolved against the
@@ -530,6 +541,16 @@ export const Sessions = memo((props: Props) => {
     source: d.sessionSource, detail: d,
   })
 
+  const toLiveRow = (s: SessionActiveItem): Row => ({
+    id: s.id,
+    title: s.title || s.preview || s.id,
+    preview: s.preview ?? "",
+    message_count: s.message_count ?? 0,
+    started_at: s.started_at ?? s.last_active ?? 0,
+    source: "live",
+    live: s,
+  })
+
   // Two-stage paint. io.list is off-thread, so the mount frame commits
   // (spinner / cached rows) before it resolves; the RPC is slower still.
   // Kids (subagents per parent) fill in after the list — the tree
@@ -537,6 +558,9 @@ export const Sessions = memo((props: Props) => {
   const load = useCallback(async () => {
     setPending(true)
     const rpc = gw.request<SessionListResponse>("session.list", { limit: LIMIT })
+      .then(r => ({ ok: true as const, v: r }))
+      .catch((e: Error) => ({ ok: false as const, e }))
+    const active = gw.request<SessionActiveListResponse>("session.active_list", { current_session_id: props.currentId })
       .then(r => ({ ok: true as const, v: r }))
       .catch((e: Error) => ({ ok: false as const, e }))
     const fs = Promise.resolve(io.list(LIMIT)).catch(() => [])
@@ -555,6 +579,13 @@ export const Sessions = memo((props: Props) => {
       if (cached) last.kids = m
     }
     void fillKids(diskRows)
+
+    const a = await active
+    if (a.ok) {
+      const live = (a.v.sessions ?? []).map(toLiveRow)
+      setLiveRows(live)
+      if (live.length === 0) setView(v => v === "live" ? "history" : v)
+    }
 
     // Stock session.list doesn't drop 0-msg stubs — every abandoned
     // connect leaves one, and they're never useful to resume. Keep
@@ -581,7 +612,7 @@ export const Sessions = memo((props: Props) => {
         ? `gateway session.list failed (${r.e.message}) — listing state.db directly; rows may not resume`
         : r.e.message
       : "")
-  }, [gw])
+  }, [gw, props.currentId])
 
   useEffect(() => { load() }, [load])
 
@@ -618,7 +649,9 @@ export const Sessions = memo((props: Props) => {
     l.searching ? setSearchSel(i) : setSel(i)
     const hit = l.searching ? l.results[i] : l.visible[i]?.row
     const id = l.searching ? (hit as SessionHit | undefined)?.session_id : (hit as Row | undefined)?.id
-    if (!id || !l.onSwitch) return
+    if (!id) return
+    if (l.showingLive && !l.searching) return l.onActivateLive?.(id)
+    if (!l.onSwitch) return
     if (id === l.currentId) return l.onSwitch(id)
     const title = (hit as { title?: string } | undefined)?.title || "Untitled"
     const n = l.searching ? undefined : (hit as Row).message_count
@@ -731,7 +764,9 @@ export const Sessions = memo((props: Props) => {
       page: Math.max(1, (vscroll.current?.viewport.height ?? 10) - 1),
       scrollTo: n => vscroll.current?.scrollChildIntoView(rowId(n)),
       onActivate: () => rowActivate(sel),
-      onToggle: () => setSort(sort === "active" ? "started" : "active"),
+      onToggle: () => liveRows.length > 0
+        ? setView(showingLive ? "history" : "live")
+        : setSort(sort === "active" ? "started" : "active"),
       onRefresh: () => { void load(); toast.show({ variant: "info", message: "Reloaded", duration: 1000 }) },
       onDelete: () => {
         const v = visible[sel]
@@ -759,7 +794,7 @@ export const Sessions = memo((props: Props) => {
     }
   })
 
-  const empty = searching ? results.length === 0 && query.length > 0 : rows.length === 0
+  const empty = searching ? results.length === 0 && query.length > 0 : listed.length === 0
   // Sidebar yields at <140 on non-Chat tabs (app.tsx), so detail can
   // stay mounted down to the shell's own floor.
   const showDetailPanel = dims.width >= 120
@@ -770,7 +805,7 @@ export const Sessions = memo((props: Props) => {
       <TabShell
         title={searching
           ? `Search Results (${results.length})`
-          : `Sessions (${rows.length}${pending ? "…" : ""})`}
+          : `${showingLive ? "Live Sessions" : "Sessions"} (${listed.length}${pending ? "…" : ""})`}
         error={warn || null}
         grow={3}
       >
@@ -797,6 +832,17 @@ export const Sessions = memo((props: Props) => {
           </box>
         ) : (
           <box key="table" flexDirection="column" flexGrow={1} minWidth={0}>
+            {!searching && liveRows.length > 0 ? (
+              <box height={1} marginBottom={1} flexDirection="row">
+                <box onMouseDown={() => setView("live")}>
+                  <text fg={showingLive ? theme.accent : theme.textMuted}>{`live ${liveRows.length}`}</text>
+                </box>
+                <text fg={theme.textMuted}>  ·  </text>
+                <box onMouseDown={() => setView("history")}>
+                  <text fg={showingLive ? theme.textMuted : theme.accent}>{`history ${rows.length}`}</text>
+                </box>
+              </box>
+            ) : null}
             {searching ? <SearchHeaderRow /> : <HeaderRow sort={sort} onSort={setSort} />}
             <box height={1} />
             <scrollbox ref={vscroll} scrollY viewportCulling flexGrow={1}
@@ -832,9 +878,9 @@ export const Sessions = memo((props: Props) => {
       : [
           ["↑↓", "navigate"],
           ["←→", "lineage"],
-          [`${keys.print("list.activate")}/click`, "switch"],
+          [`${keys.print("list.activate")}/click`, showingLive ? "activate live" : "switch"],
           [keys.print("list.search"), "search"],
-          [keys.print("list.toggle"), `sort: ${sort}`],
+          liveRows.length > 0 ? ["mouse", showingLive ? "history" : "live"] : [keys.print("list.toggle"), `sort: ${sort}`],
           [keys.print("sessions.rename"), "rename"],
           [keys.print("list.delete"), "delete"],
           [keys.print("list.refresh"), "refresh"],

--- a/src/tabs/SessionsGroup.tsx
+++ b/src/tabs/SessionsGroup.tsx
@@ -14,6 +14,7 @@ type Props = {
   setSub: (i: number) => void
   // Sessions
   onSwitch?: (sid: string) => void
+  onActivateLive?: (sid: string) => void
   currentId?: string
   // Context
   messages?: Message[]
@@ -43,7 +44,9 @@ export const SessionsGroup = memo((props: Props) => {
       <box flexGrow={1} minWidth={0} flexDirection="column">
         <Pane visible={props.sub === 0}>
           <Sessions focused={!!props.focused && props.sub === 0}
-                    onSwitch={props.onSwitch} currentId={props.currentId} />
+                    onSwitch={props.onSwitch}
+                    onActivateLive={props.onActivateLive}
+                    currentId={props.currentId} />
         </Pane>
         <Pane visible={props.sub === 1}>
           <Context focused={!!props.focused && props.sub === 1}

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -16,6 +16,10 @@ export type ToolPart = {
   startedAt?: number
   duration?: number
   preview?: string
+  /** Redacted verbose args from gateway tool.start.args_text, when /verbose verbose is active. */
+  verboseArgs?: string
+  /** Redacted verbose result from gateway tool.complete.result_text, when /verbose verbose is active. */
+  verboseResult?: string
   result?: string
   diff?: string
   /** Subagent only — child tool calls accumulated from subagent.tool events. */

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -35,6 +35,7 @@ export type ThinkingPart = {
   key?: string
   content: string
   streaming: boolean
+  verbose?: boolean
 }
 
 /** Agent-originated interactive prompt. Renders inline in the

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test"
 import { act } from "react"
-import { mount, until, MockGateway } from "./harness"
+import { mount as mountApp, until, MockGateway } from "./harness"
 import * as prefs from "../src/context/preferences"
 import * as exit from "../src/app/exit"
 import { DOUBLE_TAB_MS, QUIT_MS } from "../src/app/useAppKeys"
 import type { GatewayEvent } from "../src/context/wire"
 
 describe("app", () => {
+  const mount = (opts: Parameters<typeof mountApp>[0] = {}) =>
+    mountApp({ keyOverrides: {}, ...opts })
+
   const clearKeyPrefs = () => {
     prefs.set("keys", undefined)
     prefs.reset()
@@ -74,8 +77,7 @@ describe("app", () => {
 
   test("user keybind override that collides surfaces a system-line warning", async () => {
     // agents.kill → 'r' collides with list.refresh (list↔agents overlap).
-    prefs.set("keys", { "agents.kill": "r" })
-    const t = await mount()
+    const t = await mount({ keyOverrides: { "agents.kill": "r" } })
     await until(t, () => t.frame().includes("Keybinding conflict"))
     expect(t.frame()).toMatch(/R → .*list\.refresh.*agents\.kill|R → .*agents\.kill.*list\.refresh/)
     t.destroy()
@@ -141,8 +143,7 @@ describe("app", () => {
   })
 
   test("tab.next rebind via preferences.keys is honored end-to-end", async () => {
-    prefs.set("keys", { "tab.next": "ctrl+]", "tab.prev": "ctrl+[" })
-    const t = await mount()
+    const t = await mount({ keyOverrides: { "tab.next": "ctrl+]", "tab.prev": "ctrl+[" } })
     await until(t, () => t.frame().includes("Ready"))
 
     // Default chord no longer switches.

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test"
 import { act } from "react"
 import { mount, until, MockGateway } from "./harness"
 import * as prefs from "../src/context/preferences"
@@ -7,6 +7,14 @@ import { DOUBLE_TAB_MS, QUIT_MS } from "../src/app/useAppKeys"
 import type { GatewayEvent } from "../src/context/wire"
 
 describe("app", () => {
+  const clearKeyPrefs = () => {
+    prefs.set("keys", undefined)
+    prefs.reset()
+  }
+
+  beforeEach(clearKeyPrefs)
+  afterEach(clearKeyPrefs)
+
   test("boots and renders chat tab with status bar", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))

--- a/test/context.test.tsx
+++ b/test/context.test.tsx
@@ -50,6 +50,20 @@ describe("Context tab", () => {
     t.destroy()
   })
 
+  test("uses session.info tools without legacy session JSON snapshots", async () => {
+    const info: SessionInfo = {
+      model: "test",
+      context_max: 10_000,
+      tools: { builtin: ["terminal"], mcp: ["mcp_search"] },
+    }
+    const t = await mountNode(<Context info={info} />)
+    await t.settle()
+    const f = strip(t.frame())
+    expect(f).toContain("System Tools")
+    expect(f).toContain("MCP Tools")
+    t.destroy()
+  })
+
   // In-grid threshold marker (◼ in textMuted past threshold) + ×N badge.
   describe("threshold marker", () => {
     test("renders '×N compressed' badge when compressions > 0", async () => {

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "fs"
 import { join, resolve } from "path"
 import { tmpdir } from "os"
-import { python } from "../src/context/gateway-client"
+import { hermesAgentRoot, python } from "../src/context/gateway-client"
 
 const withEnv = <T>(key: string, value: string | undefined, fn: () => T): T => {
   const prev = process.env[key]
@@ -16,6 +16,40 @@ const withEnv = <T>(key: string, value: string | undefined, fn: () => T): T => {
 }
 
 const tmp = () => mkdtempSync(join(tmpdir(), "herm-gateway-"))
+
+describe("hermesAgentRoot", () => {
+  test("uses HERMES_AGENT_ROOT when set", () => {
+    withEnv("HERMES_AGENT_ROOT", resolve("/custom/hermes-agent"), () => {
+      expect(hermesAgentRoot()).toBe(resolve("/custom/hermes-agent"))
+    })
+  })
+
+  test("returns home path by default", () => {
+    withEnv("HERMES_AGENT_ROOT", undefined, () => {
+      const home = hermesAgentRoot()
+      expect(home).toContain(".hermes/hermes-agent")
+    })
+  })
+
+  test("falls back to FHS path when home path doesn't exist", () => {
+    withEnv("HERMES_AGENT_ROOT", undefined, () => {
+      withEnv("HOME", tmp(), () => {
+        // HOME is set to a tmp dir that has no .hermes/hermes-agent
+        // so the function falls through to the FHS path check
+        const root = hermesAgentRoot()
+        // If /usr/local/lib/hermes-agent doesn't exist on this machine,
+        // it returns the (non-existent) home path — which is expected
+        // behavior. The important part is the FHS path is checked.
+        if (existsSync("/usr/local/lib/hermes-agent")) {
+          expect(root).toBe("/usr/local/lib/hermes-agent")
+        } else {
+          // No FHS path either — returns home path as default
+          expect(root).toContain("hermes-agent")
+        }
+      })
+    })
+  })
+})
 
 describe("python", () => {
   test("uses HERMES_PYTHON when set", () => {

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -66,6 +66,22 @@ describe("mapEvent", () => {
       .toMatchObject({ kind: "tool.complete", id: "t1", summary: "5 lines" })
   })
 
+  test("verbose tool payload maps args/result text and duration_s", () => {
+    expect(map({
+      type: "tool.start",
+      payload: { tool_id: "t1", name: "patch", context: "f.ts", args_text: "{\"path\":\"f.ts\"}" },
+    }).action).toEqual({
+      kind: "tool.start", id: "t1", name: "patch", preview: "f.ts", args: "{\"path\":\"f.ts\"}",
+    })
+
+    expect(map({
+      type: "tool.complete",
+      payload: { tool_id: "t1", duration_s: 1.25, result_text: "patched", inline_diff: "diff" },
+    }).action).toEqual({
+      kind: "tool.complete", id: "t1", duration: 1250, result: "patched", inline_diff: "diff",
+    })
+  })
+
   test("status.update: cosmetic → null; lifecycle → system", () => {
     const a = map({ type: "status.update", payload: { kind: "status", text: "spin" } })
     expect(a.action).toBeNull()
@@ -129,6 +145,8 @@ describe("mapEvent", () => {
       .toEqual({ kind: "thinking", text: "hmm", final: false })
     expect(map({ type: "reasoning.available", payload: { text: "done" } }).action)
       .toEqual({ kind: "thinking", text: "done", final: true })
+    expect(map({ type: "reasoning.available", payload: { text: "done", verbose: true } }).action)
+      .toEqual({ kind: "thinking", text: "done", final: true, verbose: true })
   })
 
   test("request events return prompt actions (no side callback)", () => {

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -135,12 +135,13 @@ type Opts = {
   handlers?: Record<string, Handler>
   launch?: import("../src/app/launch").Launch
   plugins?: ReadonlyArray<HermPlugin>
+  keyOverrides?: Record<string, string>
 }
 
 /** Mount the full <App> under a test renderer with a MockGateway. */
 export async function mount(opts: Opts = {}): Promise<Harness> {
   const gw = opts.gw ?? new MockGateway(opts.handlers)
-  return render(<App gateway={gw} launch={opts.launch ?? { mode: "new", splash: false }} />, gw, opts)
+  return render(<App gateway={gw} launch={opts.launch ?? { mode: "new", splash: false }} keyOverrides={opts.keyOverrides} />, gw, opts)
 }
 
 /** Mount an arbitrary subtree wrapped in all providers (for component tests). */

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -43,6 +43,8 @@ export class MockGateway extends EventEmitter implements Gateway {
     this.on$("session.create", () => ({ session_id: "test-sid" }))
     this.on$("session.resume", p => ({ session_id: p.session_id ?? "test-sid", messages: [] }))
     this.on$("session.list", () => ({ sessions: [] }))
+    this.on$("session.active_list", () => ({ sessions: [] }))
+    this.on$("session.activate", p => ({ session_id: p.session_id ?? "test-sid", messages: [], status: "idle" }))
     this.on$("agents.list", () => ({ processes: [] }))
     this.on$("delegation.status", () => ({ active: [], paused: false, max_spawn_depth: 2, max_concurrent_children: 3 }))
     this.on$("complete.path", () => ({ items: [] }))

--- a/test/hermes-home-sessions.test.ts
+++ b/test/hermes-home-sessions.test.ts
@@ -24,6 +24,22 @@ const seed = () => {
   return db
 }
 
+const resetMessagesSchema = () => {
+  const db = openStateDb()
+  db.run("DROP TRIGGER IF EXISTS messages_fts_insert")
+  db.run("DROP TRIGGER IF EXISTS messages_fts_delete")
+  db.run("DROP TABLE IF EXISTS messages_fts")
+  db.run("DROP TABLE IF EXISTS messages")
+  db.close()
+  openStateDb().close()
+  resetDb()
+}
+
+const addMessageProvenanceColumns = (db: ReturnType<typeof openStateDb>) => {
+  db.run("ALTER TABLE messages ADD COLUMN platform_message_id TEXT")
+  db.run("ALTER TABLE messages ADD COLUMN observed INTEGER DEFAULT 0")
+}
+
 const sess = (
   db: ReturnType<typeof openStateDb>,
   id: string,
@@ -569,10 +585,12 @@ describe("chainTip() — returns tip regardless of message_count", () => {
 afterAll(() => { wipe(); resetDb() })
 
 describe("peek() — tail N messages for a session", () => {
+  beforeEach(resetMessagesSchema)
   afterAll(wipe)
 
   test("returns last N rows chronological, content SUBSTR'd", () => {
     const db = seed()
+    addMessageProvenanceColumns(db)
     sess(db, "px", "tui", 1700000000)
     for (let i = 0; i < 8; i++) msg(db, "px", "user", `m${i}`, 1000 + i)
     db.close()
@@ -584,6 +602,7 @@ describe("peek() — tail N messages for a session", () => {
 
   test("includes tool_name and tool_calls columns", () => {
     const db = seed()
+    addMessageProvenanceColumns(db)
     sess(db, "px", "tui", 1700000000)
     db.prepare("INSERT INTO messages (session_id, role, content, tool_calls, timestamp) VALUES (?,?,?,?,?)")
       .run("px", "assistant", null, '[{"name":"terminal"}]', 1000)
@@ -596,7 +615,37 @@ describe("peek() — tail N messages for a session", () => {
     expect(rows[1].tool_name).toBe("terminal")
   })
 
+  test("omits v13 provenance fields when the messages table is old schema", () => {
+    const db = seed()
+    sess(db, "px", "tui", 1700000000)
+    msg(db, "px", "user", "legacy", 1000)
+    db.close()
+
+    const rows = peek("px", 10)
+    expect(rows[0].platform_message_id).toBeUndefined()
+    expect(rows[0].observed).toBeUndefined()
+  })
+
+  test("includes v13 provenance fields when the messages table has them", () => {
+    const db = seed()
+    addMessageProvenanceColumns(db)
+    sess(db, "px", "tui", 1700000000)
+    db.prepare("INSERT INTO messages (session_id, role, content, platform_message_id, observed, timestamp) VALUES (?,?,?,?,?,?)")
+      .run("px", "user", "from discord", "discord-42", 1, 1000)
+    db.close()
+    resetDb()
+
+    const rows = peek("px", 10)
+    expect(rows[0].platform_message_id).toBe("discord-42")
+    expect(rows[0].observed).toBe(1)
+  })
+
   test("unknown session → empty", () => {
+    const db = seed()
+    addMessageProvenanceColumns(db)
+    db.close()
+    resetDb()
+
     expect(peek("nope", 10)).toEqual([])
   })
 })

--- a/test/home-store.test.ts
+++ b/test/home-store.test.ts
@@ -170,7 +170,7 @@ describe("HomeStore > core", () => {
     expect(Array.isArray(await h.ensure("recentSessions"))).toBe(true)
     expect(Array.isArray(await h.ensure("memoryActivity"))).toBe(true)
     expect(await h.ensure("systemPrompt")).toBeNull()
-    // toolsInfo scans sessions/ for session_*.json; fixture has none.
+    // toolsInfo is a legacy/debug snapshot fallback; fixture has none.
     expect(await h.ensure("toolsInfo")).toBeNull()
   })
 

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -1,12 +1,13 @@
-import { describe, test, expect, beforeAll } from "bun:test"
+import { describe, test, expect, beforeAll, afterEach } from "bun:test"
 import { act } from "react"
 import { Database } from "bun:sqlite"
-import { mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { mkdirSync, writeFileSync, rmSync, chmodSync } from "node:fs"
 import { mountNode, MockGateway, until } from "./harness"
 import { hermesPath } from "../src/service/hermes-home"
 import {
   board, boardOf, detail, assignees, tailLog, q, resetKanban,
   currentBoard, listBoards, parseDiagnostics, maxSeverity, sortDiags,
+  boardStateOf, boardErrors, corruptBackupsOf,
 } from "../src/service/hermes-kanban"
 import { Kanban } from "../src/tabs/Kanban"
 
@@ -37,6 +38,16 @@ const schema = (db: Database) => {
     status TEXT, outcome TEXT, started_at INTEGER, ended_at INTEGER,
     summary TEXT, error TEXT, worker_pid INTEGER)`)
 }
+
+
+const cleanupHazardBoards = () => {
+  for (const slug of ["bad", "missing", "quarantined", "ui_bad", "unreadable"])
+    rmSync(hermesPath(`kanban/boards/${slug}`), { recursive: true, force: true })
+  rmSync(hermesPath("kanban.db.corrupt.20260527_010204.bak"), { force: true })
+  resetKanban()
+}
+
+afterEach(() => cleanupHazardBoards())
 
 beforeAll(() => {
   delete process.env.HERMES_KANBAN_BOARD
@@ -105,6 +116,57 @@ describe("hermes-kanban readers", () => {
     expect(boardOf("atm10").get("ready")?.[0]?.id).toBe("m1")
     expect(boardOf("default").get("ready")?.[0]?.id).toBe("t1")
     expect([...boardOf("zeta").values()].every(v => v.length === 0)).toBe(true)
+  })
+
+
+  test("boardStateOf() keeps missing DB empty but reports corrupt existing DB", () => {
+    rmSync(hermesPath("kanban/boards/missing"), { recursive: true, force: true })
+    mkdirSync(hermesPath("kanban/boards/missing"), { recursive: true })
+    resetKanban()
+
+    const missing = boardStateOf("missing")
+    expect(missing.error).toBeNull()
+    expect([...missing.columns.values()].every(v => v.length === 0)).toBe(true)
+
+    mkdirSync(hermesPath("kanban/boards/bad"), { recursive: true })
+    writeFileSync(hermesPath("kanban/boards/bad/kanban.db"), "not sqlite\n")
+    resetKanban()
+
+    const bad = boardStateOf("bad")
+    expect(bad.error?.kind).toBe("corrupt")
+    expect(bad.error?.path).toContain("kanban/boards/bad/kanban.db")
+    expect(bad.error?.message).toContain("invalid SQLite header")
+    expect([...bad.columns.values()].every(v => v.length === 0)).toBe(true)
+  })
+
+  test("boardStateOf() reports unreadable existing DB separately from missing DB", () => {
+    mkdirSync(hermesPath("kanban/boards/unreadable"), { recursive: true })
+    writeFileSync(hermesPath("kanban/boards/unreadable/kanban.db"), "SQLite format 3\0")
+    chmodSync(hermesPath("kanban/boards/unreadable/kanban.db"), 0o000)
+    resetKanban()
+    try {
+      const unreadable = boardStateOf("unreadable")
+      expect(unreadable.error).not.toBeNull()
+      expect(unreadable.error?.kind).not.toBe("missing")
+      expect(unreadable.error?.path).toContain("kanban/boards/unreadable/kanban.db")
+    } finally {
+      chmodSync(hermesPath("kanban/boards/unreadable/kanban.db"), 0o600)
+    }
+  })
+
+  test("boardErrors() and corruptBackupsOf() expose board-level DB hazards", () => {
+    mkdirSync(hermesPath("kanban/boards/bad"), { recursive: true })
+    writeFileSync(hermesPath("kanban/boards/bad/kanban.db"), "not sqlite\n")
+    mkdirSync(hermesPath("kanban/boards/quarantined"), { recursive: true })
+    writeFileSync(hermesPath("kanban/boards/quarantined/kanban.db.corrupt.20260527_010203.bak"), "old bytes")
+    writeFileSync(hermesPath("kanban.db.corrupt.20260527_010204.bak"), "old default bytes")
+    resetKanban()
+
+    const qs = corruptBackupsOf("quarantined")
+    const ds = corruptBackupsOf("default")
+    expect(qs.some(p => p.endsWith("kanban.db.corrupt.20260527_010203.bak"))).toBe(true)
+    expect(ds.some(p => p.endsWith("kanban.db.corrupt.20260527_010204.bak"))).toBe(true)
+    expect(boardErrors().some(e => e.slug === "bad" && e.error.kind === "corrupt")).toBe(true)
   })
 
   test("detail() hydrates parents/children/comments", () => {
@@ -186,6 +248,26 @@ describe("Kanban tab", () => {
     expect(f).toContain("upgrade forge")
     expect(f).not.toMatch(/t2\s+researcher\s+P3/)
     t.destroy()
+  })
+
+
+  test("renders corrupt DB as a board error instead of an empty create prompt", async () => {
+    mkdirSync(hermesPath("kanban/boards/ui_bad"), { recursive: true })
+    writeFileSync(hermesPath("kanban/boards/ui_bad/board.json"), JSON.stringify({ name: "Bad Board" }))
+    writeFileSync(hermesPath("kanban/boards/ui_bad/kanban.db"), "broken board bytes")
+    resetKanban()
+
+    const t = await mountNode(<Kanban focused />, { width: 180, height: 44 })
+    try {
+      await until(t, () => t.frame().includes("Bad Board"))
+      const f = t.frame()
+      expect(f).toMatch(/Bad Board\s+·\s+corrupt/)
+      expect(f).toContain("Kanban DB corrupt")
+      expect(f).toContain("invalid SQLite header")
+      expect(f).not.toMatch(/Bad Board[\s\S]*no tasks —/)
+    } finally {
+      t.destroy()
+    }
   })
 
   test("arrows nav within board; Enter → detail pane", async () => {

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -867,6 +867,17 @@ describe("patchTask direct writes", () => {
     } finally { db.close() }
   }
 
+  test("write handle applies hardened SQLite pragmas", async () => {
+    const { kanbanWritePragmas } = await import("../src/service/hermes-kanban")
+    const p = kanbanWritePragmas("default")!
+    expect(String(p.journal_mode).toLowerCase()).toBe("wal")
+    expect(p.synchronous).toBe(2) // FULL
+    expect(p.wal_autocheckpoint).toBe(100)
+    expect(p.secure_delete).toBe(1)
+    expect(p.cell_size_check).toBe(1)
+    expect(p.foreign_keys).toBe(1)
+  })
+
   test("title + body in one txn ⇒ single 'edited' event", async () => {
     const { patchTask } = await import("../src/service/hermes-kanban")
     // Seed by re-using t4 (done) so we have a stable target.

--- a/test/legacy-session-json.test.ts
+++ b/test/legacy-session-json.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect, afterEach } from "bun:test"
+import { mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+
+const HH = process.env.HERMES_HOME!
+
+afterEach(() => {
+  rmSync(join(HH, "sessions"), { recursive: true, force: true })
+})
+
+describe("legacy session JSON readers", () => {
+  test("missing sessions directory is empty optional state", async () => {
+    rmSync(join(HH, "sessions"), { recursive: true, force: true })
+
+    const { readLiveSessions, readToolsFromLatestSession } = await import("../src/service/hermes-home")
+
+    expect(await readLiveSessions()).toEqual({})
+    expect(await readToolsFromLatestSession()).toBeNull()
+  })
+
+  test("missing JSON snapshots do not break home slices", async () => {
+    rmSync(join(HH, "sessions"), { recursive: true, force: true })
+
+    const { HomeStore } = await import("../src/home/store")
+    const h = new HomeStore()
+    try {
+      expect(await h.ensure("liveSessions")).toEqual({})
+      expect(await h.ensure("toolsInfo")).toBeNull()
+    } finally {
+      h.close()
+    }
+  })
+
+  test("legacy snapshots still read when explicitly present", async () => {
+    const dir = join(HH, "sessions")
+    rmSync(dir, { recursive: true, force: true })
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "sessions.json"), JSON.stringify({
+      a: { session_id: "sid-legacy", last_prompt_tokens: 42 },
+    }))
+    writeFileSync(join(dir, "session_legacy.json"), JSON.stringify({
+      tools: [
+        { function: { name: "terminal", description: "run commands", parameters: { type: "object" } } },
+      ],
+    }))
+
+    const { readLiveSessions, readToolsFromLatestSession } = await import("../src/service/hermes-home")
+
+    expect((await readLiveSessions()).a.session_id).toBe("sid-legacy")
+    const tools = await readToolsFromLatestSession()
+    expect(tools?.source.relative).toBe("sessions/session_legacy.json")
+    expect(tools?.tools.map(t => t.name)).toEqual(["terminal"])
+  })
+})

--- a/test/live-session-events.test.tsx
+++ b/test/live-session-events.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+
+describe("live session event routing", () => {
+  test("ignores sibling session stream events after activating another session", async () => {
+    const gw = new MockGateway({
+      "session.resume": p => ({
+        session_id: p.session_id,
+        messages: p.session_id === "sid-b"
+          ? [{ role: "user", content: "Question B", timestamp: 1 }]
+          : [],
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "sid-b", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => {
+      t.gw.push({ type: "message.start", session_id: "sid-b" })
+      t.gw.push({ type: "message.delta", session_id: "sid-b", payload: { text: "B is streaming" } })
+      t.gw.push({ type: "message.start", session_id: "sid-a" })
+      t.gw.push({ type: "message.delta", session_id: "sid-a", payload: { text: "LATE_FROM_A" } })
+      t.gw.push({ type: "status.update", session_id: "sid-a", payload: { text: "A is still running", kind: "lifecycle" } })
+      t.gw.push({ type: "message.complete", session_id: "sid-a", payload: { text: "DONE_A" } })
+    })
+    await until(t, () => t.frame().includes("B is streaming"))
+
+    expect(t.frame()).not.toContain("LATE_FROM_A")
+    expect(t.frame()).not.toContain("DONE_A")
+    expect(t.frame()).not.toContain("A is still running")
+    expect(t.frame()).not.toContain("Ready")
+    t.destroy()
+  })
+})

--- a/test/quit-argshint.test.tsx
+++ b/test/quit-argshint.test.tsx
@@ -13,7 +13,7 @@ const Probe = forwardRef<Handle>((_, ref) => {
   return null
 })
 
-async function setup(catalog: { pairs: [string, string][] }) {
+async function setup(catalog: { pairs: [string, string][], canon?: Record<string, string> }) {
   const gw = new MockGateway()
   gw.on$("commands.catalog", () => catalog)
   const ref = createRef<Handle>()
@@ -45,6 +45,19 @@ describe("useSlashCommands /quit description", () => {
     })
     const quit = ref.current!.cmds().find(c => c.name === "quit")!
     expect(quit.description).toBe("Exit the CLI")
+    t.destroy()
+  })
+
+  test("keeps catalog alias canonicalization for /q → /queue and /exit → /quit", async () => {
+    const { t, ref } = await setup({
+      pairs: [["/queue", "Queue a prompt"], ["/quit", "Exit the CLI"]],
+      canon: { "/q": "/queue", "/exit": "/quit" },
+    })
+    const queue = ref.current!.cmds().find(c => c.name === "queue")!
+    const quit = ref.current!.cmds().find(c => c.name === "quit")!
+    expect(queue.aliases).toContain("q")
+    expect(quit.aliases).toContain("exit")
+    expect(quit.aliases).not.toContain("q")
     t.destroy()
   })
 })

--- a/test/session-close.test.tsx
+++ b/test/session-close.test.tsx
@@ -94,4 +94,40 @@ describe("session.close", () => {
 
     t.destroy()
   })
+
+  test("live session activation does not close the outgoing session and hydrates inflight", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/sessions", "sessions"]] }),
+      "session.active_list": () => ({ sessions: [
+        { id: "live-a", title: "Live A", message_count: 2, started_at: 1700000000, status: "working" },
+      ]}),
+      "session.activate": p => ({
+        session_id: p.session_id,
+        session_key: "live-key",
+        status: "working",
+        running: true,
+        started_at: 1700000000,
+        info: { model: "live-model", session_id: p.session_id, tools: {}, skills: {} },
+        messages: [
+          { role: "user", text: "older question" },
+          { role: "assistant", text: "older answer" },
+        ],
+        inflight: { user: "new question", assistant: "partial answer", streaming: true },
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "first", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/sessions") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Live Sessions"))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("partial answer"))
+
+    expect(t.gw.last("session.activate")?.params.session_id).toBe("live-a")
+    expect(t.gw.last("session.close")).toBeUndefined()
+    expect(t.frame()).toContain("new question")
+
+    t.destroy()
+  })
 })

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -27,6 +27,32 @@ const detail = (over: Partial<SessionRow> & { id: string; sessionSource: string 
 })
 
 describe("Sessions tab", () => {
+  test("lists live sessions first and activates without closing siblings", async () => {
+    const gw = new MockGateway({
+      "session.active_list": p => ({ sessions: [
+        { id: "live-a", title: "Working live", preview: "do the thing", message_count: 3, started_at: 1700000000, status: "working", current: p.current_session_id === "live-a" },
+        { id: "live-b", title: "Idle live", preview: "done", message_count: 1, started_at: 1700000100, status: "idle" },
+      ]}),
+      "session.list": () => ({ sessions: ROWS }),
+    })
+    let activated = ""
+    const t = await mountNode(
+      <Sessions focused io={NOIO} currentId="live-a" onActivateLive={sid => { activated = sid }} />,
+      { gw },
+    )
+    await until(t, () => t.frame().includes("Live Sessions (2)"))
+
+    expect(t.frame()).toContain("Working live")
+    expect(t.gw.last("session.active_list")?.params.current_session_id).toBe("live-a")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(activated).toBe("live-a")
+    expect(t.frame()).not.toContain("Load session?")
+
+    t.destroy()
+  })
+
   test("lists from session.list RPC and switches on Enter", async () => {
     const gw = new MockGateway({ "session.list": () => ({ sessions: ROWS }) })
     let switched = ""

--- a/test/slash.test.ts
+++ b/test/slash.test.ts
@@ -33,8 +33,13 @@ describe("slash", () => {
     expect(r.map(c => c.name)).toEqual(["a", "c", "b"])
   })
 
-  test("LOCAL_COMMANDS includes logs", () => {
-    expect(LOCAL_COMMANDS.some(c => c.name === "logs")).toBe(true)
+  test("LOCAL_COMMANDS includes local fallbacks for queue and quit aliases", () => {
+    const queue = LOCAL_COMMANDS.find(c => c.name === "queue")
+    const quit = LOCAL_COMMANDS.find(c => c.name === "quit")
+    expect(queue?.aliases).toContain("q")
+    expect(quit?.aliases).toContain("exit")
+    expect(quit?.aliases).not.toContain("q")
+    expect(resolve(LOCAL_COMMANDS, "q")).toMatchObject({ hit: { name: "queue" } })
   })
 
   // Parity guard — every `case "x"` in app/slash.tsx must be in

--- a/test/slash.test.ts
+++ b/test/slash.test.ts
@@ -58,7 +58,7 @@ describe("slash", () => {
   test("LOCAL_NAMES covers session-mutating commands", () => {
     for (const n of ["resume", "branch", "compress", "undo", "retry", "model",
                      "quit", "copy", "paste", "image", "background", "voice",
-                     "mouse", "redraw", "save"])
+                     "mouse", "redraw", "save", "browser"])
       expect(LOCAL_NAMES.has(n)).toBe(true)
   })
 

--- a/test/tool-detail.test.tsx
+++ b/test/tool-detail.test.tsx
@@ -69,4 +69,32 @@ describe("Tool > detail mode", () => {
     expect(r.frame().trim().length).toBeGreaterThan(0)
     r.destroy()
   })
+
+  test("expanded mode shows verbose args and result details", async () => {
+    const verbose: ToolPart = {
+      type: "tool", id: "t3", name: "patch", args: "",
+      preview: "src/z.ts", status: "done", duration: 10,
+      verboseArgs: "{\"path\":\"src/z.ts\"}",
+      verboseResult: "patched result",
+    }
+    const t = await mount(verbose, "expanded")
+    await until(t, () => t.frame().includes("Args"))
+    const f = t.frame()
+    expect(f).toContain("Result")
+    expect(f).toContain("patched result")
+    t.destroy()
+  })
+
+  test("collapsed mode keeps verbose details hidden", async () => {
+    const verbose: ToolPart = {
+      type: "tool", id: "t3", name: "patch", args: "",
+      preview: "src/z.ts", status: "done", duration: 10,
+      verboseArgs: "{\"path\":\"src/z.ts\"}",
+      verboseResult: "patched result",
+    }
+    const t = await mount(verbose, "collapsed")
+    await until(t, () => t.frame().includes("Edit src/z.ts"))
+    expect(t.frame()).not.toContain("patched result")
+    t.destroy()
+  })
 })

--- a/test/turnReducer.test.ts
+++ b/test/turnReducer.test.ts
@@ -82,6 +82,37 @@ describe("turnReducer", () => {
     expect((last(s).parts[0] as ToolPart).status).toBe("error")
   })
 
+  test("verbose tool details are stored without replacing normal preview", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "tool.start", id: "t1", name: "patch", preview: "src/x.ts", args: "{\"path\":\"src/x.ts\"}" },
+      { kind: "tool.complete", id: "t1", summary: "edited src/x.ts", result: "raw result text", duration: 1200 },
+    ])
+    const tool = last(s).parts[0] as ToolPart
+    expect(tool).toMatchObject({
+      status: "done",
+      preview: "edited src/x.ts",
+      args: "{\"path\":\"src/x.ts\"}",
+      result: "edited src/x.ts",
+      verboseResult: "raw result text",
+      duration: 1200,
+    })
+  })
+
+  test("inline_diff completion keeps verbose result text for details", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "tool.start", id: "t1", name: "patch", preview: "src/x.ts", args: "args" },
+      { kind: "tool.complete", id: "t1", inline_diff: "--- a\n+++ b", result: "patched result" },
+    ])
+    const tool = last(s).parts[0] as ToolPart
+    expect(tool.preview).toBe("--- a\n+++ b")
+    expect(tool.diff).toBe("--- a\n+++ b")
+    expect(tool.result).toBeUndefined()
+    expect(tool.verboseResult).toBe("patched result")
+    expect(tool.verboseArgs).toBe("args")
+  })
+
   test("thinking deltas win; reasoning.available is fallback-only", () => {
     const s = run([
       { kind: "message.start" },

--- a/test/turnReducer.test.ts
+++ b/test/turnReducer.test.ts
@@ -131,6 +131,14 @@ describe("turnReducer", () => {
     expect(last(s).parts[0]).toMatchObject({ type: "thinking", content: "recovered from last_reasoning", streaming: false })
   })
 
+  test("reasoning.available preserves forced verbose flag", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "thinking", text: "trace", final: true, verbose: true },
+    ])
+    expect(last(s).parts[0]).toMatchObject({ type: "thinking", content: "trace", streaming: false, verbose: true })
+  })
+
   test("interrupt.notice dedupes consecutive identical notices", () => {
     const s = run([
       { kind: "interrupt.notice", text: "press esc" },


### PR DESCRIPTION
## Summary

This brings upstream parity fixes into one Herm branch so the TUI matches current Hermes Agent surfaces more closely.

| Area | Change |
| --- | --- |
| Kanban | Hardened direct SQLite edits, surfaces corrupt board databases, handles scheduled tasks and newer task fields. |
| Sessions | Keeps live sibling sessions open, activates live sessions through RPCs, and prevents sibling stream events from mutating the active transcript. |
| Transcript | Preserves verbose tool args/results and forced verbose reasoning metadata through the reducer and renderer. |
| Slash commands | Pins `/q` to `/queue` instead of letting catalog prefix matching hijack it; routes `/browser` through `browser.manage`. |
| Context/home | Stops depending on legacy `sessions/*.json` snapshots unless they are explicitly present. |
| Gateway | Resolves hermes-agent from FHS root installs when the profile-local checkout is absent. |
| Session DB | Reads newer message provenance fields while keeping old schemas safe. |

## Credits

- Includes `/browser` RPC routing from #84 by Keith Marble / @kdmarble.
- Includes FHS root install fallback from #85 by Keith Marble / @kdmarble.

## Test Plan

- `bun test test/kanban.test.tsx test/app.test.tsx test/turnReducer.test.ts test/session-close.test.tsx test/sessions.test.tsx test/live-session-events.test.tsx test/gatewayEvents.test.ts test/tool-detail.test.tsx test/context.test.tsx test/home-store.test.ts test/legacy-session-json.test.ts test/hermes-home-sessions.test.ts test/quit-argshint.test.tsx test/slash.test.ts test/gateway-client.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
