### PR TITLE
fix: restore ready state after session resume

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -342,10 +342,17 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     summoned.current = true
     setSplash(true)
     setSwitching(true)
+    gw.setSession("")
+    setSid("")
     goToTab(CHAT_TAB)
     try {
       const res = await session.resume(target)
       setSid(res.id)
+      if (res.info) {
+        setInfo(res.info)
+        setUsage(res.info.usage)
+      }
+      setReady(true)
       sessionStart.current = Date.now()
       if (res.messages.length) dispatch({ kind: "load", messages: res.messages })
       // Close only after resume succeeds — a failed resume leaves the
@@ -362,7 +369,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     } finally {
       setSwitching(false)
     }
-  }, [reset, session, goToTab])
+  }, [reset, session, goToTab, gw])
 
   const liveStatus = (state?: string, running = false) => {
     if (state === "waiting") return "waiting for input…"

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -49,6 +49,7 @@ export type CompressResult = {
 }
 
 type Booted = { id: string; messages: Message[]; note?: string }
+type Resumed = { id: string; messages: Message[]; info?: SessionInfo }
 type Activated = { id: string; messages: Message[]; info?: SessionInfo; running: boolean; status?: string; startedAt?: number }
 
 export const normalize = (sid: string): string =>
@@ -58,7 +59,7 @@ type SessionOps = {
   /** Establish the initial session per launch intent. */
   boot: (launch: Launch) => Promise<Booted>
   create: () => Promise<string>
-  resume: (sid: string) => Promise<{ id: string; messages: Message[] }>
+  resume: (sid: string) => Promise<Resumed>
   activate: (sid: string) => Promise<Activated>
   /** Finalize a gateway session (best-effort — swallows errors). */
   close: (sid: string) => Promise<void>
@@ -93,7 +94,7 @@ export function useSession(): SessionOps {
     const model = spec(row)
     if (model) await gw.request("config.set", { key: "model", value: model }).catch(() => {})
     const messages = res.messages?.length ? transcriptToMessages(res.messages) : []
-    return { id, messages }
+    return { id, messages, info: res.info }
   }, [gw])
 
   // No `cols` param and no `terminal.resize` RPC on SIGWINCH: herm renders

--- a/test/session-close.test.tsx
+++ b/test/session-close.test.tsx
@@ -56,6 +56,29 @@ describe("session.close", () => {
     t.destroy()
   })
 
+  test("switchSession restores ready when pre-response session.info is filtered", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "session.create": () => ({ session_id: "old" }),
+      "session.resume": p => {
+        gw.push({ type: "session.info", session_id: "new", payload: { session_id: "new", model: "m", tools: {}, skills: {} } })
+        return { session_id: "new", resumed: p.session_id, messages: [{ role: "user", text: "hello" }] }
+      },
+    })
+    const t = await mount({ gw, launch: { mode: "new", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/resume past") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.last("session.resume")?.params.session_id === "past")
+    await until(t, () => t.frame().includes("Ready") && t.frame().includes("hello"))
+
+    expect(t.frame()).not.toContain("Connecting")
+    expect(t.gw.last("session.close")?.params.session_id).toBe("old")
+
+    t.destroy()
+  })
+
   test("switchSession keeps prev live when resume fails", async () => {
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),


### PR DESCRIPTION
## Summary

- Clears the active gateway/local sid before switching to a resumed session, matching `/new` stale-sid hygiene.
- Applies `session.resume` response info directly and restores Composer ready state after a successful resume.
- Adds a regression test for the pre-response `session.info` race where the old sid filter can drop the new session event.

Fixes #89

## Test Plan

- `bunx tsc --noEmit 2>&1 | grep -E '^(src|test)/'`
- `bun test test/session-close.test.tsx`
- `bun test`
- `bun run build`
