### PR TITLE
fix: use configured model.context_length for Context tab fallback

### DIFF
--- a/src/service/hermes-home.ts
+++ b/src/service/hermes-home.ts
@@ -68,6 +68,7 @@ export interface HermesConfig {
     default: string;
     provider: string;
     base_url: string;
+    context_length: number;
   };
   agent: {
     max_turns: number;
@@ -460,6 +461,7 @@ export async function readConfig(): Promise<HermesConfig | null> {
         default: raw?.model?.default ?? "unknown",
         provider: raw?.model?.provider ?? "auto",
         base_url: raw?.model?.base_url ?? "",
+        context_length: raw?.model?.context_length ?? 0,
       },
       agent: {
         max_turns: raw?.agent?.max_turns ?? 60,

--- a/src/tabs/Context.tsx
+++ b/src/tabs/Context.tsx
@@ -52,9 +52,10 @@ type Props = {
 
 type Wire = { input: number; output: number; total: number; calls: number }
 
-// Conservative fallback when gateway hasn't surfaced info.context_max
-// yet (fresh session, pre-session.info). Real value comes from
-// SessionInfo.context_max on the wire.
+// Last-resort fallback when neither the gateway (info.context_max) nor
+// config (model.context_length) has surfaced a window yet. Real value
+// comes from SessionInfo.context_max on the wire; the configured
+// model.context_length is preferred over this constant.
 const DEFAULT_CTX = 128_000
 const COLS = 16
 
@@ -336,10 +337,15 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
 
   // Derived
   const session = recentSessions?.[0]
-  // Gateway's context_max is the authoritative runtime value. Fall back
-  // to DEFAULT_CTX only during the fresh-session window before
-  // session.info lands.
-  const ctxLen = info?.context_max ?? DEFAULT_CTX
+  // Gateway's context_max is the authoritative runtime value. Before
+  // session.info lands (fresh-session window) fall back to the user's
+  // configured model.context_length, then to DEFAULT_CTX. Using the
+  // config value avoids showing a misleading 128K bar for models whose
+  // real window the gateway hasn't surfaced yet.
+  const ctxLen = info?.context_max
+    ?? (config?.model?.context_length && config.model.context_length > 0
+        ? config.model.context_length
+        : DEFAULT_CTX)
 
   const live = session
     ? Object.values(liveSessions ?? {}).find(ls => ls.session_id === session.id)


### PR DESCRIPTION
## Problem

The Context tab shows a misleading **128K** context window for any model whose real window the gateway hasn't surfaced via `info.context_max` yet. The fresh-session window (before `session.info` lands) falls straight through to the hardcoded `DEFAULT_CTX = 128_000`, even when the user's `config.yaml` clearly specifies a different `model.context_length`.

This makes the context gauge (and the percent-full / compression-threshold markers derived from it) wrong for any model that isn't ~128K, until/unless the gateway reports an authoritative value.

## Fix

Prefer the user's configured `model.context_length` (when set and positive) ahead of the hardcoded constant:

```ts
const ctxLen = info?.context_max
  ?? (config?.model?.context_length && config.model.context_length > 0
      ? config.model.context_length
      : DEFAULT_CTX)
```

Resolution order is now: gateway `info.context_max` (authoritative runtime) → config `model.context_length` → `DEFAULT_CTX` (last resort). `config` is already in scope in `Context.tsx` (it's read for `compression.threshold`), so no new data plumbing.

## Changes

- `src/service/hmx-home.ts`: add `context_length` to the `HermesConfig.model` read type and parse it in `readConfig()` (defaults to `0` so the positivity guard handles "unset").
- `src/tabs/Context.tsx`: use the config value as the fallback before `DEFAULT_CTX`; updated the related comments.

## Verification

- `bunx tsc --noEmit` passes.
- No behavior change when the gateway reports `context_max` (still authoritative) or when `model.context_length` is unset (still falls back to 128K).