### PR TITLE
docs: add Quick Start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ bun run src/index.tsx
 
 Herm looks for `~/.hermes`. If yours lives elsewhere, set `HERMES_HOME`. See [`.env.example`](./.env.example) for rarely-needed overrides.
 
+## Quick Start
+
+Once herm launches you'll see a splash screen with tips at the bottom — click them to cycle through more. From there:
+
+**Change theme:** Type `/theme` in the composer to open the theme picker. Browse 40+ themes including Catppuccin, Dracula, Gruvbox, Nord, Tokyo Night, and many more. If text is hard to read (especially in tmux or with a dark terminal), pick a lighter theme like `daylight`, `mercury`, or `github`.
+
+**Get help:** Type `/help` for keyboard shortcuts, or press `Ctrl+K` to open the command palette for all available actions.
+
+**Navigate tabs:** Use `Tab` / `Shift+Tab` to move between top-level tabs (Sessions, Context, Config, etc.). Arrow keys navigate within a tab.
+
+**Key commands:** Type `/` in the composer for slash commands including:
+- `/new` — start a new session
+- `/resume <id>` — switch to an existing session
+- `/title <name>` — name the current session
+- `/model <name>` — switch models
+- `/skin <name>` — switch Hermes personality skins
+- `/keys` — view and rebind all keybindings
+- `/quit` — exit herm
+
+**Tip:** If you run herm inside tmux and text is unreadable (dark-on-dark), it's likely a color escape issue. Try `/theme daylight` or another light theme first, then check your tmux config — `set -g default-terminal "tmux-256color"` in `~/.tmux.conf` often fixes color issues on macOS.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## What

Add a **Quick Start** section to the README covering basic usage that new users struggle to find.

## Covers

- **Theme picker** — `/theme` command, searchable, 40+ themes, light theme suggestions for dark terminal / tmux contrast issues
- **Help** — `/help` for keyboard shortcuts, `Ctrl+K` command palette
- **Tab navigation** — `Tab` / `Shift+Tab` between tabs, arrows within
- **Slash commands** — `/new`, `/resume`, `/title`, `/model`, `/skin`, `/keys`, `/quit`
- **tmux troubleshooting** — 256color terminal string fix for macOS

## Why

Closes #92. The discoverability gap is real — new users land on the splash screen with no obvious way to find themes, help, or basic commands.