### PR TITLE
fix: harden lazy session startup

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -328,8 +328,12 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     // DB row, reaps its slash_worker subprocess, drops the AIAgent from
     // `_sessions`). Fire-and-forget — create() doesn't depend on it.
     if (prev) void session.close(prev)
-    try { setSid(await session.create()); sessionStart.current = Date.now() }
-    catch {}
+    try {
+      const r = await session.create()
+      setSid(r.id)
+      if (r.info) { setInfo(r.info); setUsage(r.info.usage) }
+      sessionStart.current = Date.now()
+    } catch {}
   }, [reset, session, gw])
 
   const switchSession = useCallback(async (target: string) => {
@@ -797,7 +801,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
               <VoiceIndicator voice={voice.state} keyLabel={voice.keyLabel} />
               <Composer
                 ref={composer}
-                focused={inputFocused} ready={ready} streaming={turn.streaming}
+                focused={inputFocused} connected={!!sid} ready={ready} streaming={turn.streaming}
                 status={status}
                 model={info?.model}
                 escHint={escHint}

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -472,7 +472,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           return
       }
     }
-    if (c.target !== "gateway" || !x.ready) return
+    if (c.target !== "gateway" || !x.sid) return
     const jump = TAB_SLASH[c.name]
     if (jump !== undefined && !arg) { x.goTo(jump.tab, jump.sub); return }
     const full = `/${c.name}${arg ? " " + arg : ""}`

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -48,7 +48,7 @@ export type CompressResult = {
   }
 }
 
-type Booted = { id: string; messages: Message[]; note?: string }
+type Booted = { id: string; messages: Message[]; note?: string; info?: SessionInfo }
 type Resumed = { id: string; messages: Message[]; info?: SessionInfo }
 type Activated = { id: string; messages: Message[]; info?: SessionInfo; running: boolean; status?: string; startedAt?: number }
 
@@ -58,7 +58,7 @@ export const normalize = (sid: string): string =>
 type SessionOps = {
   /** Establish the initial session per launch intent. */
   boot: (launch: Launch) => Promise<Booted>
-  create: () => Promise<string>
+  create: () => Promise<{ id: string; info?: SessionInfo }>
   resume: (sid: string) => Promise<Resumed>
   activate: (sid: string) => Promise<Activated>
   /** Finalize a gateway session (best-effort — swallows errors). */
@@ -106,7 +106,7 @@ export function useSession(): SessionOps {
   const create = useCallback(async () => {
     const res = await gw.request<SessionCreateResponse>("session.create", {})
     gw.setSession(res.session_id)
-    return res.session_id
+    return { id: res.session_id, info: res.info }
   }, [gw])
 
   const activate = useCallback(async (sid: string): Promise<Activated> => {
@@ -143,7 +143,7 @@ export function useSession(): SessionOps {
   }, [gw])
 
   const boot = useCallback(async (launch: Launch): Promise<Booted> => {
-    const fresh = async (note?: string) => ({ id: await create(), messages: [], note })
+    const fresh = async (note?: string) => ({ ...(await create()), messages: [], note })
 
     if (launch.mode === "resume") {
       const target = launch.sid ?? sdb.lastReal()?.id

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -117,6 +117,7 @@ export function useStream(c: Ctx) {
       onReady: () => {
         x.session.boot(x.launchRef.current).then((r) => {
           x.setSid(r.id)
+          if (r.info) { x.setInfo(r.info); x.setUsage(r.info.usage) }
           x.sessionStart.current = Date.now()
           if (r.messages.length) x.dispatch({ kind: "load", messages: r.messages })
           if (r.note) toast.show({ variant: "info", message: r.note })

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -49,6 +49,7 @@ export type ComposerHandle = {
 
 type Props = {
   focused: boolean
+  connected?: boolean
   ready: boolean
   streaming: boolean
   status?: string
@@ -268,7 +269,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     }
     const text = exp.text.trim()
     if (live.current.props.streaming) {
-      if (!text || !live.current.props.ready) return
+      if (!text || !(live.current.props.connected ?? live.current.props.ready)) return
       hist.push({ input: text, parts: exp.parts })
       write("")
       // Slash-shaped input routes through onSend so send() → slash()
@@ -281,7 +282,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     }
     const hasAtt = (live.current.props.attachments?.length ?? 0) > 0
     if (!text && !hasAtt) { live.current.props.onEmptyEnter?.(); return }
-    if (!live.current.props.ready) return
+    if (!(live.current.props.connected ?? live.current.props.ready)) return
     if (text) hist.push({ input: text, parts: exp.parts })
     write("")
     live.current.props.onSend(text, exp.parts)

--- a/test/lazy-session-ready.test.tsx
+++ b/test/lazy-session-ready.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+
+describe("lazy session startup", () => {
+  test("first prompt submits after session.create before session.info", async () => {
+    const gw = new MockGateway({
+      "session.create": () => ({
+        session_id: "lazy-sid",
+        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true },
+      }),
+      "prompt.submit": () => ({ status: "streaming" }),
+    })
+    gw.start = () => {
+      gw.ok = true
+      gw.push({ type: "gateway.ready" })
+    }
+
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Connecting") && t.frame().includes("lazy-model"))
+
+    await act(async () => { await t.keys.typeText("hello while lazy") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => Boolean(t.gw.last("prompt.submit")))
+
+    expect(t.gw.last("prompt.submit")?.params).toMatchObject({
+      session_id: "lazy-sid",
+      text: "hello while lazy",
+    })
+    t.destroy()
+  })
+
+  test("first skill slash command dispatches after session.create before session.info", async () => {
+    const gw = new MockGateway({
+      "session.create": () => ({
+        session_id: "lazy-sid",
+        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true },
+      }),
+      "commands.catalog": () => ({ pairs: [["/review", "Review with skill"]] }),
+      "slash.exec": () => { throw new Error("fall through") },
+      "command.dispatch": () => ({ type: "skill", name: "review", message: "Load review skill and continue" }),
+      "prompt.submit": () => ({ status: "streaming" }),
+    })
+    gw.start = () => {
+      gw.ok = true
+      gw.push({ type: "gateway.ready" })
+    }
+
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Connecting") && t.frame().includes("lazy-model"))
+    await until(t, () => Boolean(t.gw.last("commands.catalog")))
+
+    await act(async () => { await t.keys.typeText("/review") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => Boolean(t.gw.last("prompt.submit")))
+
+    expect(t.gw.last("slash.exec")?.params).toMatchObject({
+      session_id: "lazy-sid",
+      command: "/review",
+    })
+    expect(t.gw.last("command.dispatch")?.params).toMatchObject({
+      session_id: "lazy-sid",
+      name: "review",
+    })
+    expect(t.gw.last("prompt.submit")?.params).toMatchObject({
+      session_id: "lazy-sid",
+      text: "Load review skill and continue",
+    })
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## Summary
- preserves `session.create.info` so lazy sessions hydrate lightweight model/session state immediately
- centralizes startup action gates in explicit session capabilities instead of overloading `ready`
- lets prompts, skill slash commands, and queued prompts submit once a session id exists, while the status line can still show `Connecting...`

## Verification
- `bunx tsc --noEmit`
- `bun test test/sessionCapabilities.test.ts test/lazy-session-ready.test.tsx test/composer.test.tsx test/app.test.tsx`
- `bun test`
