### PR TITLE
test: add isolated home fixture

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,5 +1,16 @@
 # Test harness guide
 
+## Choosing the test tier
+
+- Pure helpers/reducers: import the function directly; no renderer.
+- `~/.hermes` readers/writers: use `tmpHome()` from `test/fixture/home`.
+- Component UI: use `mountNode()`; no global `useAppKeys` routing.
+- Shell/user flows: use `mount()` so app key routing and dialogs run.
+- Real process/CONTROL checks: use a sized pty + `/frame`; keep out of
+  default unit coverage unless explicitly scoped.
+- Host tools (git, chafa, ffmpeg, editors): gate or skip when the
+  binary/fixture is absent.
+
 ## Mount
 
 ```ts
@@ -18,6 +29,24 @@ await using t = await mountNode(<Foo ref={ref} />, { gw })
 `await using` → `[Symbol.asyncDispose]` destroys the renderer on
 block exit. Omit and call `t.destroy()` manually if you need to assert
 after cleanup.
+
+## Home fixtures
+
+```ts
+import { tmpHome } from "./fixture/home"
+
+await using h = await tmpHome({
+  config: { memory: { provider: "mem0" } },
+  files: { "memories/MEMORY.md": "one" },
+  prefs: { theme: "opencode" },
+})
+```
+
+`tmpHome()` creates a fresh `HERMES_HOME` and `HERM_CONFIG_DIR`, seeds
+files, calls `rehome()`, and restores the previous env on dispose. Use it
+for stateful service tests instead of sharing the preload sandbox. Dispose
+it after any renderer using it (`await using h` before `await using t`) so
+watchers close before the temp dir is removed.
 
 ## MockGateway
 

--- a/test/fixture/home.ts
+++ b/test/fixture/home.ts
@@ -1,0 +1,66 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { prefs } from "../../src/context/preferences"
+import { home } from "../../src/home/store"
+import { rehome } from "../../src/home/rehome"
+
+type Json = Record<string, unknown> | unknown[]
+
+type Seed = {
+  config?: string | Json
+  dirs?: string[]
+  files?: Record<string, string>
+  prefs?: Json
+}
+
+const base = () => join(process.env.HOME || homedir(), ".hermes")
+
+const write = (root: string, rel: string, body: string) => {
+  const file = join(root, rel)
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, body)
+}
+
+const yaml = (cfg: string | Json) =>
+  typeof cfg === "string" ? cfg : `${JSON.stringify(cfg, null, 2)}\n`
+
+export async function tmpHome(seed: Seed = {}) {
+  const prev = {
+    home: process.env.HERMES_HOME,
+    cfg: process.env.HERM_CONFIG_DIR,
+  }
+  const root = mkroot()
+  const path = join(root, "hermes")
+  const cfg = join(root, "config")
+
+  mkdirSync(path, { recursive: true })
+  mkdirSync(cfg, { recursive: true })
+  for (const dir of seed.dirs ?? []) mkdirSync(join(path, dir), { recursive: true })
+  for (const [rel, body] of Object.entries(seed.files ?? {})) write(path, rel, body)
+  if (seed.config !== undefined) write(path, "config.yaml", yaml(seed.config))
+  if (seed.prefs !== undefined) writeFileSync(join(cfg, "tui.json"), `${JSON.stringify(seed.prefs, null, 2)}\n`)
+
+  process.env.HERM_CONFIG_DIR = cfg
+  rehome(path)
+
+  return {
+    root,
+    path,
+    cfg,
+    write: (rel: string, body: string) => write(path, rel, body),
+    [Symbol.asyncDispose]: async () => {
+      home.close()
+      if (prev.cfg) process.env.HERM_CONFIG_DIR = prev.cfg
+      else delete process.env.HERM_CONFIG_DIR
+      rehome(prev.home ?? base())
+      if (!prev.home) delete process.env.HERMES_HOME
+      prefs.reload()
+      rmSync(root, { recursive: true, force: true })
+    },
+  }
+}
+
+function mkroot() {
+  return mkdtempSync(join(tmpdir(), "herm-home-"))
+}

--- a/test/home-fixture.test.ts
+++ b/test/home-fixture.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { tmpHome } from "./fixture/home"
+import { prefs } from "../src/context/preferences"
+import { hermesPath } from "../src/service/hermes-home"
+
+describe("tmpHome fixture", () => {
+  test("rebinds hermes home and config dirs, then restores them", async () => {
+    const prev = {
+      home: process.env.HERMES_HOME,
+      cfg: process.env.HERM_CONFIG_DIR,
+    }
+    let dir = ""
+
+    {
+      await using h = await tmpHome({
+        config: { memory: { provider: "mem0" } },
+        files: { "memories/MEMORY.md": "one" },
+        prefs: { theme: "opencode", lastSessionId: "sid-a" },
+      })
+      dir = h.path
+
+      expect(process.env.HERMES_HOME).toBe(h.path)
+      expect(process.env.HERM_CONFIG_DIR).toBe(h.cfg)
+      expect(hermesPath("memories/MEMORY.md")).toBe(`${h.path}/memories/MEMORY.md`)
+      expect(await Bun.file(hermesPath("memories/MEMORY.md")).text()).toBe("one")
+      expect(prefs.get("theme")).toBe("opencode")
+      expect(prefs.get("lastSessionId")).toBe("sid-a")
+
+      h.write("sessions/sessions.json", JSON.stringify({ a: { session_id: "sid-a" } }))
+      expect(await Bun.file(hermesPath("sessions/sessions.json")).exists()).toBe(true)
+    }
+
+    expect(process.env.HERMES_HOME).toBe(prev.home)
+    expect(process.env.HERM_CONFIG_DIR).toBe(prev.cfg)
+    expect(await Bun.file(`${dir}/memories/MEMORY.md`).exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Stateful Herm tests can now opt into a fresh `HERMES_HOME` and `HERM_CONFIG_DIR` instead of sharing the process-wide preload sandbox.

- Adds a disposable `tmpHome()` fixture that seeds files, config, and TUI prefs, then rebinds Herm through `rehome()`
- Covers the fixture's env rebinding, preference reload, seeded files, write helper, and cleanup path
- Documents the test tier decision tree so service tests use isolated homes while UI tests keep using the OpenTUI harness

## Verification

- `bun test test/home-fixture.test.ts`
- `bunx tsc --noEmit`
- `bun test`
