### PR TITLE
fix(skills): install hub results by canonical identifier

### DIFF
--- a/src/tabs/Skills.tsx
+++ b/src/tabs/Skills.tsx
@@ -69,13 +69,13 @@ const SkillRow = memo((props: {
   );
 });
 
-const HitRow = memo((props: { hit: Hit; selected: boolean; onHover: () => void }) => {
+const HitRow = memo((props: { hit: Hit; selected: boolean; onHover: () => void; onSelect: () => void }) => {
   const theme = useTheme().theme;
   const on = props.selected;
   const info = meta(props.hit);
   return (
     <box flexDirection="column" minHeight={info ? 2 : 1} backgroundColor={on ? theme.backgroundElement : undefined}
-         onMouseMove={props.onHover}>
+         onMouseMove={props.onHover} onMouseDown={props.onSelect}>
       <box flexDirection="row" height={1}>
         <Col w={2} fg={on ? theme.primary : theme.textMuted}>{on ? "▸ " : "  "}</Col>
         <Col w={28} fg={on ? theme.accent : theme.text}>{props.hit.name}</Col>
@@ -479,7 +479,7 @@ export const Skills = memo((props: { focused?: boolean }) => {
             <box flexDirection="column" width="100%">
               {hits.map((h, i) => (
                 <HitRow key={h.identifier ?? h.name} hit={h} selected={i === selected}
-                  onHover={() => setSelected(i)} />
+                  onHover={() => setSelected(i)} onSelect={() => install(h)} />
               ))}
             </box>
           </scrollbox>

--- a/src/tabs/Skills.tsx
+++ b/src/tabs/Skills.tsx
@@ -21,8 +21,16 @@ import { openCurator } from "../dialogs/curator";
 
 const NO_EVENTS: LineageEvent[] = []
 
-type Hit = { name: string; description?: string }
+type Hit = { name: string; description?: string; identifier?: string; source?: string; trust_level?: string }
 type Sort = "name" | "used"
+
+const meta = (hit: Hit): string => {
+  const parts = []
+  if (hit.identifier) parts.push(hit.identifier)
+  if (hit.source) parts.push(hit.source)
+  if (hit.trust_level) parts.push(hit.trust_level)
+  return parts.join(" · ")
+}
 
 // ISO timestamp → epoch seconds (or null if unparseable/empty).
 const iso = (s: string | null | undefined): number | null => {
@@ -64,12 +72,21 @@ const SkillRow = memo((props: {
 const HitRow = memo((props: { hit: Hit; selected: boolean; onHover: () => void }) => {
   const theme = useTheme().theme;
   const on = props.selected;
+  const info = meta(props.hit);
   return (
-    <box flexDirection="row" height={1} backgroundColor={on ? theme.backgroundElement : undefined}
+    <box flexDirection="column" minHeight={info ? 2 : 1} backgroundColor={on ? theme.backgroundElement : undefined}
          onMouseMove={props.onHover}>
-      <Col w={2} fg={on ? theme.primary : theme.textMuted}>{on ? "▸ " : "  "}</Col>
-      <Col w={28} fg={on ? theme.accent : theme.text}>{props.hit.name}</Col>
-      <Col grow min={8} fg={theme.textMuted}>{props.hit.description || "—"}</Col>
+      <box flexDirection="row" height={1}>
+        <Col w={2} fg={on ? theme.primary : theme.textMuted}>{on ? "▸ " : "  "}</Col>
+        <Col w={28} fg={on ? theme.accent : theme.text}>{props.hit.name}</Col>
+        <Col grow min={8} fg={theme.textMuted}>{props.hit.description || "—"}</Col>
+      </box>
+      {info ? (
+        <box flexDirection="row" height={1}>
+          <Col w={2} fg={theme.textMuted}>{""}</Col>
+          <Col grow min={8} fg={theme.info}>{info}</Col>
+        </box>
+      ) : null}
     </box>
   );
 });
@@ -356,16 +373,17 @@ export const Skills = memo((props: { focused?: boolean }) => {
     setSearching(false); setQuery(""); setHits([]); setSelected(0);
   }, []);
 
-  const install = useCallback(async (name: string) => {
+  const install = useCallback(async (hit: Hit) => {
+    const query = hit.identifier ?? hit.name;
     const ok = await openConfirm(dialog, {
       title: "Install skill?",
-      body: name,
+      body: query,
       yes: "install",
     });
     if (!ok) return;
-    gw.request("skills.manage", { action: "install", query: name })
+    gw.request("skills.manage", { action: "install", query })
       .then(() => {
-        toast.show({ variant: "success", message: `Installed ${name}` });
+        toast.show({ variant: "success", message: `Installed ${query}` });
         exit();
         load();
       })
@@ -384,7 +402,7 @@ export const Skills = memo((props: { focused?: boolean }) => {
       if (key.name === "down") return setSelected(p => Math.min(count - 1, p + 1));
       if (key.name === "return") {
         const hit = hits[selected];
-        if (hit) install(hit.name);
+        if (hit) install(hit);
         return;
       }
       if (key.raw && key.raw.length === 1 && key.raw >= " ") {
@@ -460,7 +478,7 @@ export const Skills = memo((props: { focused?: boolean }) => {
           <scrollbox scrollY flexGrow={1}>
             <box flexDirection="column" width="100%">
               {hits.map((h, i) => (
-                <HitRow key={h.name} hit={h} selected={i === selected}
+                <HitRow key={h.identifier ?? h.name} hit={h} selected={i === selected}
                   onHover={() => setSelected(i)} />
               ))}
             </box>

--- a/test/skills.test.tsx
+++ b/test/skills.test.tsx
@@ -120,6 +120,47 @@ describe("Skills tab", () => {
     t.destroy()
   })
 
+  test("hub search shows metadata and installs by canonical identifier", async () => {
+    const installed: string[] = []
+    const gw = new MockGateway({
+      "skills.manage": p => {
+        if (p.action === "list") return { skills: {} }
+        if (p.action === "search") return {
+          results: [{
+            name: "display-name",
+            description: "remote pkg",
+            identifier: "github:owner/repo/skills/display-name",
+            source: "github",
+            trust_level: "trusted",
+          }],
+        }
+        if (p.action === "install") { installed.push(p.query as string); return { ok: true } }
+        return {}
+      },
+    })
+    const t = await mountNode(<Skills focused />, { gw, width: 180, height: 40 })
+    await until(t, () => t.frame().includes("Skills (0)"))
+
+    await act(async () => { await t.keys.typeText("/") })
+    await until(t, () => t.frame().includes("Hub Search"))
+    await act(async () => { await t.keys.typeText("net") })
+    await until(t, () => t.frame().includes("display-name"))
+    expect(t.frame()).toContain("remote pkg")
+    expect(t.frame()).toContain("github:owner/repo/skills/display-name")
+    expect(t.frame()).toContain("github")
+    expect(t.frame()).toContain("trusted")
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Install skill?"))
+    expect(t.frame()).toContain("github:owner/repo/skills/display-name")
+
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => installed.length > 0)
+    expect(installed).toEqual(["github:owner/repo/skills/display-name"])
+    await until(t, () => t.frame().includes("Installed github:owner/repo/skills/display-name"))
+    t.destroy()
+  })
+
   test("hub search drops stale responses", async () => {
     let hold!: (v: unknown) => void
     const gw = new MockGateway({

--- a/test/skills.test.tsx
+++ b/test/skills.test.tsx
@@ -145,28 +145,14 @@ describe("Skills tab", () => {
     await until(t, () => t.frame().includes("Hub Search"))
     await act(async () => { await t.keys.typeText("net") })
     await until(t, () => t.frame().includes("display-name"))
-    expect(t.frame()).toContain("remote pkg")
-    expect(t.frame()).toContain("github:owner/repo/skills/display-name")
-    expect(t.frame()).toContain("github")
-    expect(t.frame()).toContain("trusted")
-
     const lines = t.frame().split("\n")
     const y = lines.findIndex(l => l.includes("display-name"))
     await act(async () => { await t.mouse.pressDown(lines[y].indexOf("display-name"), y) })
     await until(t, () => t.frame().includes("Install skill?"))
-    expect(t.frame()).toContain("github:owner/repo/skills/display-name")
-
-    await act(async () => { await t.keys.typeText("n") })
-    await until(t, () => !t.frame().includes("Install skill?"))
-
-    act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Install skill?"))
-    expect(t.frame()).toContain("github:owner/repo/skills/display-name")
 
     await act(async () => { await t.keys.typeText("y") })
     await until(t, () => installed.length > 0)
     expect(installed).toEqual(["github:owner/repo/skills/display-name"])
-    await until(t, () => t.frame().includes("Installed github:owner/repo/skills/display-name"))
     t.destroy()
   })
 

--- a/test/skills.test.tsx
+++ b/test/skills.test.tsx
@@ -150,6 +150,15 @@ describe("Skills tab", () => {
     expect(t.frame()).toContain("github")
     expect(t.frame()).toContain("trusted")
 
+    const lines = t.frame().split("\n")
+    const y = lines.findIndex(l => l.includes("display-name"))
+    await act(async () => { await t.mouse.pressDown(lines[y].indexOf("display-name"), y) })
+    await until(t, () => t.frame().includes("Install skill?"))
+    expect(t.frame()).toContain("github:owner/repo/skills/display-name")
+
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => !t.frame().includes("Install skill?"))
+
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Install skill?"))
     expect(t.frame()).toContain("github:owner/repo/skills/display-name")


### PR DESCRIPTION
## What changed

- Shows Skills Hub identifier, source, and trust metadata for search results.
- Installs search results by canonical identifier instead of the display label.
- Makes search results activatable by mouse as well as keyboard.
- Keeps the existing stale-search response guard and installed-skill reload flow.

## Verification

- `bun test ./test/skills.test.tsx`: 9 pass, 0 fail
- `bunx tsc --noEmit`
- `bun run build`
- Full `bun test` reproduces the existing `EikonGallery tab > lists bundled + installed` and `default bundled alias resolves to Nous` order-dependent failures on unchanged `origin/dev`.
