### PR TITLE
Integrate renderer idle and FPS settings batch

### DIFF
--- a/src/app/exit.ts
+++ b/src/app/exit.ts
@@ -14,6 +14,12 @@
 import { writeSync } from "node:fs"
 
 let done = false
+const fns = new Set<() => void>()
+
+export function onQuit(fn: () => void) {
+  fns.add(fn)
+  return () => fns.delete(fn)
+}
 
 export function quit(
   renderer: { destroy: () => void },
@@ -23,6 +29,7 @@ export function quit(
 ): never {
   if (done) process.exit(0)
   done = true
+  for (const fn of fns) fn()
   // Explicit SIGTERM to the gateway so its signal handler runs the
   // graceful sys.exit(0) → atexit → _shutdown_sessions path inside the
   // grace window. Without this we rely on stdin EOF, which works, but

--- a/src/app/idle.ts
+++ b/src/app/idle.ts
@@ -1,0 +1,105 @@
+import { StdinParser } from "@opentui/core"
+
+type Renderer = {
+  suspend: () => void
+  resume: () => void
+  addInputHandler?: (fn: (seq: string) => boolean) => void
+  prependInputHandler?: (fn: (seq: string) => boolean) => void
+  removeInputHandler?: (fn: (seq: string) => boolean) => void
+  currentControlState?: string
+  isDestroyed?: boolean
+}
+
+type Opts = { ms?: number }
+
+export class Idle {
+  private renderer: Renderer
+  private ms: number
+  private parser = new StdinParser({ armTimeouts: false })
+  private input = (seq: string) => this.handle(seq)
+  private timer?: Timer
+  private suspended = false
+  private stopping = false
+  private listening = false
+
+  constructor(renderer: Renderer, opts: Opts = {}) {
+    this.renderer = renderer
+    this.ms = opts.ms ?? 15_000
+  }
+
+  start() {
+    if (this.stopping) return
+    if (!this.listening) {
+      if (this.renderer.prependInputHandler) this.renderer.prependInputHandler(this.input)
+      else this.renderer.addInputHandler?.(this.input)
+      this.listening = true
+    }
+    this.arm()
+  }
+
+  activity() {
+    if (this.stopping) return
+    if (this.suspended) this.resume()
+    this.arm()
+  }
+
+  stop() {
+    this.stopping = true
+    this.clear()
+    this.unlisten()
+    if (this.suspended) this.resume()
+  }
+
+  shutdown() {
+    this.stopping = true
+    this.clear()
+    this.unlisten()
+  }
+
+  private handle(seq: string) {
+    const active = this.events(seq)
+    if (active) this.activity()
+    return false
+  }
+
+  private events(seq: string) {
+    let active = false
+    this.parser.push(Buffer.from(seq))
+    this.parser.drain(ev => {
+      if (ev.type === "key" || ev.type === "mouse" || ev.type === "paste") active = true
+    })
+    return active
+  }
+
+  private arm() {
+    this.clear()
+    this.timer = setTimeout(() => this.suspend(), this.ms)
+  }
+
+  private suspend() {
+    this.timer = undefined
+    if (this.stopping || this.suspended || this.renderer.isDestroyed) return
+    if (this.renderer.currentControlState !== "auto_started"
+      && this.renderer.currentControlState !== "explicit_started") return
+    this.renderer.suspend()
+    this.suspended = true
+  }
+
+  private resume() {
+    if (!this.suspended || this.renderer.isDestroyed) return
+    this.renderer.resume()
+    this.suspended = false
+  }
+
+  private clear() {
+    if (!this.timer) return
+    clearTimeout(this.timer)
+    this.timer = undefined
+  }
+
+  private unlisten() {
+    if (!this.listening) return
+    this.renderer.removeInputHandler?.(this.input)
+    this.listening = false
+  }
+}

--- a/src/context/preferences.ts
+++ b/src/context/preferences.ts
@@ -27,6 +27,8 @@ interface TuiPreferences {
   mouse?: boolean
   /** Target render FPS */
   targetFps?: number
+  /** Seconds without input before the renderer suspends */
+  idleSuspendSeconds?: number
   /** Last active session ID — stub-reuse check on fresh launch */
   lastSessionId?: string
   /** Active avatar by name; resolved against <profile>/eikons/ → bundled. */
@@ -82,9 +84,10 @@ export type KanbanPrefs = {
   }>
 }
 
-const DEFAULTS: Required<Pick<TuiPreferences, "mouse" | "targetFps">> = {
+const DEFAULTS: Required<Pick<TuiPreferences, "mouse" | "targetFps" | "idleSuspendSeconds">> = {
   mouse: true,
   targetFps: 30,
+  idleSuspendSeconds: 15,
 }
 
 import { configDir } from "../utils/paths"

--- a/src/context/preferences.ts
+++ b/src/context/preferences.ts
@@ -84,10 +84,24 @@ export type KanbanPrefs = {
   }>
 }
 
+export const TARGET_FPS_OPTIONS = [15, 24, 30] as const
+
 const DEFAULTS: Required<Pick<TuiPreferences, "mouse" | "targetFps" | "idleSuspendSeconds">> = {
   mouse: true,
   targetFps: 30,
   idleSuspendSeconds: 15,
+}
+
+export function targetFps(raw: unknown): number {
+  const n = typeof raw === "number" ? raw
+    : typeof raw === "string" && raw.trim() !== "" ? Number(raw)
+    : DEFAULTS.targetFps
+  if (!Number.isFinite(n)) return DEFAULTS.targetFps
+  const fps = Math.round(n)
+  if (fps < TARGET_FPS_OPTIONS[0]) return TARGET_FPS_OPTIONS[0]
+  if (fps > TARGET_FPS_OPTIONS[TARGET_FPS_OPTIONS.length - 1])
+    return TARGET_FPS_OPTIONS[TARGET_FPS_OPTIONS.length - 1]
+  return fps
 }
 
 import { configDir } from "../utils/paths"
@@ -129,7 +143,7 @@ export function load(): TuiPreferences {
       raw.eikon = raw.eikonPath.split("/").pop()?.replace(/\.eikon$/, "")
       delete raw.eikonPath
     }
-    const prefs = { ...DEFAULTS, ...raw }
+    const prefs = { ...DEFAULTS, ...raw, targetFps: targetFps(raw.targetFps) }
     cached = prefs
     return prefs
   } catch {
@@ -173,8 +187,9 @@ export function get<K extends keyof TuiPreferences>(key: K): TuiPreferences[K] {
  *  redundant writes (e.g. a picker's live-preview re-firing on the same
  *  row) don't notify subscribers and trigger render loops. */
 export function set<K extends keyof TuiPreferences>(key: K, value: TuiPreferences[K]): void {
-  if (load()[key] === value) return
-  save({ [key]: value } as Partial<TuiPreferences>)
+  const val = key === "targetFps" ? targetFps(value) : value
+  if (load()[key] === val) return
+  save({ [key]: val } as Partial<TuiPreferences>)
   for (const l of listeners) l()
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,7 @@ const main = async () => {
   const renderer = await createCliRenderer({
     exitOnCtrlC: false, // We handle Ctrl+C ourselves
     useMouse: prefs.mouse ?? true,
-    targetFps: prefs.targetFps ?? 30,
+    targetFps: preferences.targetFps(prefs.targetFps),
     gatherStats: false,
   });
   end()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,8 @@ import * as preferences from "./context/preferences";
 import { resetTerminalModes, installExitResetHooks } from "./utils/terminal-reset";
 import { warmup as warmTokens } from "./utils/tokens";
 import { prime as primeTheme, DEFAULT_THEME } from "./theme";
+import { Idle } from "./app/idle";
+import { onQuit } from "./app/exit";
 
 // Static ESM imports hoist above module-level code, so the only
 // honest import-graph measurement is process-uptime at the point
@@ -71,6 +73,10 @@ const main = async () => {
     || (process.stdout.isTTY && process.stdout.write("\x1b[>4;2m"))
   bump()
   renderer.on("focus", bump)
+  const idle = new Idle(renderer, { ms: Math.max(1, prefs.idleSuspendSeconds ?? 15) * 1000 })
+  idle.start()
+  renderer.on("destroy", () => idle.shutdown())
+  onQuit(() => idle.shutdown())
 
   perf.mem("post-renderer")
 

--- a/src/tabs/Config.tsx
+++ b/src/tabs/Config.tsx
@@ -17,6 +17,7 @@ import { readSlots, assign, resetAux, AUX_TASKS, type Slot } from "../config/mod
 import { openModelPicker } from "../dialogs/model-picker";
 import { managedSystem, makeSource } from "../service/hermes-home";
 import { FileLink } from "../components/ui/FileLink";
+import * as preferences from "../context/preferences";
 
 const flatten = (obj: Record<string, unknown>, prefix = ""): [string, unknown][] =>
   Object.entries(obj).flatMap(([k, v]) => {
@@ -154,6 +155,31 @@ const SlotRow = memo((p: { id: string; s: Slot; on: boolean }) => {
   );
 });
 
+const PrefRow = memo((p: { id: string; on: boolean }) => {
+  const theme = useTheme().theme;
+  const fps = preferences.usePref("targetFps") ?? 30;
+  return (
+    <box id={p.id} flexDirection="column" backgroundColor={p.on ? theme.backgroundElement : undefined}>
+      <box flexDirection="row" height={1}>
+        <Col w={2} fg={theme.textMuted}>·</Col>
+        <Col w={2} fg={p.on ? theme.primary : theme.text}>{p.on ? "▸ " : "  "}</Col>
+        <Col w={40} fg={p.on ? theme.accent : theme.text}>target FPS</Col>
+        <Col grow min={6} fg={theme.text}>{`${fps} fps`}</Col>
+        <Col w={2} fg={theme.textMuted}>⟳</Col>
+        <Col w={9} fg={theme.textMuted} right>{p.on ? "[h/l]" : ""}</Col>
+      </box>
+      {p.on ? (
+        <box flexDirection="row" minHeight={1}>
+          <box width={4} flexShrink={0} />
+          <box width={40} flexShrink={0} minHeight={1}>
+            <text wrapMode="word" fg={theme.textMuted}>Renderer frame budget. 15 fps lowers idle power, 30 fps is smoother. Restart Herm to apply.</text>
+          </box>
+        </box>
+      ) : null}
+    </box>
+  );
+});
+
 export const Config = memo((props: { focused?: boolean }) => {
   const theme = useTheme().theme;
   const gw = useGateway();
@@ -206,16 +232,18 @@ export const Config = memo((props: { focused?: boolean }) => {
   // model" lands, instead of the 56-field `auxiliary` group.
   const groups = [...grouped.keys()];
   groups.splice(1, 0, "models");
+  groups.push("TUI");
 
   const active = groups[cat] ?? groups[0];
   const onSlots = active === "models" && !searching;
+  const onPrefs = active === "TUI" && !searching;
   const slots = readSlots(raw);
   const secs: Section[] = searching && query.trim()
     ? [{ head: null, items: all.filter(f => f.key.toLowerCase().includes(query.toLowerCase())) }]
     : sections(active, grouped.get(active) ?? []);
   const fields = secs.flatMap(s => s.items);
 
-  const count = onSlots ? slots.length : fields.length;
+  const count = onSlots ? slots.length : onPrefs ? 1 : fields.length;
   const follow = useFollow("cfg");
   const catFollow = useFollow("cfg-cat");
 
@@ -426,6 +454,25 @@ export const Config = memo((props: { focused?: boolean }) => {
       return;
     }
 
+    if (onPrefs) {
+      const opts = preferences.TARGET_FPS_OPTIONS;
+      const i = opts.findIndex(fps => fps === preferences.targetFps(preferences.get("targetFps")));
+      if (key.raw === "l" || key.raw === "]") {
+        const fps = opts[(i + 1) % opts.length];
+        preferences.set("targetFps", fps);
+        toast.show({ variant: "success", message: `target FPS → ${fps}; restart Herm to apply` });
+        return;
+      }
+      if (key.raw === "h" || key.raw === "[") {
+        const fps = opts[(i - 1 + opts.length) % opts.length];
+        preferences.set("targetFps", fps);
+        toast.show({ variant: "success", message: `target FPS → ${fps}; restart Herm to apply` });
+        return;
+      }
+      handleListKey(keys, key, { count, setSel: setCursor, ...follow.opts });
+      return;
+    }
+
     const f = fields[cursor];
     const writable = !managed;
     const matched = handleListKey(keys, key, {
@@ -495,7 +542,7 @@ export const Config = memo((props: { focused?: boolean }) => {
                 const sel = i === cat;
                 const hot = sel && focus === "categories";
                 const items = grouped.get(c) ?? [];
-                const n = c === "models" ? slots.length : items.length;
+                const n = c === "models" ? slots.length : c === "TUI" ? 1 : items.length;
                 const catDirty = items.some(f => changed(f.key));
                 return (
                   <box
@@ -541,6 +588,16 @@ export const Config = memo((props: { focused?: boolean }) => {
                   <SlotRow key={s.key} id={follow.id(i)} s={s}
                            on={i === cursor && focus === "fields"} />
                 ))}
+              </scrollbox>
+            </box>
+          ) : onPrefs ? (
+            <box key="prefs" flexDirection="column" flexGrow={1}>
+              <box height={1}><text fg={theme.textMuted}>
+                Local Herm preferences persist to tui.json. Renderer settings apply on next launch.
+              </text></box>
+              <box height={1} />
+              <scrollbox ref={follow.ref} scrollY flexGrow={1} verticalScrollbarOptions={VBAR}>
+                <PrefRow id={follow.id(0)} on={focus === "fields"} />
               </scrollbox>
             </box>
           ) : (<>
@@ -604,6 +661,8 @@ export const Config = memo((props: { focused?: boolean }) => {
               ["X", "reset-all"],
               ["Tab", "categories"],
             ]} />
+          : onPrefs
+            ? <HintBar pairs={[["h/l", "target fps"], ["Tab", "categories"]]} />
           : focus === "categories" && !searching
             ? <HintBar pairs={[["↑↓", "select"], ["Tab", "fields"]]} />
             : <HintBar

--- a/src/tabs/Config.tsx
+++ b/src/tabs/Config.tsx
@@ -83,7 +83,7 @@ const FieldRow = memo((props: {
   const hint = (): string => {
     if (props.readonly || f.type === "readonly") return "🔒";
     if (f.type === "boolean") return "[space]";
-    if (f.type === "select") return "[h/l]";
+    if (f.type === "select") return "[←→]";
     return "[enter]";
   };
 
@@ -155,18 +155,19 @@ const SlotRow = memo((p: { id: string; s: Slot; on: boolean }) => {
   );
 });
 
-const PrefRow = memo((p: { id: string; on: boolean }) => {
+const PrefRow = memo((p: { id: string; on: boolean; onHover: () => void; onSelect: () => void }) => {
   const theme = useTheme().theme;
   const fps = preferences.usePref("targetFps") ?? 30;
   return (
-    <box id={p.id} flexDirection="column" backgroundColor={p.on ? theme.backgroundElement : undefined}>
+    <box id={p.id} flexDirection="column" backgroundColor={p.on ? theme.backgroundElement : undefined}
+         onMouseMove={p.onHover} onMouseDown={p.onSelect}>
       <box flexDirection="row" height={1}>
         <Col w={2} fg={theme.textMuted}>·</Col>
         <Col w={2} fg={p.on ? theme.primary : theme.text}>{p.on ? "▸ " : "  "}</Col>
         <Col w={40} fg={p.on ? theme.accent : theme.text}>target FPS</Col>
         <Col grow min={6} fg={theme.text}>{`${fps} fps`}</Col>
         <Col w={2} fg={theme.textMuted}>⟳</Col>
-        <Col w={9} fg={theme.textMuted} right>{p.on ? "[h/l]" : ""}</Col>
+        <Col w={9} fg={theme.textMuted} right>{p.on ? "[←→]" : ""}</Col>
       </box>
       {p.on ? (
         <box flexDirection="row" minHeight={1}>
@@ -257,6 +258,14 @@ export const Config = memo((props: { focused?: boolean }) => {
     setNested(next, key, val);
     setRaw(next);
     setYaml(yamlStringify(next));
+  };
+
+  const fps = (step: 1 | -1) => {
+    const opts = preferences.TARGET_FPS_OPTIONS;
+    const i = opts.findIndex(n => n === preferences.targetFps(preferences.get("targetFps")));
+    const val = opts[(i + step + opts.length) % opts.length];
+    preferences.set("targetFps", val);
+    toast.show({ variant: "success", message: `target FPS → ${val}; restart Herm to apply` });
   };
 
   const fmt = (v: unknown) =>
@@ -455,20 +464,8 @@ export const Config = memo((props: { focused?: boolean }) => {
     }
 
     if (onPrefs) {
-      const opts = preferences.TARGET_FPS_OPTIONS;
-      const i = opts.findIndex(fps => fps === preferences.targetFps(preferences.get("targetFps")));
-      if (key.raw === "l" || key.raw === "]") {
-        const fps = opts[(i + 1) % opts.length];
-        preferences.set("targetFps", fps);
-        toast.show({ variant: "success", message: `target FPS → ${fps}; restart Herm to apply` });
-        return;
-      }
-      if (key.raw === "h" || key.raw === "[") {
-        const fps = opts[(i - 1 + opts.length) % opts.length];
-        preferences.set("targetFps", fps);
-        toast.show({ variant: "success", message: `target FPS → ${fps}; restart Herm to apply` });
-        return;
-      }
+      if (key.name === "right" || key.raw === "l" || key.raw === "]") { fps(1); return; }
+      if (key.name === "left" || key.raw === "h" || key.raw === "[") { fps(-1); return; }
       handleListKey(keys, key, { count, setSel: setCursor, ...follow.opts });
       return;
     }
@@ -487,11 +484,11 @@ export const Config = memo((props: { focused?: boolean }) => {
 
     if (f.type === "select" && f.options) {
       const idx = f.options.indexOf(String(f.value));
-      if (key.raw === "l" || key.raw === "]") {
+      if (key.name === "right" || key.raw === "l" || key.raw === "]") {
         update(f.key, f.options[(idx + 1) % f.options.length]);
         return;
       }
-      if (key.raw === "h" || key.raw === "[") {
+      if (key.name === "left" || key.raw === "h" || key.raw === "[") {
         update(f.key, f.options[(idx - 1 + f.options.length) % f.options.length]);
         return;
       }
@@ -597,7 +594,9 @@ export const Config = memo((props: { focused?: boolean }) => {
               </text></box>
               <box height={1} />
               <scrollbox ref={follow.ref} scrollY flexGrow={1} verticalScrollbarOptions={VBAR}>
-                <PrefRow id={follow.id(0)} on={focus === "fields"} />
+                <PrefRow id={follow.id(0)} on={focus === "fields"}
+                         onHover={() => { setFocus("fields"); setCursor(0); }}
+                         onSelect={() => { setFocus("fields"); setCursor(0); fps(1); }} />
               </scrollbox>
             </box>
           ) : (<>
@@ -662,7 +661,7 @@ export const Config = memo((props: { focused?: boolean }) => {
               ["Tab", "categories"],
             ]} />
           : onPrefs
-            ? <HintBar pairs={[["h/l", "target fps"], ["Tab", "categories"]]} />
+            ? <HintBar pairs={[["←→", "target fps"], ["Tab", "categories"]]} />
           : focus === "categories" && !searching
             ? <HintBar pairs={[["↑↓", "select"], ["Tab", "fields"]]} />
             : <HintBar

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -279,12 +279,21 @@ describe("Config tab", () => {
     await until(t, () => t.frame().includes("target FPS"))
     expect(t.frame()).toContain("30 fps")
     expect(t.frame()).toContain("15 fps lowers")
+    expect(t.frame()).toContain("[←→] target fps")
 
-    await act(async () => { await t.keys.typeText("h") })
+    act(() => t.keys.pressArrow("left"))
     await until(t, () => prefs.get("targetFps") === 24)
-    await act(async () => { await t.keys.typeText("h") })
+    act(() => t.keys.pressArrow("left"))
     await until(t, () => prefs.get("targetFps") === 15)
     expect(t.frame()).toContain("15 fps")
+
+    const lines = t.frame().split("\n")
+    const y = lines.findIndex(l => l.includes("target FPS") && l.includes("15 fps"))
+    await act(async () => { await t.mouse.pressDown(lines[y].indexOf("target FPS"), y) })
+    await until(t, () => prefs.get("targetFps") === 24)
+    act(() => t.keys.pressArrow("left"))
+    await until(t, () => prefs.get("targetFps") === 15)
+
     prefs.reset()
     expect(prefs.get("targetFps")).toBe(15)
     t.destroy()

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -266,4 +266,27 @@ describe("Config tab", () => {
     expect(t.frame().split("\n").some(l => l.includes("▸") && l.includes("general"))).toBe(true)
     t.destroy()
   })
+
+  test("tui preferences expose target FPS and persist lower-power preset", async () => {
+    const prefs = await import("../src/context/preferences")
+    prefs.set("targetFps", 30)
+    const gw = new MockGateway({ "config.get": () => ({ config: {} }) })
+    const t = await mountNode(<Config focused />, { gw, width: 160, height: 40 })
+    await until(t, () => t.frame().includes("TUI (1)"))
+
+    for (let i = 0; i <= GROUPS.length; i++) act(() => t.keys.pressArrow("down"))
+    act(() => t.keys.pressTab())
+    await until(t, () => t.frame().includes("target FPS"))
+    expect(t.frame()).toContain("30 fps")
+    expect(t.frame()).toContain("15 fps lowers")
+
+    await act(async () => { await t.keys.typeText("h") })
+    await until(t, () => prefs.get("targetFps") === 24)
+    await act(async () => { await t.keys.typeText("h") })
+    await until(t, () => prefs.get("targetFps") === 15)
+    expect(t.frame()).toContain("15 fps")
+    prefs.reset()
+    expect(prefs.get("targetFps")).toBe(15)
+    t.destroy()
+  })
 })

--- a/test/idle-renderer.test.ts
+++ b/test/idle-renderer.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test"
+import { Idle } from "../src/app/idle"
+
+class Renderer {
+  currentControlState = "auto_started"
+  isDestroyed = false
+  suspends = 0
+  resumes = 0
+  inputs: Array<(seq: string) => boolean> = []
+
+  suspend() { this.suspends++ }
+  resume() { this.resumes++ }
+  prependInputHandler(fn: (seq: string) => boolean) { this.inputs.unshift(fn) }
+  removeInputHandler(fn: (seq: string) => boolean) {
+    this.inputs = this.inputs.filter(x => x !== fn)
+  }
+  write(seq: string) { this.inputs.forEach(fn => fn(seq)) }
+}
+
+describe("Idle", () => {
+  test("suspends after idle timeout", async () => {
+    const r = new Renderer()
+    const idle = new Idle(r, { ms: 100 })
+
+    idle.start()
+    await Bun.sleep(110)
+
+    expect(r.suspends).toBe(1)
+    expect(r.resumes).toBe(0)
+    idle.stop()
+  })
+
+  test("keyboard activity resumes before callers continue", async () => {
+    const r = new Renderer()
+    const idle = new Idle(r, { ms: 100 })
+
+    idle.start()
+    await Bun.sleep(110)
+    r.write("a")
+
+    expect(r.suspends).toBe(1)
+    expect(r.resumes).toBe(1)
+    idle.stop()
+  })
+
+  test("mouse activity resumes before target handlers run", async () => {
+    const r = new Renderer()
+    const order: string[] = []
+    const idle = new Idle(r, { ms: 100 })
+
+    idle.start()
+    r.inputs.push(() => { order.push(r.resumes === 1 ? "resumed" : "suspended"); return false })
+    await Bun.sleep(110)
+    r.write("\x1B[<0;1;1M")
+
+    expect(r.suspends).toBe(1)
+    expect(r.resumes).toBe(1)
+    expect(order).toEqual(["resumed"])
+    idle.stop()
+  })
+
+  test("activity postpones suspend", async () => {
+    const r = new Renderer()
+    const idle = new Idle(r, { ms: 100 })
+
+    idle.start()
+    await Bun.sleep(60)
+    r.write("a")
+    await Bun.sleep(60)
+    expect(r.suspends).toBe(0)
+    await Bun.sleep(55)
+    expect(r.suspends).toBe(1)
+    idle.stop()
+  })
+
+  test("stop cleans timer and resumes if suspended", async () => {
+    const r = new Renderer()
+    const idle = new Idle(r, { ms: 100 })
+
+    idle.start()
+    await Bun.sleep(110)
+    idle.stop()
+    await Bun.sleep(110)
+
+    expect(r.suspends).toBe(1)
+    expect(r.resumes).toBe(1)
+  })
+
+  test("shutdown prevents suspend and resume", async () => {
+    const r = new Renderer()
+    const idle = new Idle(r, { ms: 100 })
+
+    idle.start()
+    idle.shutdown()
+    await Bun.sleep(110)
+    r.write("a")
+
+    expect(r.suspends).toBe(0)
+    expect(r.resumes).toBe(0)
+  })
+})

--- a/test/prefs-migrate.test.ts
+++ b/test/prefs-migrate.test.ts
@@ -12,3 +12,17 @@ test("prefs: eikonPath → eikon migration on load", () => {
   expect(prefs.get("eikonPath")).toBeUndefined()
   expect(prefs.get("theme")).toBe("t")
 })
+
+test("prefs: targetFps is parsed and clamped", () => {
+  mkdirSync(configDir(), { recursive: true })
+  writeFileSync(`${configDir()}/tui.json`, JSON.stringify({ targetFps: "12" }))
+  prefs.reset()
+  expect(prefs.get("targetFps")).toBe(15)
+
+  prefs.set("targetFps", 99)
+  expect(prefs.get("targetFps")).toBe(30)
+
+  prefs.set("targetFps", 24)
+  prefs.reset()
+  expect(prefs.get("targetFps")).toBe(24)
+})


### PR DESCRIPTION
## Summary
- suspend OpenTUI rendering after idle periods and resume before input handlers run
- expose target FPS as a TUI preference in config with persisted presets
- clamp migrated/loaded target FPS values and add shutdown-safe renderer resume

## Verification
- bunx tsc --noEmit
- bun test
- targeted: bun test test/idle-renderer.test.ts test/prefs-migrate.test.ts test/config.test.tsx