### PR TITLE
fix: Windows Eikon tab crash

### DIFF
--- a/src/service/eikon-gen.ts
+++ b/src/service/eikon-gen.ts
@@ -16,12 +16,13 @@ export type GenerateOut = { path: string } | { err: string }
 export type GenerateFn = (kind: GenerateKind, prompt: string, opts: GenerateOpts) => Promise<GenerateOut>
 
 const ROOT = () => hermesPath("hermes-agent")
+const isWin = process.platform === "win32"
 const PY = () => {
   for (const v of ["venv", ".venv"]) {
-    const p = `${ROOT()}/${v}/bin/python`
-    if (existsSync(p)) return p
+    const bin = isWin ? `${ROOT()}/${v}/Scripts/python.exe` : `${ROOT()}/${v}/bin/python`
+    if (existsSync(bin)) return bin
   }
-  return "python3"
+  return isWin ? "python" : "python3"
 }
 
 /** API keys live in ~/.hermes/.env (per AGENTS.md: env file is keys-
@@ -87,7 +88,9 @@ export async function probe(): Promise<{ image: boolean; video: boolean }> {
     "from tools.video_generation_tool import check_video_generation_requirements as cv",
     "print(json.dumps({'image': bool(ci()), 'video': bool(cv())}))",
   ].join("; ")
-  const r = Bun.spawn([PY(), "-c", src], { cwd: root, env: env(), stdout: "pipe", stderr: "pipe" })
+  let r
+  try { r = Bun.spawn([PY(), "-c", src], { cwd: root, env: env(), stdout: "pipe", stderr: "pipe" }) }
+  catch { return { image: false, video: false } }
   const out = await new Response(r.stdout).text()
   if ((await r.exited) !== 0) return { image: false, video: false }
   const last = out.trim().split("\n").pop()!
@@ -95,7 +98,7 @@ export async function probe(): Promise<{ image: boolean; video: boolean }> {
 }
 
 async function fetchTo(url: string, ext: string): Promise<string> {
-  const tmp = `${process.env.TMPDIR ?? "/tmp"}/eikon-gen-${Date.now()}${ext}`
+  const tmp = `${process.env.TMPDIR ?? process.env.TEMP ?? process.env.TMP ?? "/tmp"}/eikon-gen-${Date.now()}${ext}`
   const res = await fetch(url)
   if (!res.ok) throw new Error(`download ${res.status}`)
   await Bun.write(tmp, await res.arrayBuffer())

--- a/src/service/eikon-gen.ts
+++ b/src/service/eikon-gen.ts
@@ -8,6 +8,8 @@
 // providers) can swap the backend without touching callers.
 
 import { existsSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { hermesPath } from "./hermes-home"
 
 export type GenerateKind = "image" | "video"
@@ -16,13 +18,18 @@ export type GenerateOut = { path: string } | { err: string }
 export type GenerateFn = (kind: GenerateKind, prompt: string, opts: GenerateOpts) => Promise<GenerateOut>
 
 const ROOT = () => hermesPath("hermes-agent")
-const isWin = process.platform === "win32"
+const WIN = process.platform === "win32"
 const PY = () => {
   for (const v of ["venv", ".venv"]) {
-    const bin = isWin ? `${ROOT()}/${v}/Scripts/python.exe` : `${ROOT()}/${v}/bin/python`
+    const bin = WIN ? `${ROOT()}/${v}/Scripts/python.exe` : `${ROOT()}/${v}/bin/python`
     if (existsSync(bin)) return bin
   }
-  return isWin ? "python" : "python3"
+  return WIN ? "python" : "python3"
+}
+
+const spawn = (args: string[]) => {
+  try { return Bun.spawn([PY(), ...args], { cwd: ROOT(), env: env(), stdout: "pipe", stderr: "pipe" }) }
+  catch (e) { return e instanceof Error ? e : new Error(String(e)) }
 }
 
 /** API keys live in ~/.hermes/.env (per AGENTS.md: env file is keys-
@@ -88,9 +95,8 @@ export async function probe(): Promise<{ image: boolean; video: boolean }> {
     "from tools.video_generation_tool import check_video_generation_requirements as cv",
     "print(json.dumps({'image': bool(ci()), 'video': bool(cv())}))",
   ].join("; ")
-  let r
-  try { r = Bun.spawn([PY(), "-c", src], { cwd: root, env: env(), stdout: "pipe", stderr: "pipe" }) }
-  catch { return { image: false, video: false } }
+  const r = spawn(["-c", src])
+  if (r instanceof Error) return { image: false, video: false }
   const out = await new Response(r.stdout).text()
   if ((await r.exited) !== 0) return { image: false, video: false }
   const last = out.trim().split("\n").pop()!
@@ -98,7 +104,7 @@ export async function probe(): Promise<{ image: boolean; video: boolean }> {
 }
 
 async function fetchTo(url: string, ext: string): Promise<string> {
-  const tmp = `${process.env.TMPDIR ?? process.env.TEMP ?? process.env.TMP ?? "/tmp"}/eikon-gen-${Date.now()}${ext}`
+  const tmp = join(tmpdir(), `eikon-gen-${Date.now()}${ext}`)
   const res = await fetch(url)
   if (!res.ok) throw new Error(`download ${res.status}`)
   await Bun.write(tmp, await res.arrayBuffer())
@@ -106,8 +112,8 @@ async function fetchTo(url: string, ext: string): Promise<string> {
 }
 
 export const generate: GenerateFn = async (kind, prompt, opts) => {
-  const r = Bun.spawn([PY(), "-c", code(kind, prompt, opts)],
-    { cwd: ROOT(), env: env(), stdout: "pipe", stderr: "pipe" })
+  const r = spawn(["-c", code(kind, prompt, opts)])
+  if (r instanceof Error) return { err: r.message }
   const [out, err, exit] = await Promise.all([
     new Response(r.stdout).text(),
     new Response(r.stderr).text(),

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -442,7 +442,12 @@ const BLANK: Frame = Array.from({ length: H }, () => " ".repeat(W))
 // provider availability (configured key/gateway), not just the
 // toolset toggle. Cached at module scope; tests reset via setImpl.
 let genCaps: Promise<{ image: boolean; video: boolean }> | null = null
-const probeGen = () => (genCaps ??= gen.probeCached())
+const probeGen = () => {
+  if (genCaps) return genCaps
+  const p = gen.probeCached()
+  p.catch(() => { genCaps = null })
+  return (genCaps = p)
+}
 /** Test-only — wipe the gen-caps cache between mountNode calls. */
 export const resetToolsetsCache = () => { genCaps = null }
 
@@ -541,7 +546,7 @@ export const EikonStudio = memo((props: {
   // at module scope — repeated mounts share one subprocess.
   useEffect(() => {
     let dead = false
-    void probeGen().then(c => { if (!dead) setGenOk(c) })
+    void probeGen().then(c => { if (!dead) setGenOk(c) }).catch(() => {})
     return () => { dead = true }
   }, [])
 

--- a/test/eikon-gen.test.ts
+++ b/test/eikon-gen.test.ts
@@ -78,6 +78,22 @@ test("dotenv keys reach the child process so providers see API keys", async () =
   expect("path" in out).toBe(true)
 })
 
+test("missing fallback python degrades instead of rejecting", async () => {
+  rmSync(ROOT, { recursive: true, force: true })
+  mkdirSync(ROOT, { recursive: true })
+  const old = process.env.PATH
+  process.env.PATH = join(HH, "empty-path")
+  mkdirSync(process.env.PATH, { recursive: true })
+  try {
+    expect(await gen.probe()).toEqual({ image: false, video: false })
+    const out = await gen.generate("image", "x", {})
+    expect("err" in out).toBe(true)
+  } finally {
+    if (old === undefined) delete process.env.PATH
+    else process.env.PATH = old
+  }
+})
+
 test("probe() returns false/false when hermes-agent install absent", async () => {
   rmSync(ROOT, { recursive: true, force: true })
   const c = await gen.probe()


### PR DESCRIPTION
Fixes the Windows-specific crash that occurs when opening the Eikon tab. This PR addresses all root causes:
1. Fixes Python path detection for Windows venvs (uses /Scripts/python.exe instead of /bin/python)
2. Uses system  instead of  as fallback on Windows
3. Adds Windows temp directory fallback (uses %TEMP%/%TMP% instead of only /tmp)
4. Adds error handling to catch Bun.spawn() failures and prevent unhandled rejections
5. Adds defense-in-depth .catch() in EikonStudio to never pass an unhandled rejection to the global handler

Fixes #105 — opening the Eikon tab no longer forces an immediate process exit on Windows. All changes are cross-platform safe and retain full functionality on Linux/macOS. This is a pure bugfix PR with no additional features.