### PR TITLE
fix(chat): collapse inline diff tabs

### DIFF
--- a/src/components/chat/DiffTabs.tsx
+++ b/src/components/chat/DiffTabs.tsx
@@ -1,7 +1,5 @@
-// Tabbed diff frame for an assistant turn — replaces the prior stack of
-// ▸ collapsible chips with one CodeBlock-style frame whose header is a
-// wrapping row of file tabs (basenames). The active tab swaps the body.
-// Always-open: there's no per-chip toggle. Mouse-only selection.
+// Tabbed diff frame for an assistant turn. Tabs stay visible; clicking
+// a tab toggles that diff body inline.
 
 import { memo, useMemo, useState } from "react"
 import type { MouseEvent } from "@opentui/core"
@@ -92,9 +90,10 @@ function buildTabs(tools: ToolPart[]): Tab[] {
 export const DiffTabs = memo(({ tools }: { tools: ToolPart[] }) => {
   const theme = useTheme().theme
   const tabs = useMemo(() => buildTabs(tools), [tools])
-  const [active, setActive] = useState(0)
+  const [active, setActive] = useState<number | null>(null)
   if (tabs.length === 0) return null
-  const cur = tabs[Math.min(active, tabs.length - 1)]
+  const idx = active === null ? null : Math.min(active, tabs.length - 1)
+  const cur = idx === null ? null : tabs[idx]
 
   return (
     <box
@@ -107,12 +106,18 @@ export const DiffTabs = memo(({ tools }: { tools: ToolPart[] }) => {
         backgroundColor={theme.backgroundElement} paddingX={1}
       >
         {tabs.map((t, i) => {
-          const on = i === active
+          const on = i === idx
           return (
             <box
               key={t.id} height={1} flexShrink={0} marginRight={1} paddingX={1}
               backgroundColor={on ? theme.backgroundPanel : undefined}
-              onMouseDown={(e: MouseEvent) => { e.stopPropagation(); setActive(i) }}
+              onMouseDown={(e: MouseEvent) => {
+                e.stopPropagation()
+                setActive(n => {
+                  const hit = n === null ? null : Math.min(n, tabs.length - 1)
+                  return hit === i ? null : i
+                })
+              }}
             >
               <text fg={on ? theme.primary : theme.textMuted}>
                 {on ? <strong>{t.label}</strong> : t.label}
@@ -121,16 +126,18 @@ export const DiffTabs = memo(({ tools }: { tools: ToolPart[] }) => {
           )
         })}
       </box>
-      <box height={1} paddingX={1}>
-        <text>
-          <span fg={theme.success}>+{cur.add}</span>
-          <span fg={theme.textMuted}> / </span>
-          <span fg={theme.error}>-{cur.del}</span>
-        </text>
-      </box>
-      <box paddingX={1} paddingBottom={1}>
-        <DiffBlock text={cur.diff} />
-      </box>
+      {cur ? <>
+        <box height={1} paddingX={1}>
+          <text>
+            <span fg={theme.success}>+{cur.add}</span>
+            <span fg={theme.textMuted}> / </span>
+            <span fg={theme.error}>-{cur.del}</span>
+          </text>
+        </box>
+        <box paddingX={1} paddingBottom={1}>
+          <DiffBlock text={cur.diff} />
+        </box>
+      </> : null}
     </box>
   )
 })

--- a/test/diff-tabs.test.tsx
+++ b/test/diff-tabs.test.tsx
@@ -29,7 +29,7 @@ describe("DiffTabs", () => {
     t.destroy()
   })
 
-  test("single diff: tab label is basename, +1/-1 row, body present", async () => {
+  test("single diff: tab label is basename and body is collapsed", async () => {
     const t = await mountNode(
       <DiffTabs tools={[tool("a", "src/foo.ts", "thing")]} />,
       { width: 80, height: 16 },
@@ -37,16 +37,15 @@ describe("DiffTabs", () => {
     await until(t, () => t.frame().includes("foo.ts"))
     const f = t.frame()
     expect(f).toContain("foo.ts")
-    // Tab label uses basename — find the row showing "foo.ts" without the "src/" prefix.
     const tabRow = f.split("\n").find(l => /foo\.ts/.test(l) && !/src\/foo\.ts/.test(l))
     expect(tabRow).toBeDefined()
-    expect(f).toContain("+1")
-    expect(f).toContain("-1")
-    expect(f).toContain("+new thing")
+    expect(f).not.toContain("+1")
+    expect(f).not.toContain("-1")
+    expect(f).not.toContain("+new thing")
     t.destroy()
   })
 
-  test("three diffs: ribbon shows all, click swaps body", async () => {
+  test("clicking a tab toggles its body", async () => {
     const tools = [
       tool("a", "alpha.ts", "alpha"),
       tool("b", "beta.ts", "beta"),
@@ -54,17 +53,21 @@ describe("DiffTabs", () => {
     ]
     const t = await mountNode(<DiffTabs tools={tools} />, { width: 100, height: 18 })
     await until(t, () => t.frame().includes("alpha.ts") && t.frame().includes("gamma.ts"))
-    // First tab is active by default → alpha body.
-    expect(t.frame()).toContain("+new alpha")
+    expect(t.frame()).not.toContain("+new alpha")
     expect(t.frame()).not.toContain("+new beta")
 
-    // Click 'beta.ts' label.
     const rows = t.frame().split("\n")
     const y = rows.findIndex(l => l.includes("beta.ts"))
     const x = rows[y].indexOf("beta.ts")
     await act(async () => { await t.mouse.pressDown(x, y) })
     await until(t, () => t.frame().includes("+new beta"))
     expect(t.frame()).not.toContain("+new alpha")
+
+    const next = t.frame().split("\n")
+    const y2 = next.findIndex(l => l.includes("beta.ts"))
+    const x2 = next[y2].indexOf("beta.ts")
+    await act(async () => { await t.mouse.pressDown(x2, y2) })
+    await until(t, () => !t.frame().includes("+new beta"))
     t.destroy()
   })
 
@@ -102,7 +105,8 @@ describe("DiffTabs", () => {
       { width: 80, height: 12 },
     )
     // No args, no preview — pathFor falls back to the diff's `+++ b/x` header.
-    await until(t, () => t.frame().includes("+new y"))
+    await until(t, () => t.frame().includes("x"))
+    expect(t.frame()).not.toContain("+new y")
     t.destroy()
   })
 
@@ -183,6 +187,11 @@ describe("DiffTabs", () => {
       { width: 100, height: 20 },
     )
     await until(t, () => t.frame().includes("c.txt"))
+    const rows = t.frame().split("\n")
+    const y = rows.findIndex(l => l.includes("c.txt"))
+    const x = rows[y].indexOf("c.txt")
+    await act(async () => { await t.mouse.pressDown(x, y) })
+    await until(t, () => t.frame().includes("+NORTH"))
     const f = t.frame()
     // Tab label is c.txt — no `→ b/` arrow leakage into label.
     expect(f).not.toContain("review diff")
@@ -190,7 +199,6 @@ describe("DiffTabs", () => {
     // The arrow-header line itself isn't rendered as a diff row.
     const bodyRows = f.split("\n").filter(l => /→ b/.test(l))
     expect(bodyRows.length).toBe(0)
-    // Body shows real hunk lines.
     expect(f).toContain("-north")
     expect(f).toContain("+NORTH")
     expect(f).not.toContain("… more")
@@ -230,12 +238,7 @@ describe("DiffTabs", () => {
     expect(f).toContain("colors.txt")
     expect(f).toContain("c.txt")
     expect(f).toContain("d.txt")
-    // None of the previously-leaked diff-body tails should appear in the
-    // tab strip area (above the `+A / -B` line).
-    const lines = f.split("\n")
-    const countLineY = lines.findIndex(l => /\+\d+\s*\/\s*-\d+/.test(l))
-    const stripText = lines.slice(0, countLineY).join("\n")
-    expect(stripText).not.toMatch(/…@|… autumn|…\)/)
+    expect(f).not.toMatch(/…@|… autumn|…\)/)
     t.destroy()
   })
 })

--- a/test/messagelist.test.tsx
+++ b/test/messagelist.test.tsx
@@ -208,6 +208,37 @@ describe("tool/file-edit", () => {
     await until(t, () => t.frame().includes("Edit") && !t.frame().includes("changed"))
     t.destroy()
   })
+
+  test("message diff tab click expands and collapses without picking message", async () => {
+    const picks: Message[] = []
+    const msgs: Message[] = [{
+      id: "a1", role: "assistant", timestamp: 0,
+      parts: [
+        { type: "text", content: "patched", streaming: false },
+        { type: "tool", id: "td", name: "patch", args: "",
+          preview: "src/foo.ts", status: "done", duration: 42, diff: UDIFF },
+      ],
+    }]
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%">
+        <MessageList messages={msgs} streaming={false} onPick={m => picks.push(m)} />
+      </box>,
+      { width: 100, height: 18 },
+    )
+    await until(t, () => t.frame().includes("foo.ts"))
+    expect(t.frame()).not.toContain("+new line")
+
+    const hit = locate(t, "foo.ts")
+    await act(async () => { await t.mouse.click(hit.x, hit.y) })
+    await until(t, () => t.frame().includes("+new line"))
+    expect(picks).toHaveLength(0)
+
+    const again = locate(t, "foo.ts")
+    await act(async () => { await t.mouse.click(again.x, again.y) })
+    await until(t, () => !t.frame().includes("+new line"))
+    expect(picks).toHaveLength(0)
+    t.destroy()
+  })
 })
 
 describe("ErrorBlock", () => {


### PR DESCRIPTION
## Summary
Inline diff tabs now stay compact until opened, so long file edits no longer fill the assistant turn or push approval prompts out of view.

- Click a tab to show that diff.
- Click the active tab again to collapse back to tab rows.
- Keep tab clicks isolated from the containing message click handler.

## Verification
- `bun test test/diff-tabs.test.tsx test/messagelist.test.tsx`
- `bunx tsc --noEmit`
- `git diff --check -- src/components/chat/DiffTabs.tsx test/diff-tabs.test.tsx test/messagelist.test.tsx`
