### PR TITLE
fix: pin active sessions above history

### DIFF
--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -38,7 +38,6 @@ import type { SessionsPrefs } from "../context/preferences"
 
 type Row = SessionListItem & { detail?: SessionRow; live?: SessionActiveItem }
 
-type View = "live" | "history"
 type Sort = NonNullable<SessionsPrefs["sort"]>
 
 /** Row comparator for the chosen sort. "active" keys on the tip's
@@ -52,7 +51,7 @@ const cmp = (s: Sort) => {
 }
 
 const badge = (src: string): string => ({
-  cli: "CLI", tui: "TUI", api_server: "API", discord: "Discord",
+  cli: "CLI", tui: "TUI", api_server: "API", live: "Live", discord: "Discord",
   telegram: "Telegram", slack: "Slack", whatsapp: "WhatsApp", signal: "Signal",
 } as Record<string, string>)[src] ?? src
 //
@@ -348,6 +347,7 @@ const Item = memo((props: {
   const { row: r, idx: i } = props
   const [x, setX] = useState(false)
   const active = r.detail?.last_active ?? r.detail?.ended_at ?? null
+  const locked = props.indent || Boolean(r.live)
   // Parent rows get "▸ "/"  " leaders; child rows get "└─" as the tree
   // marker. Selected children still highlight via backgroundColor +
   // text color — indent is the only hierarchy signal.
@@ -368,7 +368,7 @@ const Item = memo((props: {
       <Col w={8} fg={theme.textMuted}>{stamp(r.started_at)}</Col>
       <Col w={10} fg={theme.textMuted} right>{active ? ago(active) : "—"}</Col>
       <Col w={7} fg={theme.textMuted} right>{String(r.message_count)}</Col>
-      {props.indent ? <box width={3} /> : (
+      {locked ? <box width={3} /> : (
         <box width={3}
              onMouseDown={(e) => { e.stopPropagation(); props.onDelete(i) }}
              onMouseOver={() => setX(true)} onMouseOut={() => setX(false)}>
@@ -463,7 +463,6 @@ export const Sessions = memo((props: Props) => {
 
   const [rows, setRows] = useState<Row[]>(cached ? last.rows : [])
   const [liveRows, setLiveRows] = useState<Row[]>([])
-  const [view, setView] = useState<View>("live")
   const [warn, setWarn] = useState("")
   const [pending, setPending] = useState(rows.length === 0)
   // Persisted, user-toggleable list ordering. roots() always returns
@@ -471,9 +470,12 @@ export const Sessions = memo((props: Props) => {
   // without re-hitting state.db.
   const sort: Sort = prefs.usePref("sessions")?.sort ?? "active"
   const setSort = useCallback((s: Sort) => prefs.set("sessions", { sort: s }), [])
-  const showingLive = view === "live" && liveRows.length > 0
-  const listed = showingLive ? liveRows : rows
-  const sorted = useMemo(() => showingLive ? liveRows : [...rows].sort(cmp(sort)), [showingLive, liveRows, rows, sort])
+  const active = useMemo(() => [...liveRows].sort((a, b) =>
+    Number(Boolean(b.live?.current)) - Number(Boolean(a.live?.current)) ||
+    ((b.live?.last_active ?? b.started_at) - (a.live?.last_active ?? a.started_at))), [liveRows])
+  const ids = useMemo(() => new Set(active.map(r => r.id)), [active])
+  const sorted = useMemo(() => rows.filter(r => !ids.has(r.id)).sort(cmp(sort)), [rows, ids, sort])
+  const listed = useMemo(() => [...active, ...sorted], [active, sorted])
   // Selection is tracked by row identity so that collapsing children
   // (which changes the flat index of every row below) never lands sel
   // on the wrong row. The numeric index consumers use (handleListKey,
@@ -494,14 +496,14 @@ export const Sessions = memo((props: Props) => {
   // child, the child's owning parent is expanded. Anything else = no
   // expansion. This makes collapse/expand atomic with sel changes —
   // no lagging effect, no clamp pass.
-  const anchored = anchor && sorted.find(r => r.id === anchor.id)
+  const anchored = anchor && listed.find(r => r.id === anchor.id)
   const owner =
     anchor?.indent
-      ? sorted.find(r => kids.get(r.id)?.some(c => c.id === anchor.id))
+      ? listed.find(r => kids.get(r.id)?.some(c => c.id === anchor.id))
       : (anchored?.detail?.subagent_count ?? 0) > 0 ? anchored : undefined
 
   // Flat visible sequence = parents with `owner`'s children inlined.
-  const visible = sorted.flatMap((r, i) =>
+  const visible = listed.flatMap((r, i) =>
     r.id === owner?.id
       ? [{ row: r, indent: false, parentIdx: i },
          ...(kids.get(r.id) ?? []).map(c =>
@@ -517,8 +519,8 @@ export const Sessions = memo((props: Props) => {
   // Latest-value refs so the stable row callbacks below don't close
   // over stale arrays (and therefore don't need to be in their deps,
   // which would defeat the memo).
-  const live = useRef({ rows: listed, visible, anchor, results, searching, showingLive, onSwitch: props.onSwitch, onActivateLive: props.onActivateLive, currentId: props.currentId })
-  live.current = { rows: listed, visible, anchor, results, searching, showingLive, onSwitch: props.onSwitch, onActivateLive: props.onActivateLive, currentId: props.currentId }
+  const live = useRef({ rows: listed, visible, anchor, results, searching, onSwitch: props.onSwitch, onActivateLive: props.onActivateLive, currentId: props.currentId })
+  live.current = { rows: listed, visible, anchor, results, searching, onSwitch: props.onSwitch, onActivateLive: props.onActivateLive, currentId: props.currentId }
 
   // Adapter for handleListKey, which speaks numeric sel. Translating
   // through the anchor means the target row is resolved against the
@@ -582,9 +584,8 @@ export const Sessions = memo((props: Props) => {
 
     const a = await active
     if (a.ok) {
-      const live = (a.v.sessions ?? []).map(toLiveRow)
+      const live = (a.v.sessions ?? []).map(s => ({ ...toLiveRow(s), detail: local.get(s.id) }))
       setLiveRows(live)
-      if (live.length === 0) setView(v => v === "live" ? "history" : v)
     }
 
     // Stock session.list doesn't drop 0-msg stubs — every abandoned
@@ -616,10 +617,18 @@ export const Sessions = memo((props: Props) => {
 
   useEffect(() => { load() }, [load])
 
-  // Seed anchor once rows arrive (first row, unexpanded).
+  // Seed anchor once rows arrive. If active rows arrive after the
+  // optimistic history paint, promote the untouched first row to active.
   useEffect(() => {
-    if (!anchor && sorted.length) setAnchor({ id: sorted[0].id, indent: false })
-  }, [sorted, anchor])
+    if (!listed.length) return
+    if (!anchor || !visible.some(v => v.row.id === anchor.id && v.indent === anchor.indent)) {
+      setAnchor({ id: listed[0].id, indent: false })
+      return
+    }
+    if (active[0] && sorted[0]?.id === anchor.id && !anchor.indent) {
+      setAnchor({ id: active[0].id, indent: false })
+    }
+  }, [listed, active, sorted, anchor])
 
   // Search is a synchronous FTS5 query on state.db, so debounce —
   // running it on every keystroke blocks the render thread. The
@@ -650,7 +659,10 @@ export const Sessions = memo((props: Props) => {
     const hit = l.searching ? l.results[i] : l.visible[i]?.row
     const id = l.searching ? (hit as SessionHit | undefined)?.session_id : (hit as Row | undefined)?.id
     if (!id) return
-    if (l.showingLive && !l.searching) return l.onActivateLive?.(id)
+    if (!l.searching && (hit as Row | undefined)?.live) {
+      if (l.onActivateLive) return l.onActivateLive(id)
+      return l.onSwitch?.(id)
+    }
     if (!l.onSwitch) return
     if (id === l.currentId) return l.onSwitch(id)
     const title = (hit as { title?: string } | undefined)?.title || "Untitled"
@@ -666,7 +678,7 @@ export const Sessions = memo((props: Props) => {
   // guard covers the keyboard shortcut path.
   const rowDelete = useCallback((i: number) => {
     const v = live.current.visible[i]
-    if (v && !v.indent) confirmDeleteRef.current(v.row)
+    if (v && !v.indent && !v.row.live) confirmDeleteRef.current(v.row)
   }, [])
 
   // Lineage-click switches target a SPECIFIC session (the predecessor
@@ -764,13 +776,11 @@ export const Sessions = memo((props: Props) => {
       page: Math.max(1, (vscroll.current?.viewport.height ?? 10) - 1),
       scrollTo: n => vscroll.current?.scrollChildIntoView(rowId(n)),
       onActivate: () => rowActivate(sel),
-      onToggle: () => liveRows.length > 0
-        ? setView(showingLive ? "history" : "live")
-        : setSort(sort === "active" ? "started" : "active"),
+      onToggle: () => setSort(sort === "active" ? "started" : "active"),
       onRefresh: () => { void load(); toast.show({ variant: "info", message: "Reloaded", duration: 1000 }) },
       onDelete: () => {
         const v = visible[sel]
-        if (v && !v.indent) confirmDelete(v.row)
+        if (v && !v.indent && !v.row.live) confirmDelete(v.row)
       },
       onSearch: () => { setSearching(true); setQuery(""); setResults([]); setSearchSel(0) },
     })
@@ -795,6 +805,7 @@ export const Sessions = memo((props: Props) => {
   })
 
   const empty = searching ? results.length === 0 && query.length > 0 : listed.length === 0
+  const action = visible[sel]?.row.live ? "activate live" : "switch"
   // Sidebar yields at <140 on non-Chat tabs (app.tsx), so detail can
   // stay mounted down to the shell's own floor.
   const showDetailPanel = dims.width >= 120
@@ -805,7 +816,7 @@ export const Sessions = memo((props: Props) => {
       <TabShell
         title={searching
           ? `Search Results (${results.length})`
-          : `${showingLive ? "Live Sessions" : "Sessions"} (${listed.length}${pending ? "…" : ""})`}
+          : `Sessions (${listed.length}${pending ? "…" : ""})`}
         error={warn || null}
         grow={3}
       >
@@ -832,17 +843,6 @@ export const Sessions = memo((props: Props) => {
           </box>
         ) : (
           <box key="table" flexDirection="column" flexGrow={1} minWidth={0}>
-            {!searching && liveRows.length > 0 ? (
-              <box height={1} marginBottom={1} flexDirection="row">
-                <box onMouseDown={() => setView("live")}>
-                  <text fg={showingLive ? theme.accent : theme.textMuted}>{`live ${liveRows.length}`}</text>
-                </box>
-                <text fg={theme.textMuted}>  ·  </text>
-                <box onMouseDown={() => setView("history")}>
-                  <text fg={showingLive ? theme.textMuted : theme.accent}>{`history ${rows.length}`}</text>
-                </box>
-              </box>
-            ) : null}
             {searching ? <SearchHeaderRow /> : <HeaderRow sort={sort} onSort={setSort} />}
             <box height={1} />
             <scrollbox ref={vscroll} scrollY viewportCulling flexGrow={1}
@@ -854,9 +854,17 @@ export const Sessions = memo((props: Props) => {
                       onActivate={rowActivate} onHover={rowHover} />
                   ))
                 : visible.map((v, i) => (
-                    <Item key={`${v.row.id}-${v.indent ? "c" : "p"}`} id={rowId(i)} idx={i}
-                      row={v.row} selected={i === sel} indent={v.indent}
-                      onActivate={rowActivate} onHover={rowHover} onDelete={rowDelete} />
+                    <box key={`${v.row.id}-${v.indent ? "c" : "p"}`} flexDirection="column"
+                         height={v.row.live && visible[i + 1] && !visible[i + 1].row.live ? 2 : 1}>
+                      <Item id={rowId(i)} idx={i}
+                        row={v.row} selected={i === sel} indent={v.indent}
+                        onActivate={rowActivate} onHover={rowHover} onDelete={rowDelete} />
+                      {v.row.live && visible[i + 1] && !visible[i + 1].row.live ? (
+                        <box height={1} paddingLeft={2}>
+                          <text fg={theme.textMuted}>── History ──</text>
+                        </box>
+                      ) : null}
+                    </box>
                   ))}
             </scrollbox>
           </box>
@@ -878,9 +886,9 @@ export const Sessions = memo((props: Props) => {
       : [
           ["↑↓", "navigate"],
           ["←→", "lineage"],
-          [`${keys.print("list.activate")}/click`, showingLive ? "activate live" : "switch"],
+          [`${keys.print("list.activate")}/click`, action],
           [keys.print("list.search"), "search"],
-          liveRows.length > 0 ? ["mouse", showingLive ? "history" : "live"] : [keys.print("list.toggle"), `sort: ${sort}`],
+          [keys.print("list.toggle"), `sort: ${sort}`],
           [keys.print("sessions.rename"), "rename"],
           [keys.print("list.delete"), "delete"],
           [keys.print("list.refresh"), "refresh"],

--- a/test/session-close.test.tsx
+++ b/test/session-close.test.tsx
@@ -143,7 +143,10 @@ describe("session.close", () => {
 
     await act(async () => { await t.keys.typeText("/sessions") })
     act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Live Sessions"))
+    await until(t, () => {
+      const f = t.frame()
+      return f.includes("Sessions (") && f.includes("Live A") && !f.includes("Live Sessions")
+    })
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("partial answer"))
 

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -27,7 +27,7 @@ const detail = (over: Partial<SessionRow> & { id: string; sessionSource: string 
 })
 
 describe("Sessions tab", () => {
-  test("lists live sessions first and activates without closing siblings", async () => {
+  test("pins active sessions above history without entering an active-only view", async () => {
     const gw = new MockGateway({
       "session.active_list": p => ({ sessions: [
         { id: "live-a", title: "Working live", preview: "do the thing", message_count: 3, started_at: 1700000000, status: "working", current: p.current_session_id === "live-a" },
@@ -40,9 +40,20 @@ describe("Sessions tab", () => {
       <Sessions focused io={NOIO} currentId="live-a" onActivateLive={sid => { activated = sid }} />,
       { gw },
     )
-    await until(t, () => t.frame().includes("Live Sessions (2)"))
+    await until(t, () => t.frame().includes("Sessions (4)"))
 
-    expect(t.frame()).toContain("Working live")
+    const lines = t.frame().split("\n")
+    const live = lines.findIndex(l => l.includes("Working live") && l.includes("Live"))
+    const div = lines.findIndex(l => l.includes("History"))
+    const hist = lines.findIndex(l => l.includes("First session") && l.includes("TUI"))
+    expect(live).toBeGreaterThanOrEqual(0)
+    expect(div).toBeGreaterThan(live)
+    expect(hist).toBeGreaterThan(div)
+    expect(t.frame()).toContain("Second session")
+    expect(t.frame()).toContain("sort: active")
+    expect(t.frame()).not.toContain("Live Sessions")
+    expect(t.frame()).not.toContain("live 2")
+    expect(t.frame()).not.toContain("history 2")
     expect(t.gw.last("session.active_list")?.params.current_session_id).toBe("live-a")
 
     act(() => t.keys.pressEnter())
@@ -175,6 +186,54 @@ describe("Sessions tab", () => {
     await until(t, () => t.frame().includes("Active ▾"))
     expect(order()).toBe("fresh-first")
     expect(prefs.get("sessions")?.sort).toBe("active")
+
+    prefs.reset()
+    t.destroy()
+  })
+
+  test("Space keeps sorting history while active sessions are pinned", async () => {
+    prefs.reset()
+    const disk = [
+      detail({ id: "older-fresh", sessionSource: "tui",
+        title: "Older Start Fresh Activity", message_count: 5,
+        started_at: 1700000000, last_active: 1700099999 }),
+      detail({ id: "newer-idle", sessionSource: "tui",
+        title: "Newer Start Idle", message_count: 3,
+        started_at: 1700050000, last_active: 1700050001 }),
+    ]
+    const gw = new MockGateway({
+      "session.active_list": () => ({ sessions: [
+        { id: "live-a", title: "Working live", preview: "do the thing", message_count: 3, started_at: 1700100000, status: "working" },
+      ]}),
+      "session.list": () => ({ sessions: [
+        { id: "older-fresh", title: "Older Start Fresh Activity", preview: "ping", message_count: 5, started_at: 1700000000, source: "tui" },
+        { id: "newer-idle", title: "Newer Start Idle", preview: "", message_count: 3, started_at: 1700050000, source: "tui" },
+      ]}),
+    })
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => disk }} />, { gw })
+    await until(t, () => t.frame().includes("Sessions (3)"))
+
+    const order = () => {
+      const lines = t.frame().split("\n")
+      const live = lines.findIndex(l => l.includes("Working live") && l.includes("Live"))
+      const a = lines.findIndex(l => l.includes("Older Start Fresh Activity") && l.includes("TUI"))
+      const b = lines.findIndex(l => l.includes("Newer Start Idle") && l.includes("TUI"))
+      expect(live).toBeGreaterThanOrEqual(0)
+      expect(a).toBeGreaterThan(live)
+      expect(b).toBeGreaterThan(live)
+      return a < b ? "fresh-first" : "idle-first"
+    }
+
+    expect(t.frame()).toContain("sort: active")
+    expect(t.frame()).toContain("Space")
+    expect(t.frame()).not.toContain("mouse")
+    expect(order()).toBe("fresh-first")
+
+    await act(async () => { await t.keys.typeText(" ") })
+    await until(t, () => t.frame().includes("Start ▾"))
+    expect(t.frame()).toContain("sort: started")
+    expect(order()).toBe("idle-first")
+    expect(prefs.get("sessions")?.sort).toBe("started")
 
     prefs.reset()
     t.destroy()


### PR DESCRIPTION
## Summary
- Pins active sessions at the top of the normal Sessions list with a History divider below them
- Removes the active-only default view so history stays visible when live sessions exist
- Keeps Space as the sort toggle and restores the footer hint
- Preserves live-session activation without closing the outgoing session

## Verification
- `bun test test/session-close.test.tsx`
- `bun test test/sessions.test.tsx`
- `bunx tsc --noEmit`
- `git diff --check`
- `bun install --frozen-lockfile && bun run build`
- `bun test`
