### PR TITLE
fix(context): use live usage for context meter

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -768,7 +768,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                                                  currentId={sid}
                                                  messages={turn.messages}
                                                  sessionStart={sessionStart.current}
-                                                 info={info ?? undefined} />
+                                                 info={info ?? undefined}
+                                                 usage={usage} />
         case AUTOMATION_TAB: return <Automation focused={contentFocused}
                                                 sub={subTabs[AUTOMATION_TAB] ?? 0}
                                                 setSub={autoSub}

--- a/src/service/context-segments.ts
+++ b/src/service/context-segments.ts
@@ -166,7 +166,7 @@ export function toolTokens(tool: ToolInfo): number {
 
 type Opts = {
   contextLength: number
-  inputTokens: number
+  usedTokens?: number
   sections: ReadonlyArray<Section>
   conversationTokens: number
   tools: ReadonlyArray<ToolInfo>
@@ -258,13 +258,22 @@ export function build(opts: Opts): Segment[] {
     })
   }
   if (opts.conversationTokens > 0) {
-    const ct = Math.min(opts.conversationTokens, opts.inputTokens || opts.conversationTokens)
-    result.push({ id: "conversation", label: "Conversation", tokens: ct, percent: pct(ct) })
+    const ct = opts.conversationTokens
+    result.push({ id: "conversation", label: "~Conversation", tokens: ct, percent: pct(ct) })
   }
   const taken = result.reduce((s, g) => s + g.tokens, 0)
-  const free = Math.max(0, opts.contextLength - taken)
+  const used = opts.usedTokens
+  if (typeof used !== "number") {
+    const unknown = Math.max(0, opts.contextLength - taken)
+    if (unknown > 0) result.push({ id: "unknown", label: "Unknown (live unavailable)", tokens: unknown, percent: pct(unknown) })
+    return result
+  }
+  const unknown = Math.max(0, used - taken)
+  if (unknown > 0) result.push({ id: "unknown", label: "Unknown / Provider Overhead", tokens: unknown, percent: pct(unknown) })
+  const overage = Math.max(0, taken - used)
+  if (overage > 0) result.push({ id: "overage", label: "Estimate Overage", tokens: overage, percent: pct(overage) })
+  const free = Math.max(0, opts.contextLength - used)
   result.push({ id: "free", label: "Free", tokens: free, percent: pct(free) })
-
   return result
 }
 

--- a/src/service/hermes-home.ts
+++ b/src/service/hermes-home.ts
@@ -68,7 +68,7 @@ export interface HermesConfig {
     default: string;
     provider: string;
     base_url: string;
-    context_length: number;
+    context_length?: number;
   };
   agent: {
     max_turns: number;
@@ -461,7 +461,7 @@ export async function readConfig(): Promise<HermesConfig | null> {
         default: raw?.model?.default ?? "unknown",
         provider: raw?.model?.provider ?? "auto",
         base_url: raw?.model?.base_url ?? "",
-        context_length: raw?.model?.context_length ?? 0,
+        context_length: raw?.model?.context_length,
       },
       agent: {
         max_turns: raw?.agent?.max_turns ?? 60,

--- a/src/tabs/Context.tsx
+++ b/src/tabs/Context.tsx
@@ -302,8 +302,13 @@ const toolsFromInfo = (info?: SessionInfo | null): ToolsInfo | null => {
   return { source: makeSource("state.db", "session.info"), tools }
 }
 
+const configuredContextLength = (config: HermesConfig | null): number | undefined => {
+  const n = config?.model?.context_length
+  return typeof n === "number" && n > 0 ? n : undefined
+}
+
 export const contextMeter = (usage: Usage | undefined, info: SessionInfo | undefined, config: HermesConfig | null): ContextMeter => ({
-  max: usage?.context_max ?? info?.usage?.context_max ?? info?.context_max ?? config?.model?.context_length ?? DEFAULT_CTX,
+  max: usage?.context_max ?? info?.usage?.context_max ?? info?.context_max ?? configuredContextLength(config) ?? DEFAULT_CTX,
   used: usage?.context_used ?? info?.usage?.context_used ?? info?.context_used,
 })
 

--- a/src/tabs/Context.tsx
+++ b/src/tabs/Context.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState, useRef, useMemo, memo, type Dispatch, type SetStat
 import { CORNERS } from "../ui/borders"
 import { useKeyboard } from "@opentui/react"
 
-import type { Message } from "../types/message"
+import type { Message, Usage } from "../types/message"
 import { text as msgText } from "../types/message"
 import { makeSource, type ToolInfo, type HermesConfig, type ToolsInfo } from "../service/hermes-home"
 import type { SessionInfo } from "../context/wire"
@@ -47,10 +47,12 @@ type Props = {
   messages?: Message[]
   sessionStart?: number
   info?: SessionInfo
+  usage?: Usage
   focused?: boolean
 }
 
 type Wire = { input: number; output: number; total: number; calls: number }
+type ContextMeter = { max: number; used?: number }
 
 // Last-resort fallback when neither the gateway (info.context_max) nor
 // config (model.context_length) has surfaced a window yet. Real value
@@ -75,6 +77,8 @@ export const SLOTS = [
   "project",
   "meta",
   "other",
+  "unknown",
+  "overage",
 ] as const
 
 const SLOT: Record<string, number> = Object.fromEntries(SLOTS.map((id, i) => [id, i]))
@@ -287,7 +291,7 @@ const FreePanel = memo(({ seg, theme, ctxLen, comp, onEditThreshold }: {
 const NO_MESSAGES: readonly Message[] = Object.freeze([])
 
 const toolsFromInfo = (info?: SessionInfo | null): ToolsInfo | null => {
-  if (!info?.tools) return null
+  if (!info || info.tools === undefined) return null
   const tools = Object.entries(info.tools).flatMap(([group, names]) =>
     names.map(name => ({
       name,
@@ -295,11 +299,15 @@ const toolsFromInfo = (info?: SessionInfo | null): ToolsInfo | null => {
       paramsLength: group.length,
     })),
   )
-  if (tools.length === 0) return null
   return { source: makeSource("state.db", "session.info"), tools }
 }
 
-export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focused }: Props) => {
+export const contextMeter = (usage: Usage | undefined, info: SessionInfo | undefined, config: HermesConfig | null): ContextMeter => ({
+  max: usage?.context_max ?? info?.usage?.context_max ?? info?.context_max ?? config?.model?.context_length ?? DEFAULT_CTX,
+  used: usage?.context_used ?? info?.usage?.context_used ?? info?.context_used,
+})
+
+export const Context = memo(({ messages = NO_MESSAGES as Message[], info, usage, focused }: Props) => {
   const config = useHome("config")
   const memory = useHome("memory")
   const userProfile = useHome("userProfile")
@@ -309,8 +317,6 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
   const systemPrompt = useHome("systemPrompt")
   const toolsInfo = useHome("toolsInfo")
   const soul = useHome("soul")
-  const recentSessions = useHome("recentSessions")
-  const liveSessions = useHome("liveSessions")
 
   const [wire, setWire] = useState<Wire>({ input: 0, output: 0, total: 0, calls: 0 })
   const wireRef = useRef(wire)
@@ -336,26 +342,12 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
   }, [messages])
 
   // Derived
-  const session = recentSessions?.[0]
-  // Gateway's context_max is the authoritative runtime value. Before
-  // session.info lands (fresh-session window) fall back to the user's
-  // configured model.context_length, then to DEFAULT_CTX. Using the
-  // config value avoids showing a misleading 128K bar for models whose
-  // real window the gateway hasn't surfaced yet.
-  const ctxLen = info?.context_max
-    ?? (config?.model?.context_length && config.model.context_length > 0
-        ? config.model.context_length
-        : DEFAULT_CTX)
-
-  const live = session
-    ? Object.values(liveSessions ?? {}).find(ls => ls.session_id === session.id)
-    : undefined
-
-  const lastPrompt = live?.last_prompt_tokens ?? 0
-  const fill = wire.calls > 0 ? wire.input : lastPrompt > 0 ? lastPrompt : (session?.input_tokens ?? 0)
-  const cumulative = wire.calls === 0 && lastPrompt === 0 && (session?.input_tokens ?? 0) > 0
-  const output = wire.calls > 0 ? wire.output : (session?.output_tokens ?? 0)
-  const pct = ctxLen > 0 ? Math.round((fill / ctxLen) * 100) : 0
+  const meter = contextMeter(usage, info, config ?? null)
+  const ctxLen = meter.max
+  const used = meter.used
+  const reliable = typeof used === "number"
+  const output = wire.output
+  const pct = reliable && ctxLen > 0 ? Math.round((used / ctxLen) * 100) : 0
 
   // Threshold marker inputs. `config.compression.threshold` is the
   // single source of truth; server reads the same key.
@@ -373,22 +365,27 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
   const sections = useMemo(() => parse(promptText), [promptText])
   const convTok = useMemo(() => est(messages.filter(m => m.role !== "system").map(m => msgText(m)).join("")), [messages])
 
-  const currentTools = useMemo(() => toolsFromInfo(info) ?? toolsInfo, [info, toolsInfo])
+  const currentTools = useMemo(() => {
+    const liveTools = toolsFromInfo(info)
+    if (liveTools) return liveTools
+    if (info?.tools !== undefined) return liveTools
+    return toolsInfo
+  }, [info, toolsInfo])
 
   const top = useMemo(() => build({
     contextLength: ctxLen,
-    inputTokens: fill,
+    usedTokens: used,
     sections,
     conversationTokens: convTok,
     tools: currentTools?.tools ?? [],
-  }), [ctxLen, fill, sections, convTok, currentTools])
+  }), [ctxLen, used, sections, convTok, currentTools])
 
   // Current view: top-level or drilled
   const drilledGroup = drilled ? top.find(s => s.id === drilled) : null
   const view = drilledGroup ? drill(drilledGroup) : top
   const grid = useMemo(
-    () => buildCells(view, drilledGroup ? drilledGroup.children?.[0]?.id ?? "other" : "free"),
-    [view, drilledGroup],
+    () => buildCells(view, drilledGroup ? drilledGroup.children?.[0]?.id ?? "other" : reliable ? "free" : "unknown"),
+    [view, drilledGroup, reliable],
   )
 
   // Helpers
@@ -520,8 +517,10 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
         <strong>Breakdown</strong>
         {drilledGroup ? (
           <span fg={theme.info}> · {drilledGroup.label} ({fmt(drilledGroup.tokens)} tok)</span>
-        ) : (
+        ) : reliable ? (
           <span fg={theme.info}> (click group to expand)</span>
+        ) : (
+          <span fg={theme.warning}> · live usage unavailable · limit {fmt(ctxLen)}</span>
         )}
       </text>
       {view.filter(s => s.tokens > 0).map(s => (
@@ -534,18 +533,18 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
       {output > 0 && !drilled ? (
         <text><span fg={theme.success}>◼</span> Output — {fmt(output)} tokens</text>
       ) : null}
-      <text>
-        <span fg={theme.textMuted}>◼ Beyond compression threshold ({Math.round(thresholdPct * 100)}%)</span>
-      </text>
+      {reliable && !drilled ? (
+        <text>
+          <span fg={theme.textMuted}>◼ Beyond compression threshold ({Math.round(thresholdPct * 100)}%)</span>
+        </text>
+      ) : null}
     </box>
   )
 
   const crumb = drilled
     ? `${drilledGroup?.label}${selected ? ` · ${findSeg(selected)?.label}` : ""}`
-    : wire.calls === 0 && fill === 0 ? "[no data]"
-    : cumulative ? "[cumulative — not current fill]"
-    : wire.calls === 0 && fill > 0 ? "[live session]"
-    : "↑↓ nav  ·  click a group to drill in"
+    : reliable ? "↑↓ nav  ·  click a group to drill in"
+    : "live usage unavailable · estimates shown with ~"
   const escHint = selected || drilled ? "  ·  Esc back" : ""
 
   const focus = selected || hovered
@@ -554,7 +553,7 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
   return (
     <box flexDirection="column" flexGrow={1} minWidth={0}>
     <TabShell
-      title={`Context · ${fmt(fill)} / ${fmt(ctxLen)} (${pct}%)`}
+      title={reliable ? `Context · ${fmt(used)} / ${fmt(ctxLen)} (${pct}%)` : `Context · live usage unavailable · limit ${fmt(ctxLen)}`}
     >
       <box height={1}>
         {focusSeg ? (
@@ -584,7 +583,7 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, focuse
                   // different segment lights both groups at once.
                   const hl = selected ? selected === cell.id : hovered === cell.id
                   // Past-threshold cells: ◼ in textMuted; hover still shows category color.
-                  const past = row * COLS + col >= thresholdIdx
+                  const past = !drilled && row * COLS + col >= thresholdIdx
                   const glyph = !past && cell.id === "free" ? "◻" : "◼"
                   return (
                     <box

--- a/src/tabs/Context.tsx
+++ b/src/tabs/Context.tsx
@@ -567,7 +567,7 @@ export const Context = memo(({ messages = NO_MESSAGES as Message[], info, usage,
         <box flexDirection="column" marginRight={2} flexShrink={0}>
           {/* Compression badge — shown inline above the grid when any
               compression events have fired this session. */}
-          {compressions > 0 ? (
+          {!drilled && compressions > 0 ? (
             <box height={1} marginBottom={1}>
               <text fg={theme.warning}>×{compressions} compressed</text>
             </box>

--- a/src/tabs/SessionsGroup.tsx
+++ b/src/tabs/SessionsGroup.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, type ReactNode } from "react"
-import type { Message } from "../types/message"
+import type { Message, Usage } from "../types/message"
 import type { SessionInfo } from "../context/wire"
 import { Sessions } from "./Sessions"
 import { Context } from "./Context"
@@ -20,6 +20,7 @@ type Props = {
   messages?: Message[]
   sessionStart: number
   info?: SessionInfo
+  usage?: Usage
 }
 
 // Consolidates the former Sessions / Context / Analytics tabs under a
@@ -50,7 +51,7 @@ export const SessionsGroup = memo((props: Props) => {
         </Pane>
         <Pane visible={props.sub === 1}>
           <Context focused={!!props.focused && props.sub === 1}
-                   messages={props.messages} sessionStart={props.sessionStart} info={props.info} />
+                   messages={props.messages} sessionStart={props.sessionStart} info={props.info} usage={props.usage} />
         </Pane>
         <Pane visible={props.sub === 2}>
           <Analytics focused={!!props.focused && props.sub === 2} />

--- a/test/context-segments.test.ts
+++ b/test/context-segments.test.ts
@@ -48,7 +48,7 @@ describe("classifyTools", () => {
   })
 })
 
-describe("build — 7-category taxonomy", () => {
+describe("build — context estimates", () => {
   const baseOpts = {
     contextLength: 200_000,
     inputTokens: 50_000,
@@ -57,7 +57,7 @@ describe("build — 7-category taxonomy", () => {
     tools: [] as ToolInfo[],
   }
 
-  test("produces system_prompt + system_tools + mcp_tools + memory + skills + conversation + free", () => {
+  test("produces estimated categories with explicit unknown when live usage is absent", () => {
     const sections: Section[] = [
       mkSection("soul", "SOUL.md", 500),
       mkSection("memory", "Memory Notes", 300),
@@ -80,7 +80,7 @@ describe("build — 7-category taxonomy", () => {
     const ids = got.map(g => g.id)
     expect(ids).toEqual([
       "system_prompt", "system_tools", "mcp_tools",
-      "memory", "skills", "conversation", "free",
+      "memory", "skills", "conversation", "unknown",
     ])
   })
 
@@ -111,25 +111,50 @@ describe("build — 7-category taxonomy", () => {
     expect(mem!.children?.map(c => c.id).sort()).toEqual(["mem0", "memory", "soul", "user"])
   })
 
-  test("zero-token categories are skipped", () => {
-    const got = build(baseOpts) // no sections, no tools, no conversation
+  test("zero live usage still renders free", () => {
+    const got = build({ ...baseOpts, usedTokens: 0 }) // no sections, no tools, no conversation
     expect(got.map(g => g.id)).toEqual(["free"])
   })
 
-  test("free = contextLength - sum(others) and is last", () => {
+  test("free = live used math, not estimated categories", () => {
     const sections: Section[] = [mkSection("project", "Project", 1000)]
     const tools: ToolInfo[] = [mkTool("x", 4000, 0)] // 4000 chars → 1000 tok
     const got = build({
       ...baseOpts,
       contextLength: 10_000,
+      usedTokens: 3500,
       sections,
       tools,
       conversationTokens: 2000,
     })
     const free = got[got.length - 1]
     expect(free.id).toBe("free")
-    // 10000 - (1000 + 1000 + 2000) = 6000
-    expect(free.tokens).toBe(6000)
+    // 10000 - live used 3500, independent of estimate sum.
+    expect(free.tokens).toBe(6500)
+    expect(got.find(g => g.id === "unknown")).toBeUndefined()
+  })
+
+  test("unknown records live used not explained by estimates", () => {
+    const got = build({
+      ...baseOpts,
+      contextLength: 10_000,
+      usedTokens: 5000,
+      sections: [mkSection("project", "Project", 1000)],
+      conversationTokens: 1000,
+    })
+    expect(got.find(g => g.id === "unknown")?.tokens).toBe(3000)
+    expect(got.at(-1)?.tokens).toBe(5000)
+  })
+
+  test("overage records estimates exceeding live used", () => {
+    const got = build({
+      ...baseOpts,
+      contextLength: 10_000,
+      usedTokens: 1000,
+      sections: [mkSection("project", "Project", 3000)],
+    })
+    expect(got.find(g => g.id === "overage")?.tokens).toBe(2000)
+    expect(got.at(-1)?.tokens).toBe(9000)
   })
 
   test("system_tools and mcp_tools partition tools correctly", () => {
@@ -155,7 +180,6 @@ describe("drill", () => {
     ]
     const [mem] = build({
       contextLength: 10_000,
-      inputTokens: 0,
       sections,
       conversationTokens: 0,
       tools: [],
@@ -169,7 +193,6 @@ describe("drill", () => {
     const tools: ToolInfo[] = [mkTool("terminal", 100, 100)]
     const [sys] = build({
       contextLength: 10_000,
-      inputTokens: 0,
       sections: [],
       conversationTokens: 0,
       tools,
@@ -182,7 +205,7 @@ describe("cells", () => {
   test("produces 256 cells", () => {
     const sections: Section[] = [mkSection("project", "P", 1000)]
     const segs = build({
-      contextLength: 10_000, inputTokens: 0, sections,
+      contextLength: 10_000, sections,
       conversationTokens: 0, tools: [],
     })
     expect(cells(segs)).toHaveLength(256)

--- a/test/context.test.tsx
+++ b/test/context.test.tsx
@@ -162,6 +162,32 @@ describe("Context tab", () => {
       expect(f).toContain("◻ ◻ ◻ ◻")
       t.destroy()
     })
+
+    test("drilled groups hide full-window compression markers", async () => {
+      const info: SessionInfo = {
+        model: "claude-opus-4-7",
+        context_max: 200_000,
+        usage: {
+          input: 100,
+          output: 50,
+          total: 150,
+          context_used: 40_000,
+          context_max: 200_000,
+          compressions: 3,
+        },
+        system_prompt: "# Project Context\n" + "project context ".repeat(100) + "\nConversation started:",
+      }
+      const t = await mountNode(<Context focused info={info} />)
+      act(() => t.keys.pressArrow("down"))
+      act(() => t.keys.pressEnter())
+      await t.settle()
+
+      const f = strip(t.frame())
+      expect(f).toContain("Breakdown · System Prompt")
+      expect(f).not.toContain("×3 compressed")
+      expect(f).not.toContain("Beyond compression threshold")
+      t.destroy()
+    })
   })
 
   // Categorical palette must never assign the same RGBA to two category ids,

--- a/test/context.test.tsx
+++ b/test/context.test.tsx
@@ -112,6 +112,8 @@ describe("Context tab", () => {
   test("config-only max fallback does not fabricate live usage", async () => {
     const cfg = { model: { context_length: 64_000 } } as HermesConfig
     expect(contextMeter(undefined, undefined, cfg)).toEqual({ max: 64_000, used: undefined })
+    expect(contextMeter(undefined, undefined, { model: { context_length: 0 } } as HermesConfig)).toEqual({ max: 128_000, used: undefined })
+    expect(contextMeter(undefined, undefined, { model: { context_length: -1 } } as HermesConfig)).toEqual({ max: 128_000, used: undefined })
 
     const t = await mountNode(<Context />)
     const f = strip(t.frame())

--- a/test/context.test.tsx
+++ b/test/context.test.tsx
@@ -1,9 +1,10 @@
 import { describe, test, expect } from "bun:test"
 import { act } from "react"
 import { mountNode } from "./harness"
-import { Context } from "../src/tabs/Context"
+import { Context, contextMeter } from "../src/tabs/Context"
 import type { SessionInfo } from "../src/context/wire"
-import type { Message } from "../src/types/message"
+import type { Message, Usage } from "../src/types/message"
+import type { HermesConfig } from "../src/service/hermes-home"
 
 // Strip ANSI so regex matches the visual text, not escape codes.
 const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "")
@@ -23,7 +24,7 @@ describe("Context tab", () => {
   // CTX table fallback, so contexts on models not in CTX render
   // proportionally correctly.
   test("uses info.context_max for ctxLen", async () => {
-    const info: SessionInfo = { model: "gpt-4.1", context_max: 500_000 }
+    const info: SessionInfo = { model: "gpt-4.1", context_max: 500_000, context_used: 25_000 }
     const t = await mountNode(<Context info={info} />)
     // 500_000 formatted by fmt() → "500k"; surfaces in the status header
     // and the Free-space breakdown row.
@@ -33,7 +34,7 @@ describe("Context tab", () => {
 
   test("info.context_max overrides DEFAULT_CTX fallback", async () => {
     // DEFAULT_CTX = 128k; info claims 1M. Gateway must win.
-    const info: SessionInfo = { model: "gpt-4o", context_max: 1_000_000 }
+    const info: SessionInfo = { model: "gpt-4o", context_max: 1_000_000, context_used: 50_000 }
     const t = await mountNode(<Context info={info} />)
     const f = strip(t.frame())
     // 1_000_000 formats as "1.0M" via fmt()
@@ -43,10 +44,45 @@ describe("Context tab", () => {
     t.destroy()
   })
 
-  test("falls back to DEFAULT_CTX when info absent", async () => {
-    // No info, no session → DEFAULT_CTX (128k). Verify no crash.
-    const t = await mountNode(<Context />)
-    expect(strip(t.frame())).toContain("Context")
+  test("shows unavailable state when live used is absent", async () => {
+    const messages: Message[] = [
+      { id: "m1", role: "assistant", timestamp: 0, parts: [{ type: "text", content: "a", streaming: false }], usage: { input: 40_000, output: 10, total: 40_010 } },
+      { id: "m2", role: "assistant", timestamp: 1, parts: [{ type: "text", content: "b", streaming: false }], usage: { input: 50_000, output: 10, total: 50_010 } },
+    ]
+    const t = await mountNode(<Context messages={messages} info={{ model: "test", context_max: 100_000 }} />)
+    const f = strip(t.frame())
+    expect(f).toContain("live usage unavailable")
+    expect(f).toContain("~Conversation")
+    expect(f).not.toContain("90k / 100k")
+    expect(f).not.toContain("Context · 90k")
+    t.destroy()
+  })
+
+  test("uses app-level live usage before cumulative message input", async () => {
+    const messages: Message[] = [
+      { id: "m1", role: "assistant", timestamp: 0, parts: [{ type: "text", content: "a", streaming: false }], usage: { input: 40_000, output: 10, total: 40_010 } },
+      { id: "m2", role: "assistant", timestamp: 1, parts: [{ type: "text", content: "b", streaming: false }], usage: { input: 50_000, output: 10, total: 50_010 } },
+    ]
+    const usage: Usage = { input: 90_000, output: 20, total: 90_020, context_used: 12_000, context_max: 100_000 }
+    const t = await mountNode(<Context messages={messages} usage={usage} info={{ model: "test", context_max: 100_000 }} />)
+    const f = strip(t.frame())
+    expect(f).toContain("Context · 12k / 100k (12%)")
+    expect(f).not.toContain("90k / 100k")
+    expect(f).toContain("Free — 88k")
+    t.destroy()
+  })
+
+  test("uses resumed session.info usage before top-level context fields", async () => {
+    const info: SessionInfo = {
+      model: "test",
+      context_used: 70_000,
+      context_max: 100_000,
+      usage: { input: 1, output: 2, total: 3, context_used: 22_000, context_max: 80_000 },
+    }
+    const t = await mountNode(<Context info={info} />)
+    const f = strip(t.frame())
+    expect(f).toContain("Context · 22k / 80k (28%)")
+    expect(f).toContain("Free — 58k")
     t.destroy()
   })
 
@@ -54,6 +90,7 @@ describe("Context tab", () => {
     const info: SessionInfo = {
       model: "test",
       context_max: 10_000,
+      context_used: 1000,
       tools: { builtin: ["terminal"], mcp: ["mcp_search"] },
     }
     const t = await mountNode(<Context info={info} />)
@@ -64,13 +101,33 @@ describe("Context tab", () => {
     t.destroy()
   })
 
+  test("empty live tools do not fall back to legacy tool snapshots", async () => {
+    const t = await mountNode(<Context info={{ model: "test", context_max: 10_000, context_used: 1000, tools: {} }} />)
+    const f = strip(t.frame())
+    expect(f).not.toContain("System Tools")
+    expect(f).not.toContain("MCP Tools")
+    t.destroy()
+  })
+
+  test("config-only max fallback does not fabricate live usage", async () => {
+    const cfg = { model: { context_length: 64_000 } } as HermesConfig
+    expect(contextMeter(undefined, undefined, cfg)).toEqual({ max: 64_000, used: undefined })
+
+    const t = await mountNode(<Context />)
+    const f = strip(t.frame())
+    expect(f).toContain("limit 128k")
+    expect(f).toContain("live usage unavailable")
+    expect(f).not.toContain("Context · 0 / 128k")
+    t.destroy()
+  })
+
   // In-grid threshold marker (◼ in textMuted past threshold) + ×N badge.
   describe("threshold marker", () => {
     test("renders '×N compressed' badge when compressions > 0", async () => {
       const info: SessionInfo = {
         model: "claude-opus-4-7",
         context_max: 200_000,
-        usage: { input: 100, output: 50, total: 150, compressions: 3 },
+        usage: { input: 100, output: 50, total: 150, context_used: 40_000, context_max: 200_000, compressions: 3 },
       }
       const t = await mountNode(<Context info={info} />)
       expect(strip(t.frame())).toContain("×3 compressed")
@@ -81,7 +138,7 @@ describe("Context tab", () => {
       const info: SessionInfo = {
         model: "claude-opus-4-7",
         context_max: 200_000,
-        usage: { input: 100, output: 50, total: 150, compressions: 0 },
+        usage: { input: 100, output: 50, total: 150, context_used: 40_000, context_max: 200_000, compressions: 0 },
       }
       const t = await mountNode(<Context info={info} />)
       expect(strip(t.frame())).not.toMatch(/×\d/)
@@ -89,14 +146,14 @@ describe("Context tab", () => {
     })
 
     test("no badge when usage absent", async () => {
-      const info: SessionInfo = { model: "claude-opus-4-7", context_max: 200_000 }
+      const info: SessionInfo = { model: "claude-opus-4-7", context_max: 200_000, context_used: 40_000 }
       const t = await mountNode(<Context info={info} />)
       expect(strip(t.frame())).not.toMatch(/×\d/)
       t.destroy()
     })
 
     test("cells past threshold render ◼ in the grid", async () => {
-      const info: SessionInfo = { model: "claude-opus-4-7", context_max: 200_000 }
+      const info: SessionInfo = { model: "claude-opus-4-7", context_max: 200_000, context_used: 40_000 }
       const t = await mountNode(<Context info={info} />)
       const f = strip(t.frame())
       // All-free fixture, threshold 0.5 → rows 0-7 are ◻, rows 8-15 are ◼.
@@ -151,7 +208,7 @@ describe("Context tab", () => {
       parts: [{ type: "text", content: "hello world ".repeat(50), streaming: false }],
       usage: { input: 200, output: 0, total: 200 },
     }]
-    const info: SessionInfo = { model: "test", context_max: 10_000 }
+    const info: SessionInfo = { model: "test", context_max: 10_000, context_used: 1000 }
     const legend = (f: string) => f.split("\n").find(l => l.includes(" tok ")) ?? ""
 
     test("↓ selects first; clamps at last; ← steps back; Esc clears", async () => {
@@ -163,10 +220,10 @@ describe("Context tab", () => {
       await t.settle()
       expect(legend(strip(t.frame()))).toContain("Conversation")
 
-      // Two segs → three ↓ clamps on Free (list.* clamps, does not wrap)
-      act(() => { t.keys.pressArrow("down"); t.keys.pressArrow("down"); t.keys.pressArrow("down") })
+      // Three segs → two ↓ lands on Unknown / Provider Overhead.
+      act(() => { t.keys.pressArrow("down"); t.keys.pressArrow("down") })
       await t.settle()
-      expect(legend(strip(t.frame()))).toContain("Free")
+      expect(legend(strip(t.frame()))).toContain("Unknown / Provider Overhead")
 
       // ← alias behaves like list.up
       act(() => t.keys.pressArrow("left"))


### PR DESCRIPTION
## Summary

- Context now treats live `context_used` and `context_max` as the source of truth for exact meter and free-space math.
- When live usage is unavailable, the tab shows an unavailable/estimated state instead of deriving a precise fill from cumulative input tokens.
- Estimated contributor breakdowns stay separate from exact meter values, and drilled views hide full-window compression markers.

## Verification

- `bun test test/context.test.tsx test/context-segments.test.ts test/sidebar.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `git diff --check origin/dev..HEAD`

## Credits

- Builds on #93 by @saenidev for the `model.context_length` fallback; this PR keeps that fallback while replacing the meter fill source with live usage.
