### PR TITLE
fix: centralize lazy session capabilities

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -54,6 +54,7 @@ import { PluginProvider, usePlugins } from "./plugins/runtime"
 import { BackgroundProvider } from "./app/background"
 import { useVoice } from "./voice/useVoice"
 import { VoiceIndicator } from "./voice/Indicator"
+import { sessionCapabilities } from "./app/sessionCapabilities"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch; keyOverrides?: Record<string, string> }
 
@@ -93,6 +94,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [ready, setReady] = useState(false)
   const [sid, setSid] = useState("")
   const sidRef = useRef(sid); sidRef.current = sid
+  const capabilities = sessionCapabilities({ sid, ready, streaming: turn.streaming })
   const [tab, setTab] = useState(CHAT_TAB)
   // Sub-tab per group — Chat has none, so key 0 is unused.
   // Defensive clamp lives inside each group (SessionsGroup/Automation/
@@ -536,7 +538,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const sendRef = useRef<(raw: string) => void>(() => {})
   const slash = useSlash({
     dispatch, session, turnRef, queueRef, sendRef, composer, summoned, undone,
-    ready, info, sid, title, skin,
+    capabilities, info, sid, title, skin,
     setQueue, setFocusRegion, setSplash, setAttachments, setInfo, setUsage, setTitle,
     newSession, switchSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
   })
@@ -633,12 +635,12 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // one tick. `inflight` bridges the dispatch→message.start gap.
   useEffect(() => { if (turn.streaming) inflight.current = false }, [turn.streaming])
   useEffect(() => {
-    if (turn.streaming || inflight.current || !ready || queue.length === 0) return
+    if (!capabilities.canDrainQueue || inflight.current || queue.length === 0) return
     const [head, ...rest] = queue
     inflight.current = true
     setQueue(rest)
     send(head)
-  }, [turn.streaming, ready, queue, send])
+  }, [capabilities.canDrainQueue, queue, send])
 
   const dequeue = useCallback((i: number) => {
     const item = queueRef.current[i]
@@ -823,7 +825,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
               <VoiceIndicator voice={voice.state} keyLabel={voice.keyLabel} />
               <Composer
                 ref={composer}
-                focused={inputFocused} connected={!!sid} ready={ready} streaming={turn.streaming}
+                focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming}
                 status={status}
                 model={info?.model}
                 escHint={escHint}

--- a/src/app/sessionCapabilities.ts
+++ b/src/app/sessionCapabilities.ts
@@ -1,0 +1,26 @@
+export type SessionCapabilityInput = {
+  sid?: string | null
+  ready: boolean
+  streaming: boolean
+}
+
+export type SessionCapabilities = {
+  sessionConnected: boolean
+  metadataHydrated: boolean
+  canSubmitPrompt: boolean
+  canDispatchGatewayCommand: boolean
+  canDrainQueue: boolean
+}
+
+export function sessionCapabilities(input: SessionCapabilityInput): SessionCapabilities {
+  const sessionConnected = Boolean(input.sid)
+  const metadataHydrated = input.ready
+
+  return {
+    sessionConnected,
+    metadataHydrated,
+    canSubmitPrompt: sessionConnected,
+    canDispatchGatewayCommand: sessionConnected,
+    canDrainQueue: sessionConnected && !input.streaming,
+  }
+}

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -44,6 +44,7 @@ import type { SessionInfo, TranscriptMessage, ImageAttachResponse } from "../con
 import type { Message, Usage } from "../types/message"
 import { text as msgText } from "../types/message"
 import type { useSession } from "./useSession"
+import type { SessionCapabilities } from "./sessionCapabilities"
 
 export type SlashCtx = {
   dispatch: React.Dispatch<Action>
@@ -58,7 +59,7 @@ export type SlashCtx = {
    *  gateway session.undo hard-deletes with no unrevert. */
   undone: RefObject<Message[][]>
 
-  ready: boolean
+  capabilities: SessionCapabilities
   info: SessionInfo | null
   sid: string
   title: string
@@ -472,7 +473,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           return
       }
     }
-    if (c.target !== "gateway" || !x.sid) return
+    if (c.target !== "gateway" || !x.capabilities.canDispatchGatewayCommand) return
     const jump = TAB_SLASH[c.name]
     if (jump !== undefined && !arg) { x.goTo(jump.tab, jump.sub); return }
     const full = `/${c.name}${arg ? " " + arg : ""}`

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -49,7 +49,7 @@ export type ComposerHandle = {
 
 type Props = {
   focused: boolean
-  connected?: boolean
+  canSubmitPrompt: boolean
   ready: boolean
   streaming: boolean
   status?: string
@@ -270,7 +270,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     }
     const text = exp.text.trim()
     if (live.current.props.streaming) {
-      if (!text || !(live.current.props.connected ?? live.current.props.ready)) return
+      if (!text || !live.current.props.canSubmitPrompt) return
       hist.push({ input: text, parts: exp.parts })
       write("")
       // Slash-shaped input routes through onSend so send() → slash()
@@ -283,7 +283,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     }
     const hasAtt = (live.current.props.attachments?.length ?? 0) > 0
     if (!text && !hasAtt) { live.current.props.onEmptyEnter?.(); return }
-    if (!(live.current.props.connected ?? live.current.props.ready)) return
+    if (!live.current.props.canSubmitPrompt) return
     if (text) hist.push({ input: text, parts: exp.parts })
     write("")
     live.current.props.onSend(text, exp.parts)

--- a/test/atref.test.tsx
+++ b/test/atref.test.tsx
@@ -54,7 +54,7 @@ describe("atref frecency ranking", () => {
     const t: Harness = await mountNode(
       <box flexDirection="column" flexGrow={1} width="100%" height="100%">
         <box flexGrow={1} />
-        <Composer ref={ref} focused ready streaming={false} cmds={[]}
+        <Composer ref={ref} focused canSubmitPrompt={true} ready streaming={false} cmds={[]}
           onSend={() => {}} onSlash={() => {}} />
       </box>,
       { gw, width: 120, height: 30 },

--- a/test/composer-background-fragment.test.tsx
+++ b/test/composer-background-fragment.test.tsx
@@ -15,6 +15,7 @@ const Host = ({ grab, composerRef }: { grab: (api: ReturnType<typeof useBackgrou
     <Composer
       ref={composerRef}
       focused
+      canSubmitPrompt={true}
       ready
       streaming={false}
       cmds={[]}

--- a/test/composer-parts.test.tsx
+++ b/test/composer-parts.test.tsx
@@ -39,7 +39,11 @@ async function setup(gw = new MockGateway()) {
       <box flexGrow={1} />
       <Composer
         ref={ref}
-        focused ready streaming={false} cmds={LOCAL_COMMANDS}
+        canSubmitPrompt={true}
+        focused={true}
+        ready={true}
+        streaming={false}
+        cmds={LOCAL_COMMANDS}
         onSend={(text, parts) => sent.push({ text, parts })}
         onSlash={() => {}}
       />

--- a/test/composer.test.tsx
+++ b/test/composer.test.tsx
@@ -19,7 +19,7 @@ async function setup(gw = new MockGateway()) {
       <box flexGrow={1} />
       <Composer
         ref={ref}
-        focused ready streaming={false} cmds={LOCAL_COMMANDS}
+        focused canSubmitPrompt={true} ready streaming={false} cmds={LOCAL_COMMANDS}
         onSend={m => sent.push(m)} onSlash={c => slashed.push(c)}
       />
     </box>,
@@ -287,7 +287,7 @@ describe("composer", () => {
         <box flexDirection="column" flexGrow={1} width="100%" height="100%">
           <box flexGrow={1} />
           <Composer
-            ref={ref} focused ready streaming queue={q} cmds={[]}
+            ref={ref} focused canSubmitPrompt={true} ready streaming queue={q} cmds={[]}
             onSend={m => sent.push(m)} onSlash={() => {}}
             onEnqueue={m => setQ(v => [...v, m])}
             onDequeue={i => { dequeued.push(i); setQ(v => v.filter((_, j) => j !== i)) }}
@@ -328,7 +328,7 @@ describe("composer", () => {
       <box flexDirection="column" flexGrow={1} width="100%" height="100%">
         <box flexGrow={1} />
         <Composer
-          ref={ref} focused ready streaming queue={[]} cmds={LOCAL_COMMANDS}
+          ref={ref} focused canSubmitPrompt={true} ready streaming queue={[]} cmds={LOCAL_COMMANDS}
           onSend={() => {}} onSlash={c => slashed.push(c)}
           onEnqueue={m => queued.push(m)}
         />
@@ -404,7 +404,7 @@ describe("composer: paste → file drop detection", () => {
         <box flexGrow={1} />
         <Composer
           ref={ref}
-          focused ready streaming={false} cmds={LOCAL_COMMANDS}
+          focused canSubmitPrompt={true} ready streaming={false} cmds={LOCAL_COMMANDS}
           attachments={attached}
           onSend={() => {}} onSlash={() => {}}
           onAttach={r => attached.push(r)}
@@ -471,7 +471,7 @@ describe("composer: paste → file drop detection", () => {
     const t: Harness = await mountNode(
       <box flexDirection="column" flexGrow={1} width="100%" height="100%">
         <box flexGrow={1} />
-        <Composer ref={ref} focused ready streaming={false} cmds={LOCAL_COMMANDS}
+        <Composer ref={ref} focused canSubmitPrompt={true} ready streaming={false} cmds={LOCAL_COMMANDS}
           onSend={() => {}} onSlash={() => {}} />
       </box>,
       { gw, width: 120, height: 30 },

--- a/test/lazy-session-ready.test.tsx
+++ b/test/lazy-session-ready.test.tsx
@@ -68,4 +68,42 @@ describe("lazy session startup", () => {
     })
     t.destroy()
   })
+
+  test("queued prompt drains after lazy session.create before session.info", async () => {
+    const gw = new MockGateway({
+      "session.create": () => ({
+        session_id: "lazy-sid",
+        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true },
+      }),
+      "prompt.submit": () => ({ status: "streaming" }),
+    })
+    gw.start = () => {
+      gw.ok = true
+      gw.push({ type: "gateway.ready" })
+    }
+
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Connecting") && t.frame().includes("lazy-model"))
+
+    act(() => {
+      t.gw.push({ type: "message.start" })
+    })
+    await until(t, () => t.frame().includes("Type to queue"))
+
+    await act(async () => { await t.keys.typeText("queued while lazy") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("queued while lazy"))
+    expect(t.gw.calls.filter(c => c.method === "prompt.submit").length).toBe(0)
+
+    act(() => {
+      t.gw.push({ type: "message.complete", payload: { text: "done" } })
+    })
+    await until(t, () => Boolean(t.gw.last("prompt.submit")))
+
+    expect(t.gw.last("prompt.submit")?.params).toMatchObject({
+      session_id: "lazy-sid",
+      text: "queued while lazy",
+    })
+    t.destroy()
+  })
 })

--- a/test/sessionCapabilities.test.ts
+++ b/test/sessionCapabilities.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { sessionCapabilities } from "../src/app/sessionCapabilities"
+
+describe("sessionCapabilities", () => {
+  test("session id enables actions before metadata hydration", () => {
+    expect(sessionCapabilities({ sid: "lazy-sid", ready: false, streaming: false })).toEqual({
+      sessionConnected: true,
+      metadataHydrated: false,
+      canSubmitPrompt: true,
+      canDispatchGatewayCommand: true,
+      canDrainQueue: true,
+    })
+  })
+
+  test("queue drain waits for idle but not session.info", () => {
+    expect(sessionCapabilities({ sid: "lazy-sid", ready: false, streaming: true })).toMatchObject({
+      canSubmitPrompt: true,
+      canDispatchGatewayCommand: true,
+      canDrainQueue: false,
+    })
+  })
+
+  test("missing session id disables session actions even if metadata is marked ready", () => {
+    expect(sessionCapabilities({ sid: "", ready: true, streaming: false })).toEqual({
+      sessionConnected: false,
+      metadataHydrated: true,
+      canSubmitPrompt: false,
+      canDispatchGatewayCommand: false,
+      canDrainQueue: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- centralizes startup action gates in explicit session capabilities instead of overloading `ready`
- lets prompts, skill slash commands, and queued prompts submit once a session id exists, while the status line can still show `Connecting...`
- adds lazy-startup regression coverage and direct capability tests

## Verification
- `bunx tsc --noEmit`
- `bun test test/sessionCapabilities.test.ts test/lazy-session-ready.test.tsx test/composer.test.tsx test/app.test.tsx`
- `bun test`
