### PR TITLE
fix: honor resumed session model context

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -360,7 +360,6 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const switchSession = useCallback(async (target: string) => {
     const prev = sidRef.current
-    reset()
     // Keep splash visible while the resume RPC lands so the user sees
     // the ornate frame instead of the empty-transcript welcome. summoned
     // suppresses the continue-prompt (we've already chosen a session);
@@ -373,6 +372,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     goToTab(CHAT_TAB)
     try {
       const res = await session.resume(target)
+      reset()
       setSid(res.id)
       if (res.info) {
         setInfo(res.info)
@@ -389,6 +389,11 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setSplash(false)
       summoned.current = false
     } catch (err) {
+      if (prev) {
+        gw.setSession(prev)
+        setSid(prev)
+        setReady(true)
+      }
       dispatch({ kind: "system", text: `Failed to resume: ${err instanceof Error ? err.message : String(err)}` })
       setSplash(false)
       summoned.current = false
@@ -405,13 +410,15 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const activateSession = useCallback(async (target: string) => {
     const prev = sidRef.current
-    reset()
     summoned.current = true
     setSplash(true)
     setSwitching(true)
+    gw.setSession("")
+    setSid("")
     goToTab(CHAT_TAB)
     try {
       const res = await session.activate(target)
+      reset()
       setSid(res.id)
       if (res.info) {
         setInfo(res.info)
@@ -425,13 +432,18 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       summoned.current = false
       if (prev && prev !== res.id) toast.show({ variant: "info", message: "switched live session" })
     } catch (err) {
+      if (prev) {
+        gw.setSession(prev)
+        setSid(prev)
+        setReady(true)
+      }
       dispatch({ kind: "system", text: `Failed to activate: ${err instanceof Error ? err.message : String(err)}` })
       setSplash(false)
       summoned.current = false
     } finally {
       setSwitching(false)
     }
-  }, [reset, session, goToTab, toast])
+  }, [reset, session, goToTab, toast, gw])
   // Rebind every HERMES_HOME reader, respawn the gateway subprocess
   // under the new env, and re-run the boot path. prefs.reload (inside
   // rehome) retints theme/eikon/keys via usePref; home.reset repaints

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -87,12 +87,12 @@ export function useSession(): SessionOps {
     // pass exact ids on purpose; boot() resolves tips itself.
     const target = normalize(sid)
     const row = byId(target)
+    const model = spec(row)
+    if (model) await gw.request("config.set", { session_id: undefined, key: "model", value: model })
     const res = await gw.request<SessionResumeResponse>("session.resume", { session_id: target })
     const id = res.session_id
     gw.setSession(id)
     preferences.set("lastSessionId", res.resumed ?? target)
-    const model = spec(row)
-    if (model) await gw.request("config.set", { key: "model", value: model }).catch(() => {})
     const messages = res.messages?.length ? transcriptToMessages(res.messages) : []
     return { id, messages, info: res.info }
   }, [gw])

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -475,7 +475,8 @@ export const Sessions = memo((props: Props) => {
   const active = useMemo(() => [...liveRows].sort((a, b) =>
     Number(Boolean(b.live?.current)) - Number(Boolean(a.live?.current)) ||
     ((b.live?.last_active ?? b.started_at) - (a.live?.last_active ?? a.started_at))), [liveRows])
-  const ids = useMemo(() => new Set(active.map(r => r.id)), [active])
+  const ids = useMemo(() => new Set(active.flatMap(r =>
+    [r.id, r.live?.session_key].filter((x): x is string => Boolean(x)))), [active])
   const sorted = useMemo(() => rows.filter(r => !ids.has(r.id)).sort(cmp(sort)), [rows, ids, sort])
   const listed = useMemo(() => [...active, ...sorted], [active, sorted])
   // Selection is tracked by row identity so that collapsing children
@@ -557,6 +558,9 @@ export const Sessions = memo((props: Props) => {
     live: s,
   })
 
+  const pick = <T,>(m: Map<string, T>, s: SessionActiveItem) =>
+    m.get(s.id) ?? m.get(s.session_key ?? "")
+
   // Two-stage paint. io.list is off-thread, so the mount frame commits
   // (spinner / cached rows) before it resolves; the RPC is slower still.
   // Kids (subagents per parent) fill in after the list — the tree
@@ -589,7 +593,7 @@ export const Sessions = memo((props: Props) => {
     const a = await active
     const live = a.ok ? (a.v.sessions ?? []) : []
     if (a.ok) {
-      setLiveRows(live.map(s => toLiveRow(s, local.get(s.id))))
+      setLiveRows(live.map(s => toLiveRow(s, pick(local, s))))
     }
 
     // Stock session.list doesn't drop 0-msg stubs — every abandoned
@@ -610,7 +614,7 @@ export const Sessions = memo((props: Props) => {
       setRows(merged)
       if (cached) last.rows = merged
       const found = new Map(merged.map(s => [s.id, s]))
-      if (live.length) setLiveRows(live.map(s => toLiveRow(s, local.get(s.id), found.get(s.id))))
+      if (live.length) setLiveRows(live.map(s => toLiveRow(s, pick(local, s), pick(found, s))))
       void fillKids(merged)
     }
     setPending(false)

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -167,10 +167,15 @@ describe("useSession.boot", () => {
       "session.resume": p => ({ session_id: "live-past", resumed: p.session_id, messages: [] }),
       "config.set": p => { sets.push(p); return { value: p.value } },
     })
+    gw.setSession("old")
     await boot(gw, { mode: "resume", sid: "past" })
 
     expect(gw.last("session.resume")?.params.session_id).toBe("past")
-    expect(sets).toEqual([{ session_id: "live-past", key: "model", value: "gpt-5.5 --provider openai-codex" }])
+    expect(sets).toEqual([{ session_id: undefined, key: "model", value: "gpt-5.5 --provider openai-codex" }])
+    const ci = gw.calls.findIndex(c => c.method === "config.set")
+    const ri = gw.calls.findIndex(c => c.method === "session.resume")
+    expect(ci).toBeGreaterThan(-1)
+    expect(ci).toBeLessThan(ri)
   })
 
   test("mode:resume normalizes session_*.json filenames", async () => {

--- a/test/session-close.test.tsx
+++ b/test/session-close.test.tsx
@@ -5,9 +5,31 @@
 // (sessions-db.ts SUB/CONT predicates) until quit. Parity with Ink
 // TUI's useSessionLifecycle.closeSession.
 
-import { describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, test } from "bun:test"
 import { act } from "react"
 import { mount, until, MockGateway } from "./harness"
+import { openStateDb } from "./fixtures/state-db"
+import { resetDb } from "../src/service/sessions-db"
+
+const wipe = () => {
+  const db = openStateDb()
+  db.run("DELETE FROM messages")
+  db.run("DELETE FROM sessions")
+  db.close()
+  resetDb()
+}
+
+const seed = () => {
+  const db = openStateDb()
+  db.run("DELETE FROM messages")
+  db.run("DELETE FROM sessions")
+  db.run(`INSERT INTO sessions (id, source, model, billing_provider, started_at, message_count)
+    VALUES ('past', 'tui', 'gpt-5.5', 'openai-codex', 1000, 2)`)
+  db.close()
+  resetDb()
+}
+
+afterAll(wipe)
 
 describe("session.close", () => {
   test("/new closes the outgoing session", async () => {
@@ -79,23 +101,153 @@ describe("session.close", () => {
     t.destroy()
   })
 
+  test("switchSession preconfigures stored model before resume", async () => {
+    seed()
+    let prepped = false
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "session.create": () => ({ session_id: "old" }),
+      "config.set": p => {
+        prepped = p.value === "gpt-5.5 --provider openai-codex" && p.session_id === undefined
+        return { key: p.key, value: p.value, warning: "" }
+      },
+      "session.resume": p => ({
+        session_id: "live-past",
+        resumed: p.session_id,
+        messages: [{ role: "user", text: "hello" }],
+        info: {
+          model: "gpt-5.5",
+          session_id: "live-past",
+          tools: {},
+          skills: {},
+          usage: {
+            input: 0,
+            output: 0,
+            total: 0,
+            context_used: 110_000,
+            context_max: prepped ? 1_000_000 : 256_000,
+          },
+        },
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "new", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/resume past") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Ready") && t.frame().includes("hello"))
+
+    const ri = gw.calls.findIndex(c => c.method === "session.resume" && c.params.session_id === "past")
+    const ci = gw.calls.findIndex(c => c.method === "config.set" && c.params.value === "gpt-5.5 --provider openai-codex")
+    expect(ci).toBeGreaterThan(-1)
+    expect(ci).toBeLessThan(ri)
+    expect(t.frame()).toContain("110K / 1M")
+
+    t.destroy()
+  })
+
+  test("Sessions tab preconfigures stored model on first resume", async () => {
+    seed()
+    let prepped = false
+    const row = { id: "past", title: "Past", preview: "hello", message_count: 2, started_at: 1000, source: "tui" }
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/sessions", "sessions"]] }),
+      "session.create": () => ({ session_id: "old" }),
+      "session.list": () => ({ sessions: [row] }),
+      "config.set": p => {
+        prepped = p.value === "gpt-5.5 --provider openai-codex" && p.session_id === undefined
+        return { key: p.key, value: p.value, warning: "" }
+      },
+      "session.resume": p => ({
+        session_id: "live-past",
+        resumed: p.session_id,
+        messages: [{ role: "user", text: "hello" }],
+        info: {
+          model: "gpt-5.5",
+          session_id: "live-past",
+          tools: {},
+          skills: {},
+          usage: {
+            input: 0,
+            output: 0,
+            total: 0,
+            context_used: 110_000,
+            context_max: prepped ? 1_000_000 : 256_000,
+          },
+        },
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "new", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/sessions") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Sessions (1)"))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Load session?"))
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("Ready") && t.frame().includes("hello"))
+
+    const ci = gw.calls.findIndex(c => c.method === "config.set" && c.params.value === "gpt-5.5 --provider openai-codex")
+    const ri = gw.calls.findIndex(c => c.method === "session.resume" && c.params.session_id === "past")
+    expect(ci).toBeGreaterThan(-1)
+    expect(ci).toBeLessThan(ri)
+    expect(t.frame()).toContain("110K / 1M")
+    expect(t.frame()).not.toContain("Connecting")
+
+    t.destroy()
+  })
+
+  test("switchSession stops before resume when model preconfigure fails", async () => {
+    seed()
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "session.create": () => ({ session_id: "old" }),
+      "config.set": () => { throw new Error("model switch failed") },
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "new", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/resume past") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Failed to resume: model switch failed"))
+
+    expect(gw.calls.some(c => c.method === "session.resume" && c.params.session_id === "past")).toBe(false)
+    expect(t.frame()).not.toContain("Connecting")
+
+    await act(async () => { await t.keys.typeText("still old") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("prompt.submit") !== undefined)
+    expect(t.gw.last("prompt.submit")?.params.session_id).toBe("old")
+
+    t.destroy()
+  })
+
   test("switchSession keeps prev live when resume fails", async () => {
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
       "session.resume": p => {
         if (p.session_id === "bad") throw new Error("nope")
-        return { session_id: p.session_id, messages: [] }
+        return { session_id: p.session_id, messages: [{ role: "user", text: "old transcript" }] }
       },
     })
     const t = await mount({ gw, launch: { mode: "resume", sid: "first", splash: false } })
-    await until(t, () => t.frame().includes("Ready"))
+    await until(t, () => t.frame().includes("Ready") && t.frame().includes("old transcript"))
 
     await act(async () => { await t.keys.typeText("/resume bad") })
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Failed to resume"))
 
-    // No close — user is still on "first", which must stay live.
+    // No close — user is still on "first", which must stay live and usable.
     expect(t.gw.last("session.close")).toBeUndefined()
+    expect(t.frame()).not.toContain("Connecting")
+    expect(t.frame()).toContain("old transcript")
+
+    await act(async () => { await t.keys.typeText("still here") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("prompt.submit") !== undefined)
+    expect(t.gw.last("prompt.submit")?.params.session_id).toBe("first")
 
     t.destroy()
   })

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -105,6 +105,26 @@ describe("Sessions tab", () => {
     t.destroy()
   })
 
+  test("active resumed session_key suppresses duplicate history row", async () => {
+    const gw = new MockGateway({
+      "session.active_list": () => ({ sessions: [
+        { id: "live-past", session_key: "past", title: "Past Root", preview: "hello", message_count: 2, started_at: 1700000000, status: "idle" },
+      ]}),
+      "session.list": () => ({ sessions: [
+        { id: "past", title: "Past Root", preview: "hello", message_count: 2, started_at: 1700000000, source: "tui" },
+      ]}),
+    })
+    const disk = [detail({ id: "past", sessionSource: "tui", title: "Past Root", message_count: 2, started_at: 1700000000 })]
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => disk }} currentId="live-past" />, { gw, width: 110 })
+    await until(t, () => t.frame().includes("Sessions (1)") && t.frame().includes("Past Root"))
+
+    expect(t.frame()).toContain("Active Session")
+    expect(t.frame()).toContain("TUI")
+    expect(t.frame()).not.toContain("History")
+
+    t.destroy()
+  })
+
   test("lists from session.list RPC and switches on Enter", async () => {
     const gw = new MockGateway({ "session.list": () => ({ sessions: ROWS }) })
     let switched = ""


### PR DESCRIPTION
## Summary

Herm now resumes stored sessions under the provider/model that created them, so the resumed agent reports the expected context window instead of falling back to the current process default. Failed session switches leave the outgoing chat live and usable instead of clearing the transcript and parking the composer on Connecting.

The Sessions tab also treats an active resumed session's `session_key` as the same row as its historical id, which prevents the duplicate History row that made selecting the same session a second time look like the real resume path.

## Test plan

- `bun test test/session-close.test.tsx test/launch.test.tsx test/sessions.test.tsx`
- `bunx tsc --noEmit`
- `bun test`
