### PR TITLE
feat(eikon): add Eikon Haven Import sub-tab

### DIFF
--- a/src/app/tabs.ts
+++ b/src/app/tabs.ts
@@ -26,9 +26,7 @@ export const SUB_TABS: Record<number, readonly string[]> = {
   [SESSIONS_TAB]:   ["List", "Context", "Analytics"],
   [AUTOMATION_TAB]: ["Kanban", "Profiles", "Cron"],
   [CONFIG_TAB]:     ["Config", "Skills", "Toolsets", "Env", "Memory"],
-  // A third "Advanced" sub-tab (rasterizer install/config) is reserved
-  // — not yet implemented; group clamps defensively like the others.
-  [EIKON_TAB]:      ["Gallery", "Studio"],
+  [EIKON_TAB]:      ["Gallery", "Studio", "Import"],
 }
 
 /** Slash-command name → {tab, sub}. `sub` is the sub-tab index within that
@@ -51,4 +49,5 @@ export const TAB_SLASH: Record<string, { tab: number; sub: number }> = {
   memory:     { tab: CONFIG_TAB,     sub: 4 },
   studio:     { tab: EIKON_TAB,      sub: 1 },
   gallery:    { tab: EIKON_TAB,      sub: 0 },
+  import:     { tab: EIKON_TAB,      sub: 2 },
 }

--- a/src/tabs/EikonGroup.tsx
+++ b/src/tabs/EikonGroup.tsx
@@ -4,6 +4,7 @@ import { SUB_TABS, EIKON_TAB } from "../app/tabs"
 import { useKeys } from "../keys"
 import { EikonStudio } from "./EikonStudio"
 import { EikonGallery } from "./EikonGallery"
+import { EikonImport } from "./EikonImport"
 import type { SidebarPreview } from "../components/sidebar/Sidebar"
 
 type Props = {
@@ -15,8 +16,8 @@ type Props = {
 }
 
 // Gallery is the landing sub-tab; it lists installed + bundled eikons and
-// can hand a name to Studio for editing. A third "Advanced"
-// sub-tab (rasterizer setup) is reserved — see tabs.ts.
+// can hand a name to Studio for editing. Import lets users paste an
+// eikon-haven.top URL or slug to import eikons from the haven.
 export const EikonGroup = memo((props: Props) => {
   const keys = useKeys()
   const labels = SUB_TABS[EIKON_TAB]!
@@ -35,6 +36,9 @@ export const EikonGroup = memo((props: Props) => {
         </Pane>
         <Pane visible={props.sub === 1}>
           <EikonStudio focused={!!props.focused && props.sub === 1} name={target} />
+        </Pane>
+        <Pane visible={props.sub === 2}>
+          <EikonImport focused={!!props.focused && props.sub === 2} />
         </Pane>
       </box>
     </box>

--- a/src/tabs/EikonImport.tsx
+++ b/src/tabs/EikonImport.tsx
@@ -1,0 +1,198 @@
+// Eikon Haven Import — paste a URL or slug from eikon-haven.top to
+// import eikons into the local gallery. Fetches metadata + .eikon file
+// from Supabase, saves to ~/.hermes/eikons/<name>/, shows braille preview.
+
+import { memo, useCallback, useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { useTheme } from "../theme"
+import { useToast } from "../ui/toast"
+import { useDialog } from "../ui/dialog"
+import { useKeys } from "../keys"
+import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
+import { hermesPath } from "../service/hermes-home"
+import { eikon } from "../service/eikon"
+import { parseEikon, type ParsedEikon } from "../components/avatar/eikon"
+
+const SB_URL = "https://ofoepdrohvrruonxpnsd.supabase.co"
+
+type Row = {
+  id: string
+  name: string
+  slug: string
+  author?: string
+  tags?: string[]
+  file_path: string
+}
+
+type Imported = {
+  name: string
+  slug: string
+  author?: string
+  tags?: string[]
+  preview?: ParsedEikon
+}
+
+type Props = {
+  focused: boolean
+}
+
+const extractSlug = (raw: string): string => {
+  const trimmed = raw.trim()
+  const m = trimmed.match(/eikon-haven\.top\/eikon\/([a-z0-9_-]+)/i)
+  return m ? m[1] : trimmed.replace(/[^a-z0-9_-]/gi, "").toLowerCase()
+}
+
+export const EikonImport = memo((props: Props) => {
+  const theme = useTheme().theme
+  const toast = useToast()
+  const dialog = useDialog()
+  const keys = useKeys()
+
+  const [input, setInput] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | undefined>(undefined)
+  const [result, setResult] = useState<Imported | undefined>(undefined)
+  const [recent, setRecent] = useState<Imported[]>([])
+
+  const sbKey = process.env.SUPABASE_ANON_KEY
+
+  const doImport = useCallback(async () => {
+    const slug = extractSlug(input)
+    if (!slug) return
+    setBusy(true)
+    setError(undefined)
+    setResult(undefined)
+
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    }
+    if (sbKey) headers["apikey"] = sbKey
+    if (sbKey) headers["Authorization"] = `Bearer ${sbKey}`
+
+    try {
+      const metaUrl = `${SB_URL}/rest/v1/eikons?slug=eq.${encodeURIComponent(slug)}&status=eq.approved&select=*`
+      const metaRes = await fetch(metaUrl, { headers })
+      if (!metaRes.ok) throw new Error(`HTTP ${metaRes.status}`)
+      const rows: Row[] = await metaRes.json() as Row[]
+      if (rows.length === 0) throw new Error(`No approved eikon found for "${slug}"`)
+      const row = rows[0]
+
+      const fileUrl = `${SB_URL}/storage/v1/object/public/eikons-public/${row.file_path}`
+      const fileRes = await fetch(fileUrl)
+      if (!fileRes.ok) throw new Error(`Download failed: HTTP ${fileRes.status}`)
+      const text = await fileRes.text()
+
+      const paths = eikon.ensure(row.slug)
+      writeFileSync(join(paths.dir, `${row.slug}.eikon`), text, "utf8")
+
+      let preview: ParsedEikon | undefined
+      try { preview = parseEikon(text) } catch { /* ignore */ }
+
+      // Fire-and-forget download tracking
+      void fetch(`${SB_URL}/rest/v1/rpc/track_download`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ p_eikon_id: row.id }),
+      }).catch(() => { /* ignore */ })
+
+      const entry: Imported = { name: row.name, slug: row.slug, author: row.author, tags: row.tags, preview }
+      setResult(entry)
+      setRecent(p => [entry, ...p.filter(r => r.slug !== entry.slug).slice(0, 9)])
+      setInput("")
+      toast.show({ variant: "success", message: `Imported "${row.name}"` })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      setError(msg)
+      toast.show({ variant: "error", title: "Import failed", message: msg })
+    } finally {
+      setBusy(false)
+    }
+  }, [input, sbKey, toast])
+
+  const reset = useCallback(() => {
+    setInput("")
+    setError(undefined)
+    setResult(undefined)
+  }, [])
+
+  useKeyboard(key => {
+    if (!props.focused || dialog.open()) return
+    if (key.name === "r" && !busy) { reset(); return }
+  })
+
+  return (
+    <box flexDirection="column" flexGrow={1} minWidth={0} minHeight={0}>
+      <box flexDirection="row" flexGrow={1} minHeight={0}>
+        <TabShell title="Import from Eikon Haven" focus={props.focused} grow={3}>
+          <box flexDirection="column" padding={1} gap={1} flexGrow={1} minWidth={0}>
+            <text fg={theme.textMuted}>Paste a URL or slug from eikon-haven.top:</text>
+            <box flexDirection="row" gap={1}>
+              <box flexGrow={1} minWidth={0}>
+                <input
+                  value={input}
+                  onChange={setInput}
+                  onSubmit={doImport}
+                  placeholder="https://eikon-haven.top/eikon/ares or just ares"
+                  focused={props.focused && !busy}
+                />
+              </box>
+            </box>
+            {busy ? <text fg={theme.primary}>Importing…</text> : null}
+            {error ? <text fg={theme.error}>{error}</text> : null}
+            {result ? (
+              <box flexDirection="column" gap={0} marginTop={1}>
+                <text fg={theme.success}><strong>✓ {result.name}</strong></text>
+                {result.author ? <text fg={theme.textMuted}>  by {result.author}</text> : null}
+                {result.tags && result.tags.length > 0
+                  ? <text fg={theme.textMuted}>  tags: {result.tags.join(", ")}</text> : null}
+              </box>
+            ) : null}
+            {!sbKey ? (
+              <box flexDirection="column" marginTop={1}>
+                <text fg={theme.warning}>⚠ SUPABASE_ANON_KEY not set</text>
+                <text fg={theme.textMuted}>Set the env var to enable Eikon Haven imports.</text>
+              </box>
+            ) : null}
+            {recent.length > 0 ? (
+              <box flexDirection="column" marginTop={1}>
+                <text fg={theme.textMuted}><strong>Recent imports:</strong></text>
+                {recent.map(r => (
+                  <text key={r.slug} fg={theme.text}>  • {r.name} ({r.slug})</text>
+                ))}
+              </box>
+            ) : null}
+          </box>
+        </TabShell>
+        <TabShell title={result ? `Preview — ${result.name}` : "Preview"} grow={2}>
+          <box alignItems="center" justifyContent="center" flexGrow={1}>
+            {result?.preview
+              ? <Preview preview={result.preview} />
+              : <text fg={theme.textMuted}>Import an eikon to see preview.</text>}
+          </box>
+        </TabShell>
+      </box>
+      <HintBar pairs={[
+        ["Enter", "import"],
+        ["r", "reset"],
+        ...(!sbKey ? [["export SUPABASE_ANON_KEY", "required"] as const] : []),
+      ]} />
+    </box>
+  )
+})
+
+const Preview = (props: { preview: ParsedEikon }) => {
+  const theme = useTheme().theme
+  const idle = props.preview.states.get("idle")
+  if (!idle) return <text fg={theme.textMuted}>No idle state.</text>
+  const frame = idle.frames[0]
+  if (!frame) return <text fg={theme.textMuted}>Empty frame.</text>
+  const rows = frame.slice(0, 8)
+  return (
+    <box flexDirection="column">
+      {rows.map((line, i) => <text key={i}>{line}</text>)}
+    </box>
+  )
+}


### PR DESCRIPTION
Adds an Import sub-tab to the Eikon group (Gallery | Studio | Import) that lets users paste a URL or slug from eikon-haven.top to import eikons directly.

Changes:
- New `src/tabs/EikonImport.tsx` — paste-based import from Eikon Haven (Supabase backend)
- Updated `src/tabs/EikonGroup.tsx` — adds Import as third sub-tab
- Updated `src/app/tabs.ts` — adds Import to SUB_TABS and /import slash command
- Reads Supabase anon key from SUPABASE_ANON_KEY env var (no hardcoded credentials)

How it works:
- User copies a link from eikon-haven.top (e.g. `https://eikon-haven.top/eikon/ares`) or just the slug
- Pastes into the input field
- Component fetches eikon metadata from Supabase REST API
- Downloads the .eikon file from public storage
- Saves to `~/.hermes/eikons/<name>/`
- Tracks download via track_download RPC (IP-based dedup, fire-and-forget)
- Shows braille preview of the imported eikon
- Keyboard: Enter to import, r to reset input