### PR TITLE
fix(input): swallow degraded mouse-burst noise before composer

### DIFF
--- a/src/app/mouseFilter.ts
+++ b/src/app/mouseFilter.ts
@@ -1,0 +1,12 @@
+const SGR_MOUSE_BLOB_RE = /^(?:\x1b\[|\^\[\[)?<?\d+(?:;\d+){1,2}[Mm]$/
+const SGR_MOUSE_RESIDUE_RE = /^\d+(?:;\d+){1,2}[Mm]$/
+
+export function isDegradedMouseInput(key: { name?: string; raw?: string; sequence?: string }): boolean {
+  const vals = [key.raw, key.sequence, key.name]
+  return vals.some(v => typeof v === "string" && isDegradedMouseBlob(v))
+}
+
+export function isDegradedMouseBlob(text: string): boolean {
+  if (!text || /\s/.test(text)) return false
+  return SGR_MOUSE_BLOB_RE.test(text) || SGR_MOUSE_RESIDUE_RE.test(text)
+}

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -20,6 +20,7 @@ import { editInEditor } from "../utils/editor"
 import { Selection } from "../utils/selection"
 import { useKeys, conflicts } from "../keys"
 import { print as chordPrint } from "../keys/chord"
+import { isDegradedMouseInput } from "./mouseFilter"
 import type { ComposerHandle } from "../components/chat/Composer"
 import { isVoiceToggleKey } from "../voice/platform"
 import type { VoiceKey } from "../voice/types"
@@ -101,6 +102,11 @@ export function useAppKeys(o: Opts) {
 
   useKeyboard((key) => {
     const c = o.composer.current
+
+    if (isDegradedMouseInput(key)) {
+      key.stopPropagation()
+      return
+    }
 
     // An active text selection pre-empts every shell binding: Esc
     // clears it (not the dialog, not the interrupt counter), Ctrl+C

--- a/test/mouse-filter.test.tsx
+++ b/test/mouse-filter.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+
+const pk = (name: string, raw = name) => ({
+  name,
+  ctrl: false,
+  meta: false,
+  shift: false,
+  option: false,
+  super: false,
+  sequence: raw,
+  raw,
+  number: false,
+  eventType: "press" as const,
+  source: "raw" as const,
+})
+
+describe("degraded mouse burst filter", () => {
+  test("swallows pure SGR mouse leak blobs before composer submit", async () => {
+    const gw = new MockGateway()
+    await using t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.renderer.keyInput.processParsedKey(pk("<35;120;7M")))
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    expect(gw.last("prompt.submit")).toBeUndefined()
+    expect(t.frame()).not.toContain("<35;120;7M")
+  })
+
+  test("swallows stalled-loop residue chunks", async () => {
+    const gw = new MockGateway()
+    await using t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.renderer.keyInput.processParsedKey(pk("35;120;7M")))
+    act(() => t.renderer.keyInput.processParsedKey(pk("120;7m")))
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    expect(gw.last("prompt.submit")).toBeUndefined()
+    expect(t.frame()).not.toContain("35;120;7M")
+    expect(t.frame()).not.toContain("120;7m")
+  })
+
+  test("preserves normal prose containing M and m", async () => {
+    const gw = new MockGateway()
+    await using t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("Mmm MMM mmm yummy") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.last("prompt.submit") !== undefined)
+
+    expect(gw.last("prompt.submit")?.params.text).toBe("Mmm MMM mmm yummy")
+  })
+})


### PR DESCRIPTION
## What

Swallow degraded SGR mouse-burst noise before it reaches the composer, so a stalled render loop can't leak garbage like `M6M35;220;56M…` into input or fire spurious key actions.

Adds `src/app/mouseFilter.ts` (the filter) and wires it in `src/app/useAppKeys.ts`. Prose containing `M`/`m` is preserved unchanged.

## Why

Parity with the upstream hermes-agent fix for degraded mouse bursts; without a client-side filter, a stalled loop can lock the composer with SGR residue.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test test/mouse-filter.test.tsx` — 3 pass / 0 fail (SGR blob swallow, stalled-loop residue, prose-with-M preserved)

Reviewed clean via kanban reviewer (0 blocking findings). Branch rebased onto current dev; no schema or unrelated changes.