### PR TITLE
feat(agents): nudge users toward live delegated work

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -55,6 +55,8 @@ import { BackgroundProvider } from "./app/background"
 import { useVoice } from "./voice/useVoice"
 import { VoiceIndicator } from "./voice/Indicator"
 import { sessionCapabilities } from "./app/sessionCapabilities"
+import { useHome } from "./home"
+import { agentsNudge, agentsNudgeEnabled, isAgentsSurface, TEXT as AGENTS_NUDGE_TEXT } from "./app/agentsNudge"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch; keyOverrides?: Record<string, string> }
 
@@ -112,6 +114,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const autoSub = useCallback((i: number) => setSub(AUTOMATION_TAB, i), [setSub])
   const cfgSub = useCallback((i: number) => setSub(CONFIG_TAB, i), [setSub])
   const eikSub = useCallback((i: number) => setSub(EIKON_TAB, i), [setSub])
+  const agentsSub = SUB_TABS[AUTOMATION_TAB].indexOf("Profiles")
   const [hideSidebar, setHideSidebar] = useState(false)
   const [usage, setUsage] = useState<Usage | undefined>(undefined)
   const [info, setInfo] = useState<SessionInfo | null>(null)
@@ -320,9 +323,23 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   }, [busy, gw, toast])
   const onAttach = useCallback((r: ImageAttachResponse) => setAttachments(a => [...a, r]), [])
 
+  const cfg = useHome("config")
+  const nudge = useRef({ shown: false })
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
     setSid, setInfo, setReady, setTitle, setBusy, setUsage, setStatus, setSkin, setErrorPulse,
+    onEvent: ev => {
+      if (!agentsNudge(nudge.current, ev, {
+        enabled: agentsNudgeEnabled(cfg),
+        agentsSurface: isAgentsSurface(tab, subTabs[AUTOMATION_TAB] ?? 0, AUTOMATION_TAB, agentsSub),
+      })) return
+      toast.show({
+        variant: "info",
+        message: AGENTS_NUDGE_TEXT,
+        duration: 5000,
+        action: { label: "/agents", run: () => goTo(AUTOMATION_TAB, agentsSub) },
+      })
+    },
   })
   intr.current = stream.doInterrupt
 

--- a/src/app/agentsNudge.ts
+++ b/src/app/agentsNudge.ts
@@ -1,0 +1,33 @@
+import type { GatewayEvent } from "../context/wire"
+
+export const TEXT = "subagents working · /agents to watch live"
+
+export type AgentsNudgeConfig = {
+  display?: {
+    tui_agents_nudge?: boolean
+  }
+}
+
+export type AgentsNudgeState = {
+  shown: boolean
+}
+
+export function agentsNudgeEnabled(cfg: AgentsNudgeConfig | null | undefined): boolean {
+  return cfg?.display?.tui_agents_nudge === true
+}
+
+export function isAgentsSurface(tab: number, sub: number, agentsTab: number, agentsSub: number): boolean {
+  return tab === agentsTab && sub === agentsSub
+}
+
+export function agentsNudge(
+  state: AgentsNudgeState,
+  ev: Pick<GatewayEvent, "type">,
+  opts: { enabled: boolean; agentsSurface: boolean },
+): boolean {
+  if (ev.type === "message.start") state.shown = false
+  if (ev.type !== "subagent.start" && ev.type !== "subagent.spawn_requested") return false
+  if (!opts.enabled || opts.agentsSurface || state.shown) return false
+  state.shown = true
+  return true
+}

--- a/src/app/agentsNudge.ts
+++ b/src/app/agentsNudge.ts
@@ -13,7 +13,7 @@ export type AgentsNudgeState = {
 }
 
 export function agentsNudgeEnabled(cfg: AgentsNudgeConfig | null | undefined): boolean {
-  return cfg?.display?.tui_agents_nudge === true
+  return cfg?.display?.tui_agents_nudge !== false
 }
 
 export function isAgentsSurface(tab: number, sub: number, agentsTab: number, agentsSub: number): boolean {

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -248,6 +248,8 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
         case "resume":
           if (arg) { void x.switchSession(arg); return }
           x.goTo(TAB_SLASH.sessions.tab, TAB_SLASH.sessions.sub); return
+        case "agents":
+          x.goTo(TAB_SLASH.agents.tab, TAB_SLASH.agents.sub); return
         case "branch":
           x.session.branch(arg || undefined).then(id => id
             ? void x.switchSession(id)

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -35,6 +35,7 @@ export type SlashCommand = {
 export const LOCAL_NAMES = new Set([
   "clear", "new", "theme", "help", "keys", "logs", "title",
   "rollback", "save", "history", "status", "usage", "profile", "steer",
+  "agents",
   "reload", "reload-mcp", "reload-skills", "chafa", "splash", "skin",
   // parity: session-mutating commands the slash-worker can't service
   "resume", "branch", "compress", "undo", "redo", "retry", "model", "quit",
@@ -64,6 +65,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "status",  description: "Version, model, paths",       category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "usage",   description: "Tokens, context fill, cost",   category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "profile", description: "Active profile details",       category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "agents", description: "Open the Agents tab",             category: "Client", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "steer",   description: "Inject a note mid-turn (no interrupt)", category: "Session", aliases: [], argsHint: "[text]", subcommands: [], source: "local", target: "local" },
   { name: "reload-mcp", description: "Restart MCP servers & rediscover tools", category: "Session", aliases: [], argsHint: "[now|always]", subcommands: ["now", "always"], source: "local", target: "local" },
   { name: "reload", description: "Hot-reload ~/.hermes/.env (API keys)", category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -36,6 +36,7 @@ type Ctx = {
   setStatus: (s: string) => void
   setSkin: (s: SkinState) => void
   setErrorPulse: (v: boolean) => void
+  onEvent?: (ev: GatewayEvent) => void
 }
 
 // Events that mutate the in-progress assistant turn. Everything else
@@ -45,6 +46,7 @@ const STREAM_EVENTS = new Set<GatewayEvent["type"]>([
   "message.start",
   "message.delta", "reasoning.delta", "reasoning.available", "thinking.delta",
   "tool.start", "tool.progress", "tool.generating",
+  "subagent.start", "subagent.spawn_requested", "subagent.thinking", "subagent.tool", "subagent.progress",
 ])
 
 export function useStream(c: Ctx) {
@@ -113,6 +115,7 @@ export function useStream(c: Ctx) {
       if (STREAM_EVENTS.has(ev.type)) return
       if (ev.type === "status.update" && ev.payload?.kind === "lifecycle") return
     }
+    x.onEvent?.(ev)
     const action = mapEvent(ev, {
       onReady: () => {
         x.session.boot(x.launchRef.current).then((r) => {

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -121,11 +121,12 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
     }
 
     case "subagent.start":
+    case "subagent.spawn_requested":
     case "subagent.thinking":
     case "subagent.tool":
     case "subagent.progress":
     case "subagent.complete": {
-      const sub = ev.type.slice(9) as "start" | "thinking" | "tool" | "progress" | "complete"
+      const sub = (ev.type === "subagent.spawn_requested" ? "start" : ev.type.slice(9)) as "start" | "thinking" | "tool" | "progress" | "complete"
       // Feed the turn-wide accumulator so the completed tree can be
       // persisted (spawn_tree.save) and the Agents tab can read live
       // tool trails without its own event listener.

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -33,6 +33,7 @@ export type GatewayEvent = ({
   | { type: "voice.status"; payload?: { state?: "idle" | "listening" | "transcribing" } }
   | { type: "voice.transcript"; payload?: { text?: string; no_speech_limit?: boolean } }
   | { type: "subagent.start"; payload: SubagentPayload }
+  | { type: "subagent.spawn_requested"; payload: SubagentPayload }
   | { type: "subagent.thinking"; payload: SubagentPayload }
   | { type: "subagent.tool"; payload: SubagentPayload }
   | { type: "subagent.progress"; payload: SubagentPayload }

--- a/src/home/store.ts
+++ b/src/home/store.ts
@@ -214,6 +214,12 @@ export class HomeStore {
     for (const dep of DEPENDENTS.get(k) ?? []) this.invalidate(dep)
   }
 
+  setForTest<K extends SliceKey>(k: K, v: HomeState[K] | undefined): void {
+    if (v === undefined) delete this.data[k]
+    else this.data[k] = v
+    this.notify(k)
+  }
+
   /** Dispose all watchers and timers. Tests must call this. */
   close(): void {
     for (const ws of this.watchers.values()) for (const w of ws) w.close()

--- a/src/service/hermes-home.ts
+++ b/src/service/hermes-home.ts
@@ -94,6 +94,7 @@ export interface HermesConfig {
     personality: string;
     skin: string;
     show_cost: boolean;
+    tui_agents_nudge?: boolean;
   };
   curator: {
     enabled: boolean;
@@ -487,6 +488,7 @@ export async function readConfig(): Promise<HermesConfig | null> {
         personality: raw?.display?.personality ?? "default",
         skin: raw?.display?.skin ?? "default",
         show_cost: raw?.display?.show_cost ?? false,
+        tui_agents_nudge: raw?.display?.tui_agents_nudge,
       },
       curator: {
         enabled: raw?.curator?.enabled ?? true,

--- a/test/agents-nudge-app.test.tsx
+++ b/test/agents-nudge-app.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+import * as homeMod from "../src/home"
+import type { HermesConfig } from "../src/service/hermes-home"
+import type { GatewayEvent } from "../src/context/wire"
+
+const cfg = (on: boolean): HermesConfig => ({
+  source: { file: "config.yaml", label: "config.yaml", relative: "config.yaml" },
+  model: { default: "", provider: "", base_url: "" },
+  agent: { max_turns: 60, reasoning_effort: "" },
+  compression: { enabled: true, threshold: 0.5, target_ratio: 0.2, protect_last_n: 20, summary_model: "" },
+  memory: {
+    memory_enabled: true, user_profile_enabled: true, memory_char_limit: 2200,
+    user_char_limit: 1375, provider: "", nudge_interval: 10, flush_min_turns: 6,
+  },
+  display: { personality: "", skin: "", show_cost: false, tui_agents_nudge: on },
+  curator: { enabled: true, interval_hours: 168, stale_after_days: 30, archive_after_days: 90 },
+  approvals: { destructive_slash_confirm: true },
+  gateway: { platforms: {} },
+})
+
+const subagent = (type: "subagent.start" | "subagent.spawn_requested", task_index = 0): GatewayEvent => ({
+  type,
+  payload: { task_index, goal: "inspect" },
+})
+
+async function setup(on: boolean) {
+  const prev = homeMod.home.get("config")
+  homeMod.home.setForTest("config", cfg(on))
+  const gw = new MockGateway({ "commands.catalog": () => ({ pairs: [["/agents", "Open Agents"]] }) })
+  const t = await mount({ gw, width: 160, height: 48 })
+  await until(t, () => t.frame().includes("Ready"))
+  return { t, gw, restore: () => homeMod.home.setForTest("config", prev) }
+}
+
+describe("Agents nudge app integration", () => {
+  test("appears only once per turn and resets on message.start", async () => {
+    const { t, gw, restore } = await setup(true)
+    try {
+      act(() => gw.push(subagent("subagent.start")))
+      await until(t, () => t.frame().includes("subagents working · /agents to watch live"))
+      act(() => gw.push(subagent("subagent.start", 2)))
+      await t.settle()
+      expect(t.frame().match(/subagents working · \/agents to watch live/g)?.length).toBe(1)
+
+      act(() => gw.push({ type: "message.start" }))
+      await t.settle()
+      act(() => gw.push({ type: "message.complete", payload: { text: "" } }))
+      await t.settle()
+      act(() => gw.push(subagent("subagent.spawn_requested", 1)))
+      await t.settle()
+      expect(t.frame().match(/subagents working · \/agents to watch live/g)?.length).toBe(2)
+    } finally {
+      restore()
+      t.destroy()
+    }
+  })
+
+  test("is suppressed when config is disabled or Agents is active", async () => {
+    const off = await setup(false)
+    try {
+      act(() => off.gw.push(subagent("subagent.start")))
+      await off.t.settle()
+      expect(off.t.frame()).not.toContain("subagents working")
+    } finally {
+      off.restore()
+      off.t.destroy()
+    }
+
+    const on = await setup(true)
+    try {
+      await act(async () => { await on.t.keys.typeText("/agents") })
+      act(() => on.t.keys.pressEnter())
+      await until(on.t, () => on.t.frame().includes("Profiles") && on.t.frame().includes("Delegation"))
+      act(() => on.gw.push(subagent("subagent.start")))
+      await on.t.settle()
+      expect(on.t.frame()).not.toContain("subagents working")
+    } finally {
+      on.restore()
+      on.t.destroy()
+    }
+  })
+})

--- a/test/agents-nudge.test.ts
+++ b/test/agents-nudge.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { agentsNudge, agentsNudgeEnabled, isAgentsSurface, TEXT } from "../src/app/agentsNudge"
+
+describe("agents nudge", () => {
+  test("reads the display.tui_agents_nudge config key only", () => {
+    expect(agentsNudgeEnabled({ display: { tui_agents_nudge: true } })).toBe(true)
+    expect(agentsNudgeEnabled({ display: { tui_agents_nudge: false } })).toBe(false)
+    expect(agentsNudgeEnabled({ display: {} })).toBe(false)
+    expect(agentsNudgeEnabled(null)).toBe(false)
+  })
+
+  test("fires once for first subagent event and resets on message.start", () => {
+    const state = { shown: false }
+    const opts = { enabled: true, agentsSurface: false }
+
+    expect(agentsNudge(state, { type: "subagent.start" }, opts)).toBe(true)
+    expect(agentsNudge(state, { type: "subagent.spawn_requested" }, opts)).toBe(false)
+    expect(agentsNudge(state, { type: "message.start" }, opts)).toBe(false)
+    expect(agentsNudge(state, { type: "subagent.spawn_requested" }, opts)).toBe(true)
+  })
+
+  test("suppresses when disabled or already on Agents", () => {
+    expect(agentsNudge({ shown: false }, { type: "subagent.start" }, { enabled: false, agentsSurface: false })).toBe(false)
+    expect(agentsNudge({ shown: false }, { type: "subagent.start" }, { enabled: true, agentsSurface: true })).toBe(false)
+  })
+
+  test("uses the Herm-native hint text and Agents surface predicate", () => {
+    expect(TEXT).toBe("subagents working · /agents to watch live")
+    expect(isAgentsSurface(2, 1, 2, 1)).toBe(true)
+    expect(isAgentsSurface(2, 0, 2, 1)).toBe(false)
+  })
+})

--- a/test/agents-nudge.test.ts
+++ b/test/agents-nudge.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, test } from "bun:test"
 import { agentsNudge, agentsNudgeEnabled, isAgentsSurface, TEXT } from "../src/app/agentsNudge"
 
 describe("agents nudge", () => {
-  test("reads the display.tui_agents_nudge config key only", () => {
+  test("defaults display.tui_agents_nudge on unless explicitly disabled", () => {
     expect(agentsNudgeEnabled({ display: { tui_agents_nudge: true } })).toBe(true)
     expect(agentsNudgeEnabled({ display: { tui_agents_nudge: false } })).toBe(false)
-    expect(agentsNudgeEnabled({ display: {} })).toBe(false)
-    expect(agentsNudgeEnabled(null)).toBe(false)
+    expect(agentsNudgeEnabled({ display: {} })).toBe(true)
+    expect(agentsNudgeEnabled({})).toBe(true)
+    expect(agentsNudgeEnabled(null)).toBe(true)
   })
 
   test("fires once for first subagent event and resets on message.start", () => {


### PR DESCRIPTION
## What

Shows a one-shot toast when delegated/subagent work starts, pointing users to `/agents` for live tracking. The hint resets on the next turn and is suppressed when disabled or when the Agents surface is already visible.

Adds the Herm-side config plumbing for `display.tui_agents_nudge` and accepts both `subagent.start` and `subagent.spawn_requested` gateway events.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test test/agents-nudge-app.test.tsx test/agents-nudge.test.ts` — 6 pass / 0 fail
