### PR TITLE
feat(approval): remember never-ask decisions

### DIFF
--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -166,6 +166,9 @@ export function useStream(c: Ctx) {
         })
       },
       onStatus: (text) => x.setStatus(text),
+      onApprovalRemembered: () => {
+        void gw.request("approval.respond", { choice: "always" }).catch(() => {})
+      },
       onProcessNotification: (text) => {
         const n = procs.current
         n.texts.push(text)

--- a/src/components/chat/PromptCard.tsx
+++ b/src/components/chat/PromptCard.tsx
@@ -19,6 +19,7 @@ import { LEFT_BAR } from "../../ui/borders"
 import type { ParsedKey, SubmitEvent } from "@opentui/core"
 import { useTheme } from "../../theme"
 import { useGateway } from "../../context/gateway"
+import { mkApproval, remember } from "../../context/approval-memory"
 import type { PromptPart, PromptReq, Part } from "../../types/message"
 
 export type PromptCardHandle = {
@@ -67,13 +68,19 @@ const Pill = (p: { on: boolean; hot: string; label: string; onPick: () => void }
   )
 }
 
-const CHOICES = ["once", "session", "always", "deny"] as const
+const CHOICES = ["once", "session", "never", "deny"] as const
 type Choice = typeof CHOICES[number]
 const LABELS: Record<Choice, string> = {
   once: "Allow once",
   session: "Allow this session",
-  always: "Always allow",
+  never: "Never ask",
   deny: "Deny",
+}
+const RESPOND: Record<Choice, string> = {
+  once: "once",
+  session: "session",
+  never: "always",
+  deny: "deny",
 }
 
 const Approval = forwardRef<PromptCardHandle, {
@@ -88,10 +95,13 @@ const Approval = forwardRef<PromptCardHandle, {
   const [note, setNote] = useState("")
   const done = useRef(false)
 
+  const prompt = mkApproval(p.req)
+
   const send = (c: Choice) => {
     if (done.current) return
     done.current = true
-    void gw.request("approval.respond", { choice: c }).catch(() => {})
+    if (c === "never") remember(prompt)
+    void gw.request("approval.respond", { choice: RESPOND[c] }).catch(() => {})
     p.onAnswer(LABELS[c], c !== "deny")
   }
 
@@ -134,6 +144,7 @@ const Approval = forwardRef<PromptCardHandle, {
         <box flexDirection="row" gap={1} height={1}>
           <text fg={theme.warning}>△</text>
           <text fg={theme.text}>Permission required</text>
+          <text fg={theme.textMuted}>· {prompt.question}</text>
         </box>
         <box flexDirection="row" gap={1} paddingLeft={2} minHeight={1}>
           <text fg={theme.textMuted}>#</text>
@@ -174,6 +185,9 @@ const Approval = forwardRef<PromptCardHandle, {
                   onPick={() => send(c)} />
           ))}
           <Pill on={false} hot="s" label="Steer" onPick={() => { setSteering(true); setNote("") }} />
+          <box height={1}>
+            <text fg={theme.textMuted}>subject: {prompt.subject}</text>
+          </box>
           <box flexGrow={1} />
           <box height={1}>
             <text fg={theme.textMuted}>←/→ · enter · s steer · esc deny</text>

--- a/src/context/approval-memory.ts
+++ b/src/context/approval-memory.ts
@@ -1,0 +1,38 @@
+import * as prefs from "./preferences"
+import type { NeverPrompt } from "./preferences"
+import type { PromptReq } from "../types/message"
+
+export type ApprovalReq = Extract<PromptReq, { variant: "approval" }>
+export type ApprovalPrompt = ApprovalReq & {
+  group: string
+  question: string
+  subject: string
+}
+
+const group = "approval"
+
+export function question(req: ApprovalReq): string {
+  return (req.description || "Shell command").trim()
+}
+
+export function subject(req: ApprovalReq): string {
+  if (req.pattern_keys?.length) return req.pattern_keys.join("|")
+  return req.command.trim()
+}
+
+export function mkApproval(req: ApprovalReq): ApprovalPrompt {
+  return { ...req, group, question: question(req), subject: subject(req) }
+}
+
+export function shouldRemember(req: ApprovalReq): boolean {
+  const cur: NeverPrompt[] = prefs.get("neverPrompts") ?? []
+  const p = mkApproval(req)
+  return cur.some(x => x.group === p.group && x.question === p.question && x.subject === p.subject)
+}
+
+export function remember(req: ApprovalReq): void {
+  const cur: NeverPrompt[] = prefs.get("neverPrompts") ?? []
+  const p = mkApproval(req)
+  if (cur.some(x => x.group === p.group && x.question === p.question && x.subject === p.subject)) return
+  prefs.set("neverPrompts", [...cur, { group: p.group, question: p.question, subject: p.subject }])
+}

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -2,6 +2,7 @@
 
 import * as perf from "../utils/perf"
 import * as spawnHistory from "../app/spawnHistory"
+import { shouldRemember } from "./approval-memory"
 import type { GatewayEvent, GatewaySkin, SessionInfo } from "../context/wire"
 import type { Action } from "../app/turnReducer"
 import { pid, type Usage } from "../types/message"
@@ -15,6 +16,7 @@ export type Side = {
   onBtw?: (text: string) => void
   onStatus?: (text: string) => void
   onSkin?: (skin: GatewaySkin | null | undefined) => void
+  onApprovalRemembered?: () => void
   /** voice.status event — gateway VAD loop state change (listening/transcribing/idle). */
   onVoiceStatus?: (state: string) => void
   /** voice.transcript event — transcribed text from a completed voice capture. */
@@ -141,6 +143,10 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
                req: { variant: "clarify", ...ev.payload } }
 
     case "approval.request":
+      if (shouldRemember({ variant: "approval", ...ev.payload })) {
+        side.onApprovalRemembered?.()
+        return null
+      }
       // Approval has no request_id upstream — the gateway's approval
       // responder is a single pending slot. Mint a unique part id so
       // multiple approvals in one turn don't alias each other when

--- a/src/context/preferences.ts
+++ b/src/context/preferences.ts
@@ -55,9 +55,17 @@ interface TuiPreferences {
    *  cursor position or transient toggles. */
   kanban?: KanbanPrefs
   sessions?: SessionsPrefs
+  /** Client-side confirm_ask approvals suppressed by exact question+subject. */
+  neverPrompts?: NeverPrompt[]
   /** Opaque plugin storage. Per-plugin keys are namespaced at the api
    *  layer (`${id}.${key}`); `enabled` holds the id→bool override map. */
   plugin?: Record<string, unknown>
+}
+
+export type NeverPrompt = {
+  group: string
+  question: string
+  subject: string
 }
 
 /** Persisted Sessions-tab state. */

--- a/test/approval-memory.test.tsx
+++ b/test/approval-memory.test.tsx
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { act, createRef } from "react"
+import { mount, mountNode, until, MockGateway } from "./harness"
+import * as prefs from "../src/context/preferences"
+import { PromptCard, type PromptCardHandle } from "../src/components/chat/PromptCard"
+import type { NeverPrompt } from "../src/context/preferences"
+import type { PromptPart, PromptReq } from "../src/types/message"
+
+type ApprovalReq = Extract<PromptReq, { variant: "approval" }>
+
+const req = (over: Partial<ApprovalReq> = {}): ApprovalReq => ({
+  variant: "approval",
+  command: "rm -rf /tmp/a",
+  description: "Run dangerous command?",
+  ...over,
+})
+
+const part = (over: Partial<ApprovalReq> = {}): PromptPart => ({
+  type: "prompt",
+  id: "approval-test",
+  variant: "approval",
+  req: req(over),
+})
+
+const prefsAny = prefs as typeof prefs & {
+  get: (key: "neverPrompts") => NeverPrompt[] | undefined
+  set: (key: "neverPrompts", value: NeverPrompt[]) => void
+}
+
+beforeEach(() => {
+  prefs.reset()
+  prefsAny.set("neverPrompts", [])
+})
+
+describe("approval memory", () => {
+  test("normal approval prompt path sends once when no memory exists", async () => {
+    const gw = new MockGateway(); gw.ok = true
+    const ref = createRef<PromptCardHandle>()
+    await using t = await mountNode(
+      <PromptCard ref={ref} part={part({ pattern_keys: ["rm_recursive"] })} onAnswer={() => {}} />,
+      { gw },
+    )
+
+    expect(t.frame()).toContain("Permission required")
+    expect(t.frame()).toContain("$ rm -rf /tmp/a")
+    expect(gw.calls.filter(c => c.method === "approval.respond").length).toBe(0)
+
+    act(() => ref.current!.feed({ name: "1" } as never))
+    await t.settle()
+
+    expect(gw.last("approval.respond")?.params.choice).toBe("once")
+    expect(prefsAny.get("neverPrompts")).toEqual([])
+  })
+
+  test("stores never_prompts for a specific question and pattern_keys-derived subject", async () => {
+    const gw = new MockGateway(); gw.ok = true
+    const ref = createRef<PromptCardHandle>()
+    await using t = await mountNode(
+      <PromptCard ref={ref} part={part({ pattern_keys: ["rm_recursive", "tmp_write"] })} onAnswer={() => {}} />,
+      { gw },
+    )
+
+    act(() => ref.current!.feed({ name: "3" } as never))
+    await t.settle()
+
+    expect(gw.last("approval.respond")?.params.choice).toBe("always")
+    expect(prefsAny.get("neverPrompts")).toEqual([
+      { group: "approval", question: "Run dangerous command?", subject: "rm_recursive|tmp_write" },
+    ])
+  })
+
+  test("reuses memory for the same question and pattern_keys-derived subject", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "rm -rf /tmp/a", description: "Run dangerous command?", pattern_keys: ["rm_recursive", "tmp_write"] },
+    }))
+    await t.settle()
+    act(() => t.keys.pressKey("3"))
+    await t.settle()
+
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "rm -rf /tmp/b", description: "Run dangerous command?", pattern_keys: ["rm_recursive", "tmp_write"] },
+    }))
+    await t.settle()
+
+    expect(t.gw.calls.filter(c => c.method === "approval.respond").length).toBe(2)
+    expect(t.gw.last("approval.respond")?.params.choice).toBe("always")
+    expect(t.frame()).not.toContain("$ rm -rf /tmp/b")
+    t.destroy()
+  })
+
+  test("does not reuse memory for a different question or different subject", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "rm -rf /tmp/a", description: "Run dangerous command?", pattern_keys: ["rm_recursive", "tmp_write"] },
+    }))
+    await t.settle()
+    act(() => t.keys.pressKey("3"))
+    await t.settle()
+
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "rm -rf /tmp/b", description: "Run package manager?", pattern_keys: ["rm_recursive", "tmp_write"] },
+    }))
+    await t.settle()
+    expect(t.gw.calls.filter(c => c.method === "approval.respond").length).toBe(1)
+    expect(t.frame()).toContain("Run package manager?")
+    act(() => t.keys.pressEscape())
+    await t.settle()
+
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "cat /tmp/a", description: "Run dangerous command?", pattern_keys: ["tmp_read"] },
+    }))
+    await t.settle()
+    expect(t.gw.calls.filter(c => c.method === "approval.respond").length).toBe(2)
+    expect(t.frame()).toContain("$ cat /tmp/a")
+    t.destroy()
+  })
+
+  test("falls back to command as subject when approval.request.pattern_keys is missing", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "bun add zod", description: "Run package manager?" },
+    }))
+    await t.settle()
+    expect(t.frame()).toContain("subject: bun add zod")
+    act(() => t.keys.pressKey("3"))
+    await t.settle()
+
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "bun add zod", description: "Run package manager?" },
+    }))
+    await t.settle()
+    expect(t.gw.calls.filter(c => c.method === "approval.respond").length).toBe(2)
+
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "bun update zod", description: "Run package manager?" },
+    }))
+    await t.settle()
+    expect(t.gw.calls.filter(c => c.method === "approval.respond").length).toBe(2)
+    expect(t.frame()).toContain("$ bun update zod")
+    t.destroy()
+  })
+
+  test("resolve_all memory is scoped by group", async () => {
+    prefsAny.set("neverPrompts", [
+      { group: "slash", question: "Run dangerous command?", subject: "rm_recursive" },
+    ])
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "rm -rf /tmp/a", description: "Run dangerous command?", pattern_keys: ["rm_recursive"] },
+    }))
+    await t.settle()
+
+    expect(t.gw.calls.filter(c => c.method === "approval.respond").length).toBe(0)
+    expect(t.frame()).toContain("Permission required")
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## What

Adds client-side approval memory for the `Never ask` path. Approval prompts now derive a stable question and subject, persist exact never-prompt choices, and auto-respond through the existing `approval.respond` gateway path when the same approval appears again.

The prompt keeps the current steer UI, relabels the persistent choice to `Never ask`, and surfaces the derived subject for clarity.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test test/approval-memory.test.tsx` — 6 pass / 0 fail
