### PR TITLE
feat(model): group provider picker rows

### DIFF
--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -309,6 +309,12 @@ export type ConfigSetResponse = {
 export type ModelOptionsResponse = {
   provider?: string
   model?: string
+  groups?: {
+    id: string
+    title: string
+    description?: string
+    members: string[]
+  }[]
   providers?: {
     slug: string
     name: string

--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -18,35 +18,23 @@ type Step = "provider" | "member" | "model"
 
 type Provider = NonNullable<ModelOptionsResponse["providers"]>[number]
 
-type ProviderGroup = {
-  readonly id: string
-  readonly title: string
-  readonly members: readonly string[]
-}
+type ProviderGroup = NonNullable<ModelOptionsResponse["groups"]>[number]
 
 type ProviderRow =
   | { readonly kind: "provider"; readonly provider: Provider }
   | { readonly kind: "group"; readonly group: ProviderGroup; readonly members: Provider[] }
 
-const GROUPS: readonly ProviderGroup[] = [
-  { id: "kimi", title: "Kimi / Moonshot", members: ["kimi-coding", "kimi-coding-cn"] },
-  { id: "minimax", title: "MiniMax", members: ["minimax", "minimax-oauth", "minimax-cn"] },
-  { id: "xai", title: "xAI Grok", members: ["xai", "xai-oauth"] },
-  { id: "google", title: "Google Gemini", members: ["gemini", "google-gemini-cli"] },
-  { id: "openai", title: "OpenAI", members: ["openai-codex", "openai-api"] },
-  { id: "opencode", title: "OpenCode", members: ["opencode-zen", "opencode-go"] },
-  { id: "copilot", title: "GitHub Copilot", members: ["copilot", "copilot-acp"] },
-]
+const slugMap = (groups: readonly ProviderGroup[] = []) =>
+  new Map(groups.flatMap(g => g.members.map(m => [m, g] as const)))
 
-const groupBySlug = new Map(GROUPS.flatMap(g => g.members.map(m => [m, g] as const)))
-
-const groupRows = (providers: readonly Provider[]): ProviderRow[] => {
+const groupRows = (providers: readonly Provider[], groups: readonly ProviderGroup[] = []): ProviderRow[] => {
   const bySlug = new Map(providers.map(p => [p.slug, p] as const))
-  const groups = new Map(GROUPS.map(g => [g.id, g] as const))
+  const byGroup = new Map(groups.map(g => [g.id, g] as const))
+  const byMember = slugMap(groups)
   const emitted = new Set<string>()
   const rows: ProviderRow[] = []
   for (const p of providers) {
-    const group = groupBySlug.get(p.slug)
+    const group = byMember.get(p.slug)
     if (!group) { rows.push({ kind: "provider", provider: p }); continue }
     if (emitted.has(group.id)) continue
     emitted.add(group.id)
@@ -55,7 +43,7 @@ const groupRows = (providers: readonly Provider[]): ProviderRow[] => {
       return member ? [member] : []
     })
     if (members.length <= 1) { rows.push({ kind: "provider", provider: members[0] ?? p }); continue }
-    rows.push({ kind: "group", group: groups.get(group.id) ?? group, members })
+    rows.push({ kind: "group", group: byGroup.get(group.id) ?? group, members })
   }
   return rows
 }
@@ -67,6 +55,16 @@ const currentInRow = (row: ProviderRow, current?: string) => row.kind === "provi
 const rowModels = (row: ProviderRow) => row.kind === "provider"
   ? row.provider.total_models
   : row.members.reduce((sum, p) => sum + (p.total_models ?? p.models?.length ?? 0), 0)
+
+const rowDesc = (row: ProviderRow) => {
+  const count = rowModels(row)
+  if (row.kind === "provider") return count ? `${count} models` : undefined
+  return [row.group.description, count ? `${count} models` : ""].filter(Boolean).join(" · ") || undefined
+}
+
+const rowSearch = (row: ProviderRow) => row.kind === "group"
+  ? [row.group.description, ...row.members.flatMap(p => [p.name, p.slug])].filter(Boolean).join(" ")
+  : row.provider.slug
 
 type Props = {
   gw: Gateway
@@ -109,16 +107,16 @@ const ModelPickerDialog = (props: Props) => {
   const onKey = useCallback((k: { name: string }) => {
     if (k.name === "tab" && !props.onApply) { setGlobal(g => !g); return true }
     if (k.name === "left" && step === "model") {
-      const g = provider ? groupBySlug.get(provider) : undefined
+      const g = provider ? slugMap(data?.groups ?? []).get(provider) : undefined
       setStep(g && group === g.id ? "member" : "provider")
       return true
     }
     if (k.name === "left" && step === "member") { setStep("provider"); return true }
     return false
-  }, [step, props.onApply, provider, group])
+  }, [step, props.onApply, provider, group, data?.groups])
 
   const backHint = step === "model"
-    ? "←: " + (provider && groupBySlug.get(provider)?.id === group ? "members" : "providers")
+    ? "←: " + (provider && slugMap(data?.groups ?? []).get(provider)?.id === group ? "members" : "providers")
     : step === "member" ? "←: providers" : ""
   const footer = props.onApply
     ? <text fg={theme.textMuted}>{backHint || " "}</text>
@@ -134,15 +132,18 @@ const ModelPickerDialog = (props: Props) => {
 
   if (!data) return <box width={50} padding={1}><text>Loading models…</text></box>
 
+  const groups = data.groups ?? []
+
   if (step === "provider") {
-    const rows = groupRows(data.providers ?? [])
+    const rows = groupRows(data.providers ?? [], groups)
       .toSorted((a, b) => Number(currentInRow(b, data.provider)) - Number(currentInRow(a, data.provider)))
     const current = rows.find(row => currentInRow(row, data.provider))
     const currentValue = current?.kind === "group" ? `group:${current.group.id}` : data.provider
     const options: SelectOption[] = rows.map(row => ({
       title: row.kind === "group" ? row.group.title : row.provider.name,
       value: row.kind === "group" ? `group:${row.group.id}` : row.provider.slug,
-      description: rowModels(row) ? `${rowModels(row)} models` : undefined,
+      description: rowDesc(row),
+      search: rowSearch(row),
       hint: row.kind === "group" ? "›" : undefined,
       category: currentInRow(row, data.provider) ? "Current" : "Available",
     }))
@@ -164,7 +165,7 @@ const ModelPickerDialog = (props: Props) => {
   }
 
   if (step === "member") {
-    const g = GROUPS.find(x => x.id === group)
+    const g = groups.find(x => x.id === group)
     const providers = data.providers ?? []
     const options: SelectOption[] = (g?.members ?? [])
       .flatMap(slug => {
@@ -175,6 +176,7 @@ const ModelPickerDialog = (props: Props) => {
         title: p.name,
         value: p.slug,
         description: p.total_models ? `${p.total_models} models` : undefined,
+        search: p.slug,
         category: p.is_current ? "Current" : "Available",
       }))
     return (

--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -14,7 +14,59 @@ import { useToast } from "../ui/toast"
 import type { Gateway } from "../context/gateway"
 import type { ConfigSetResponse, ModelOptionsResponse } from "../context/wire"
 
-type Step = "provider" | "model"
+type Step = "provider" | "member" | "model"
+
+type Provider = NonNullable<ModelOptionsResponse["providers"]>[number]
+
+type ProviderGroup = {
+  readonly id: string
+  readonly title: string
+  readonly members: readonly string[]
+}
+
+type ProviderRow =
+  | { readonly kind: "provider"; readonly provider: Provider }
+  | { readonly kind: "group"; readonly group: ProviderGroup; readonly members: Provider[] }
+
+const GROUPS: readonly ProviderGroup[] = [
+  { id: "kimi", title: "Kimi / Moonshot", members: ["kimi-coding", "kimi-coding-cn"] },
+  { id: "minimax", title: "MiniMax", members: ["minimax", "minimax-oauth", "minimax-cn"] },
+  { id: "xai", title: "xAI Grok", members: ["xai", "xai-oauth"] },
+  { id: "google", title: "Google Gemini", members: ["gemini", "google-gemini-cli"] },
+  { id: "openai", title: "OpenAI", members: ["openai-codex", "openai-api"] },
+  { id: "opencode", title: "OpenCode", members: ["opencode-zen", "opencode-go"] },
+  { id: "copilot", title: "GitHub Copilot", members: ["copilot", "copilot-acp"] },
+]
+
+const groupBySlug = new Map(GROUPS.flatMap(g => g.members.map(m => [m, g] as const)))
+
+const groupRows = (providers: readonly Provider[]): ProviderRow[] => {
+  const bySlug = new Map(providers.map(p => [p.slug, p] as const))
+  const groups = new Map(GROUPS.map(g => [g.id, g] as const))
+  const emitted = new Set<string>()
+  const rows: ProviderRow[] = []
+  for (const p of providers) {
+    const group = groupBySlug.get(p.slug)
+    if (!group) { rows.push({ kind: "provider", provider: p }); continue }
+    if (emitted.has(group.id)) continue
+    emitted.add(group.id)
+    const members = group.members.flatMap(slug => {
+      const member = bySlug.get(slug)
+      return member ? [member] : []
+    })
+    if (members.length <= 1) { rows.push({ kind: "provider", provider: members[0] ?? p }); continue }
+    rows.push({ kind: "group", group: groups.get(group.id) ?? group, members })
+  }
+  return rows
+}
+
+const currentInRow = (row: ProviderRow, current?: string) => row.kind === "provider"
+  ? Boolean(row.provider.is_current || row.provider.slug === current)
+  : row.members.some(p => p.is_current || p.slug === current)
+
+const rowModels = (row: ProviderRow) => row.kind === "provider"
+  ? row.provider.total_models
+  : row.members.reduce((sum, p) => sum + (p.total_models ?? p.models?.length ?? 0), 0)
 
 type Props = {
   gw: Gateway
@@ -30,6 +82,7 @@ const ModelPickerDialog = (props: Props) => {
   const theme = useTheme().theme
   const [data, setData] = useState<ModelOptionsResponse | null>(null)
   const [step, setStep] = useState<Step>("provider")
+  const [group, setGroup] = useState<string | null>(null)
   const [provider, setProvider] = useState<string | null>(null)
   const [global, setGlobal] = useState(false)
 
@@ -55,27 +108,69 @@ const ModelPickerDialog = (props: Props) => {
 
   const onKey = useCallback((k: { name: string }) => {
     if (k.name === "tab" && !props.onApply) { setGlobal(g => !g); return true }
-    if (k.name === "left" && step === "model") { setStep("provider"); return true }
+    if (k.name === "left" && step === "model") {
+      const g = provider ? groupBySlug.get(provider) : undefined
+      setStep(g && group === g.id ? "member" : "provider")
+      return true
+    }
+    if (k.name === "left" && step === "member") { setStep("provider"); return true }
     return false
-  }, [step, props.onApply])
+  }, [step, props.onApply, provider, group])
 
+  const backHint = step === "model"
+    ? "←: " + (provider && groupBySlug.get(provider)?.id === group ? "members" : "providers")
+    : step === "member" ? "←: providers" : ""
   const footer = props.onApply
-    ? <text fg={theme.textMuted}>{step === "model" ? "←: providers" : " "}</text>
+    ? <text fg={theme.textMuted}>{backHint || " "}</text>
     : (
       <text fg={theme.textMuted}>
         <span>Scope: </span>
         <span fg={global ? theme.warning : theme.accent}>
           {global ? "global (persists to config)" : "this session"}
         </span>
-        <span> · Tab: toggle{step === "model" ? " · ←: providers" : ""}</span>
+        <span>{` · Tab: toggle${backHint ? ` · ${backHint}` : ""}`}</span>
       </text>
     )
 
   if (!data) return <box width={50} padding={1}><text>Loading models…</text></box>
 
   if (step === "provider") {
-    const options: SelectOption[] = (data.providers ?? [])
-      .toSorted((a, b) => Number(Boolean(b.is_current)) - Number(Boolean(a.is_current)))
+    const rows = groupRows(data.providers ?? [])
+      .toSorted((a, b) => Number(currentInRow(b, data.provider)) - Number(currentInRow(a, data.provider)))
+    const current = rows.find(row => currentInRow(row, data.provider))
+    const currentValue = current?.kind === "group" ? `group:${current.group.id}` : data.provider
+    const options: SelectOption[] = rows.map(row => ({
+      title: row.kind === "group" ? row.group.title : row.provider.name,
+      value: row.kind === "group" ? `group:${row.group.id}` : row.provider.slug,
+      description: rowModels(row) ? `${rowModels(row)} models` : undefined,
+      hint: row.kind === "group" ? "›" : undefined,
+      category: currentInRow(row, data.provider) ? "Current" : "Available",
+    }))
+    return (
+      <DialogSelect
+        title={props.title ?? "Switch Provider"}
+        options={options}
+        current={currentValue}
+        onSelect={(o) => {
+          if (!o.value.startsWith("group:")) { setProvider(o.value); setStep("model"); return }
+          setGroup(o.value.slice("group:".length))
+          setStep("member")
+        }}
+        onKey={onKey}
+        placeholder="Search providers..."
+        footer={footer}
+      />
+    )
+  }
+
+  if (step === "member") {
+    const g = GROUPS.find(x => x.id === group)
+    const providers = data.providers ?? []
+    const options: SelectOption[] = (g?.members ?? [])
+      .flatMap(slug => {
+        const p = providers.find(pp => pp.slug === slug)
+        return p ? [p] : []
+      })
       .map(p => ({
         title: p.name,
         value: p.slug,
@@ -84,7 +179,7 @@ const ModelPickerDialog = (props: Props) => {
       }))
     return (
       <DialogSelect
-        title={props.title ?? "Switch Provider"}
+        title={props.title ? `${props.title} · ${g?.title ?? group}` : `Switch Provider (${g?.title ?? group})`}
         options={options}
         current={data.provider}
         onSelect={(o) => { setProvider(o.value); setStep("model") }}

--- a/src/ui/dialog-select.tsx
+++ b/src/ui/dialog-select.tsx
@@ -20,6 +20,7 @@ export type SelectOption = {
   readonly title: string
   readonly value: string
   readonly description?: string
+  readonly search?: string
   readonly hint?: string
   readonly category?: string
 }
@@ -62,7 +63,8 @@ export const DialogSelect = (props: Props) => {
     const lower = filter.toLowerCase()
     return props.options.filter(o =>
       o.title.toLowerCase().includes(lower) ||
-      (o.description ?? "").toLowerCase().includes(lower)
+      (o.description ?? "").toLowerCase().includes(lower) ||
+      (o.search ?? "").toLowerCase().includes(lower)
     )
   }, [filter, props.options])
 

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -124,6 +124,10 @@ describe("model-picker", () => {
     const opts = {
       provider: "xai-oauth",
       model: "grok-oauth",
+      groups: [
+        { id: "xai", title: "xAI Grok", description: "Direct API or SuperGrok / Premium+ OAuth", members: ["xai", "xai-oauth"] },
+        { id: "openai", title: "OpenAI", description: "Codex CLI or direct OpenAI API", members: ["openai-codex", "openai-api"] },
+      ],
       providers: [
         { slug: "openai-api", name: "OpenAI API", total_models: 1, models: ["gpt-5"] },
         { slug: "xai", name: "xAI Direct", total_models: 1, models: ["grok-direct"] },
@@ -162,6 +166,10 @@ describe("model-picker", () => {
     const opts = {
       provider: "xai",
       model: "grok-direct",
+      groups: [
+        { id: "xai", title: "xAI Grok", description: "Direct API or SuperGrok / Premium+ OAuth", members: ["xai", "xai-oauth"] },
+        { id: "openai", title: "OpenAI", description: "Codex CLI or direct OpenAI API", members: ["openai-codex", "openai-api"] },
+      ],
       providers: [
         { slug: "xai", name: "xAI Direct", is_current: true, total_models: 1, models: ["grok-direct"] },
         { slug: "openai-api", name: "OpenAI API", total_models: 1, models: ["gpt-5"] },
@@ -176,6 +184,41 @@ describe("model-picker", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Switch Model (xAI Direct)"))
     t.destroy()
+  })
+
+  test("provider filter finds hidden group members", async () => {
+    const opts = {
+      provider: "anthropic",
+      model: "claude-3",
+      groups: [
+        { id: "openai", title: "OpenAI", description: "Codex CLI or direct OpenAI API", members: ["openai-codex", "openai-api"] },
+        { id: "xai", title: "xAI Grok", description: "Direct API or SuperGrok / Premium+ OAuth", members: ["xai", "xai-oauth"] },
+        { id: "minimax", title: "MiniMax", description: "Global, OAuth Coding Plan & China endpoints", members: ["minimax", "minimax-oauth", "minimax-cn"] },
+      ],
+      providers: [
+        { slug: "anthropic", name: "Anthropic", is_current: true, total_models: 2, models: ["claude-3", "claude-4"] },
+        { slug: "openai-codex", name: "OpenAI Codex", total_models: 1, models: ["gpt-5-codex"] },
+        { slug: "openai-api", name: "OpenAI API", total_models: 1, models: ["gpt-5"] },
+        { slug: "xai", name: "xAI Direct", total_models: 1, models: ["grok-direct"] },
+        { slug: "xai-oauth", name: "xAI OAuth", total_models: 1, models: ["grok-oauth"] },
+        { slug: "minimax", name: "MiniMax Global", total_models: 1, models: ["minimax"] },
+        { slug: "minimax-oauth", name: "MiniMax OAuth", total_models: 1, models: ["minimax-oauth"] },
+        { slug: "minimax-cn", name: "MiniMax China", total_models: 1, models: ["minimax-cn"] },
+      ],
+    }
+    for (const query of ["codex", "oauth", "cn"]) {
+      const t = await mountNode(<Open />, {
+        handlers: { "model.options": () => opts },
+      })
+      await until(t, () => t.frame().includes("Anthropic"))
+
+      await act(async () => { await t.keys.typeText(query) })
+      await until(t, () => t.frame().includes(query === "codex" ? "OpenAI" : query === "oauth" ? "xAI Grok" : "MiniMax"))
+      expect(t.frame()).not.toContain("No results found")
+      if (query === "oauth") expect(t.frame()).toContain("MiniMax")
+      if (query === "cn") expect(t.frame()).not.toContain("OpenAI")
+      t.destroy()
+    }
   })
 
 })

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -119,4 +119,63 @@ describe("model-picker", () => {
     t.destroy()
   })
 
+  test("multi-endpoint families drill group to concrete member to model", async () => {
+    const sets: Array<Record<string, unknown>> = []
+    const opts = {
+      provider: "xai-oauth",
+      model: "grok-oauth",
+      providers: [
+        { slug: "openai-api", name: "OpenAI API", total_models: 1, models: ["gpt-5"] },
+        { slug: "xai", name: "xAI Direct", total_models: 1, models: ["grok-direct"] },
+        { slug: "xai-oauth", name: "xAI OAuth", is_current: true, total_models: 1, models: ["grok-oauth"] },
+      ],
+    }
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": () => opts,
+        "config.set": (p) => { sets.push(p); return { key: "model", value: p.value } },
+      },
+    })
+    t.gw.setSession("sess-abc")
+    await until(t, () => t.frame().includes("xAI Grok"))
+    expect(t.frame()).toContain("Current")
+    expect(t.frame()).not.toContain("xAI Direct")
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Switch Provider (xAI Grok)"))
+    expect(t.frame()).toContain("xAI OAuth")
+    expect(t.frame()).toContain("xAI Direct")
+
+    act(() => t.keys.pressArrow("up"))
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Switch Model (xAI Direct)"))
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    expect(sets).toHaveLength(1)
+    expect(sets[0].value).toBe("grok-direct --provider xai")
+    t.destroy()
+  })
+
+  test("single visible group member degrades to direct provider row", async () => {
+    const opts = {
+      provider: "xai",
+      model: "grok-direct",
+      providers: [
+        { slug: "xai", name: "xAI Direct", is_current: true, total_models: 1, models: ["grok-direct"] },
+        { slug: "openai-api", name: "OpenAI API", total_models: 1, models: ["gpt-5"] },
+      ],
+    }
+    const t = await mountNode(<Open />, {
+      handlers: { "model.options": () => opts },
+    })
+    await until(t, () => t.frame().includes("xAI Direct"))
+    expect(t.frame()).not.toContain("xAI Grok")
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Switch Model (xAI Direct)"))
+    t.destroy()
+  })
+
 })


### PR DESCRIPTION
## What

Adds grouped provider support to the model picker. Gateway `model.options` responses can now include provider groups, and the picker renders multi-member groups as drill-in rows while keeping single-member groups as direct provider rows.

Search now matches hidden group members by name/slug so filtering still finds nested providers.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test test/model-picker.test.tsx` — 7 pass / 0 fail
