### PR TITLE
feat(composer): add path and slash completion

### DIFF
--- a/src/app/useCompletion.ts
+++ b/src/app/useCompletion.ts
@@ -34,7 +34,8 @@ export function completionRequest(input: string): CompletionRequest | null {
 }
 
 export function acceptCompletion(input: string, item: CompletionItem, replaceFrom: number) {
-  const left = input.slice(0, replaceFrom)
+  const replace = item.text.startsWith("/") && input.startsWith("/") ? 0 : replaceFrom
+  const left = input.slice(0, replace)
   if (item.text.includes(":")) frecency.bump(item.text)
   const space = item.text.endsWith("/") || /\s$/.test(item.text) ? "" : " "
   return left + item.text + space

--- a/src/app/useCompletion.ts
+++ b/src/app/useCompletion.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from "react"
+import type { Gateway } from "../context/gateway"
+import { frecency } from "./frecency"
+
+export type CompletionItem = {
+  readonly text: string
+  readonly display: string
+  readonly meta: string
+}
+
+export type CompletionRequest =
+  | { method: "complete.path"; params: { word: string }; replaceFrom: number }
+  | { method: "complete.slash"; params: { text: string }; replaceFrom: number }
+
+const TAB_PATH_RE = /((?:["']?(?:[A-Za-z]:[\\/]|\.{1,2}\/|~\/|\/|@|[^"'`\s]+\/))[^\s]*)$/
+
+function looksLikeSlashCommand(text: string) {
+  return /^\/[^\s/]*(?:\s|$)/.test(text)
+}
+
+function clear(setItems: (items: CompletionItem[]) => void, setCursor: (idx: number) => void, setReplace: (idx: number) => void) {
+  setItems([])
+  setCursor(0)
+  setReplace(0)
+}
+
+export function completionRequest(input: string): CompletionRequest | null {
+  const slash = looksLikeSlashCommand(input)
+  const word = slash ? null : (input.match(TAB_PATH_RE)?.[1] ?? null)
+  if (!slash && !word) return null
+  if (slash && /^\/model(?:\s|$)/.test(input)) return null
+  if (slash) return { method: "complete.slash", params: { text: input }, replaceFrom: 1 }
+  return { method: "complete.path", params: { word: word! }, replaceFrom: input.length - word!.length }
+}
+
+export function acceptCompletion(input: string, item: CompletionItem, replaceFrom: number) {
+  const left = input.slice(0, replaceFrom)
+  if (item.text.includes(":")) frecency.bump(item.text)
+  const space = item.text.endsWith("/") || /\s$/.test(item.text) ? "" : " "
+  return left + item.text + space
+}
+
+export function useCompletion(input: string, blocked: boolean, gw: Gateway) {
+  const [items, setItems] = useState<CompletionItem[]>([])
+  const [cursor, setCursor] = useState(0)
+  const [replaceFrom, setReplace] = useState(0)
+  const seq = useRef(0)
+  const dismissed = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (blocked) {
+      seq.current++
+      dismissed.current = null
+      clear(setItems, setCursor, setReplace)
+      return
+    }
+    const req = completionRequest(input)
+    if (!req) {
+      seq.current++
+      dismissed.current = null
+      clear(setItems, setCursor, setReplace)
+      return
+    }
+    if (dismissed.current === input) return
+    dismissed.current = null
+    const me = ++seq.current
+    const t = setTimeout(() => {
+      gw.request<{ items?: CompletionItem[]; replace_from?: number }>(req.method, req.params)
+        .then(r => {
+          if (seq.current !== me) return
+          const ranked = (r.items ?? [])
+            .map(i => ({ i, s: frecency.score(i.text) }))
+            .sort((a, b) => b.s - a.s)
+            .map(x => x.i)
+          setItems(ranked)
+          setCursor(0)
+          setReplace(req.method === "complete.slash" ? (r.replace_from ?? req.replaceFrom) : req.replaceFrom)
+        })
+        .catch(e => {
+          if (seq.current !== me) return
+          setItems([{ text: "", display: "completion unavailable", meta: e instanceof Error && e.message ? e.message : "unavailable" }])
+          setCursor(0)
+          setReplace(req.replaceFrom)
+        })
+    }, 60)
+    return () => clearTimeout(t)
+  }, [blocked, gw, input])
+
+  const open = items.length > 0
+  const dismiss = () => {
+    seq.current++
+    dismissed.current = input
+    clear(setItems, setCursor, setReplace)
+  }
+
+  return { open, items, cursor, setCursor, replaceFrom, dismiss }
+}

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -13,6 +13,7 @@ import { looksLikePath } from "../../utils/drop"
 import type { SlashCommand } from "../../app/slashCommands"
 import { useSlashPopover } from "../../app/useSlashPopover"
 import { useAtRefPopover, atWordAt } from "../../app/useAtRefPopover"
+import { acceptCompletion, useCompletion } from "../../app/useCompletion"
 import { frecency } from "../../app/frecency"
 import { useInputHistory, type HistEntry } from "../../app/useInputHistory"
 import { useBackground } from "../../app/background"
@@ -113,7 +114,9 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   }, [input])
 
   const pop = useSlashPopover(mode === "normal" ? head : "", props.cmds)
+  const atSpot = mode === "normal" ? atWordAt(input, caret) : null
   const at = useAtRefPopover(mode === "normal" ? input : "", caret)
+  const comp = useCompletion(mode === "normal" && !atSpot ? head : "", mode !== "normal" || pop.open, gw)
 
   const write = useCallback((v: string) => {
     // clear() wipes text + extmarks via setText(""); replay v after.
@@ -141,8 +144,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   ], [keys])
 
   // Hold latest pop/props in a ref so the imperative handle is stable.
-  const live = useRef({ pop, at, props, input })
-  live.current = { pop, at, props, input }
+  const live = useRef({ pop, at, comp, props, input })
+  live.current = { pop, at, comp, props, input }
 
   // Notify parent only on the empty↔non-empty edge so the splash
   // continue-prompt can hide the moment typing starts.
@@ -252,6 +255,13 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     // /cmd prompts all resolve against the catalog.
     const a = live.current.at
     if (a.open) return atAccept()
+    const cc = live.current.comp
+    if (cc.open) {
+      const it = cc.items[cc.cursor]
+      if (!it || !it.text) return
+      write(acceptCompletion(live.current.input, it, cc.replaceFrom))
+      return
+    }
     const p = live.current.pop
     if (p.open) {
       const c = p.popover?.[p.cursor]
@@ -299,16 +309,24 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     mode: () => modeRef.current,
     setMode,
     caret: () => ta.current?.cursorOffset ?? 0,
-    popOpen: () => live.current.pop.open || live.current.at.open,
+    popOpen: () => live.current.pop.open || live.current.at.open || live.current.comp.open,
     popNav: (d) => {
       const a = live.current.at
       if (a.open) return a.setCursor(c => Math.max(0, Math.min(a.items.length - 1, c + d)))
+      const cc = live.current.comp
+      if (cc.open) return cc.setCursor(c => Math.max(0, Math.min(cc.items.length - 1, c + d)))
       const max = (live.current.pop.popover?.length ?? 1) - 1
       pop.setCursor(c => Math.max(0, Math.min(max, c + d)))
     },
     popAccept: () => {
       const a = live.current.at
       if (a.open) return atAccept()
+      const cc = live.current.comp
+      if (cc.open) {
+        const it = cc.items[cc.cursor]
+        if (it?.text) write(acceptCompletion(live.current.input, it, cc.replaceFrom))
+        return
+      }
       const p = live.current.pop
       const c = p.popover?.[p.cursor]
       if (c) write(`/${c.name}${c.name.includes(" ") ? " " : ""}`)
@@ -316,6 +334,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     popCancel: () => {
       const a = live.current.at
       if (a.open) return a.dismiss()
+      const cc = live.current.comp
+      if (cc.open) return cc.dismiss()
       write("")
     },
     // History nav is cursor-aware: ↑ fires when the caret is on the
@@ -383,6 +403,18 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
             cursor={at.cursor}
             onCursor={at.setCursor}
             onSelect={atAccept}
+          />
+        </box>
+      ) : props.focused && comp.open ? (
+        <box position="absolute" bottom={lift} left={0} right={0}>
+          <AtRefPopover
+            items={comp.items}
+            cursor={comp.cursor}
+            onCursor={comp.setCursor}
+            onSelect={idx => {
+              const it = comp.items[idx]
+              if (it?.text) write(acceptCompletion(input, it, comp.replaceFrom))
+            }}
           />
         </box>
       ) : null}

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -34,4 +34,14 @@ describe("composer completion request", () => {
     expect(acceptCompletion("read src/app", { text: "src/app.tsx", display: "app.tsx", meta: "file" }, 5))
       .toBe("read src/app.tsx ")
   })
+
+  test("acceptance avoids duplicating slash command prefixes", () => {
+    expect(acceptCompletion("/det", { text: "/details", display: "/details", meta: "command" }, 1))
+      .toBe("/details ")
+  })
+
+  test("acceptance preserves prompt toolkit slash command items", () => {
+    expect(acceptCompletion("/go", { text: "goal", display: "goal", meta: "command" }, 1))
+      .toBe("/goal ")
+  })
 })

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { acceptCompletion, completionRequest } from "../src/app/useCompletion"
+
+describe("composer completion request", () => {
+  test("routes slash-like input through complete.slash", () => {
+    expect(completionRequest("/help")).toEqual({
+      method: "complete.slash",
+      params: { text: "/help" },
+      replaceFrom: 1,
+    })
+  })
+
+  test("does not treat absolute paths as slash commands", () => {
+    expect(completionRequest("/home/kaio/Dev/herm/src/app.tsx")).toEqual({
+      method: "complete.path",
+      params: { word: "/home/kaio/Dev/herm/src/app.tsx" },
+      replaceFrom: 0,
+    })
+  })
+
+  test("routes trailing path tokens through complete.path", () => {
+    expect(completionRequest("read src/app")).toEqual({
+      method: "complete.path",
+      params: { word: "src/app" },
+      replaceFrom: 5,
+    })
+  })
+
+  test("leaves plain prose alone", () => {
+    expect(completionRequest("read the source")).toBeNull()
+  })
+
+  test("acceptance replaces only the completion token", () => {
+    expect(acceptCompletion("read src/app", { text: "src/app.tsx", display: "app.tsx", meta: "file" }, 5))
+      .toBe("read src/app.tsx ")
+  })
+})

--- a/test/composer.test.tsx
+++ b/test/composer.test.tsx
@@ -219,6 +219,60 @@ describe("composer", () => {
     expect(atWordAt("line1\nx @f", 10)).toEqual({ word: "@f", start: 8 })
   })
 
+  test("trailing path token opens completion popover and Enter inserts", async () => {
+    const gw = new MockGateway({
+      "complete.path": p => p.word === "src/app" ? { items: [
+        { text: "src/app.tsx", display: "src/app.tsx", meta: "file" },
+      ] } : { items: [] },
+    })
+    const { t, ref } = await setup(gw)
+
+    await act(async () => { await t.keys.typeText("read src/app") })
+    await until(t, () => t.frame().includes("src/app.tsx"))
+    expect(t.gw.last("complete.path")?.params.word).toBe("src/app")
+    expect(ref.current?.popOpen()).toBe(true)
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(ref.current?.value()).toBe("read src/app.tsx ")
+    t.destroy()
+  })
+
+  test("slash RPC completion opens popover and Enter inserts replacement", async () => {
+    const gw = new MockGateway({
+      "complete.slash": p => p.text === "/zz" ? {
+        replace_from: 1,
+        items: [{ text: "zeta", display: "/zeta", meta: "remote" }],
+      } : { items: [] },
+    })
+    const { t, ref } = await setup(gw)
+
+    await act(async () => { await t.keys.typeText("/zz") })
+    await until(t, () => t.frame().includes("/zeta"))
+    expect(t.gw.last("complete.slash")?.params.text).toBe("/zz")
+    expect(ref.current?.popOpen()).toBe(true)
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(ref.current?.value()).toBe("/zeta ")
+    t.destroy()
+  })
+
+  test("completion RPC error shows unavailable row and does not submit", async () => {
+    const gw = new MockGateway({
+      "complete.path": () => { throw new Error("offline") },
+    })
+    const { t, ref, sent } = await setup(gw)
+
+    await act(async () => { await t.keys.typeText("see ./bad") })
+    await until(t, () => t.frame().includes("completion unavailable"))
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toEqual([])
+    expect(ref.current?.value()).toBe("see ./bad")
+    t.destroy()
+  })
+
   test("@ opens atref popover; Tab inserts; Esc dismisses without clearing", async () => {
     const gw = new MockGateway({
       "complete.path": p => {


### PR DESCRIPTION
## What

Adds gateway-backed path and slash completion in the composer. Path-like trailing tokens call `complete.path`; slash-like input calls `complete.slash`; accepted rows replace only the active token and avoid duplicating slash prefixes.

Completion rows share the existing popover navigation/accept/cancel path and are suppressed while existing slash or @-reference popovers are active.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test test/completion.test.ts test/composer.test.tsx` — 33 pass / 0 fail
