### PR TITLE
feat(kanban): parse dispatch telemetry

### DIFF
--- a/src/service/kanban-dispatch.ts
+++ b/src/service/kanban-dispatch.ts
@@ -1,0 +1,80 @@
+const arr = (v: unknown): unknown[] => Array.isArray(v) ? v : []
+const str = (v: unknown): string => typeof v === "string" ? v : ""
+const num = (v: unknown): number => typeof v === "number" && Number.isFinite(v) ? v : 0
+
+export type DispatchSpawned = { task_id: string; assignee: string; workspace: string }
+export type DispatchCapped = { task_id: string; assignee: string; current: number }
+export type DispatchGuarded = { task_id: string; reason: string }
+
+export type DispatchResult = {
+  reclaimed: number
+  promoted: number
+  spawned: DispatchSpawned[]
+  skipped_unassigned: string[]
+  skipped_nonspawnable: string[]
+  skipped_per_profile_capped: DispatchCapped[]
+  auto_assigned_default: string[]
+  crashed: string[]
+  auto_blocked: string[]
+  timed_out: string[]
+  stale: string[]
+  respawn_guarded: DispatchGuarded[]
+}
+
+const ids = (v: unknown): string[] => arr(v).map(str).filter(Boolean)
+
+const spawned = (v: unknown): DispatchSpawned[] => arr(v).flatMap(x => {
+  if (!x || typeof x !== "object") return []
+  const r = x as Record<string, unknown>
+  const task_id = str(r.task_id)
+  if (!task_id) return []
+  return [{ task_id, assignee: str(r.assignee), workspace: str(r.workspace) }]
+})
+
+const capped = (v: unknown): DispatchCapped[] => arr(v).flatMap(x => {
+  if (!x || typeof x !== "object") return []
+  const r = x as Record<string, unknown>
+  const task_id = str(r.task_id)
+  if (!task_id) return []
+  return [{ task_id, assignee: str(r.assignee), current: num(r.current) }]
+})
+
+const guarded = (v: unknown): DispatchGuarded[] => arr(v).flatMap(x => {
+  if (Array.isArray(x)) {
+    const task_id = str(x[0])
+    if (!task_id) return []
+    return [{ task_id, reason: str(x[1]) }]
+  }
+  if (!x || typeof x !== "object") return []
+  const r = x as Record<string, unknown>
+  const task_id = str(r.task_id)
+  if (!task_id) return []
+  return [{ task_id, reason: str(r.reason) }]
+})
+
+export const parseDispatchResult = (out: string): DispatchResult => {
+  const raw = JSON.parse(out) as Record<string, unknown>
+  return {
+    reclaimed: num(raw.reclaimed),
+    promoted: num(raw.promoted),
+    spawned: spawned(raw.spawned),
+    skipped_unassigned: ids(raw.skipped_unassigned),
+    skipped_nonspawnable: ids(raw.skipped_nonspawnable),
+    skipped_per_profile_capped: capped(raw.skipped_per_profile_capped),
+    auto_assigned_default: ids(raw.auto_assigned_default),
+    crashed: ids(raw.crashed),
+    auto_blocked: ids(raw.auto_blocked),
+    timed_out: ids(raw.timed_out),
+    stale: ids(raw.stale),
+    respawn_guarded: guarded(raw.respawn_guarded),
+  }
+}
+
+export const dispatchFailures = (r: DispatchResult): string[] => [
+  ...r.crashed,
+  ...r.auto_blocked,
+  ...r.timed_out,
+  ...r.stale,
+  ...r.skipped_unassigned,
+  ...r.respawn_guarded.map(x => x.task_id),
+]

--- a/src/service/kanban-dispatch.ts
+++ b/src/service/kanban-dispatch.ts
@@ -75,6 +75,47 @@ export const dispatchFailures = (r: DispatchResult): string[] => [
   ...r.auto_blocked,
   ...r.timed_out,
   ...r.stale,
-  ...r.skipped_unassigned,
-  ...r.respawn_guarded.map(x => x.task_id),
 ]
+
+export const dispatchGuarded = (r: DispatchResult): string[] =>
+  r.respawn_guarded.map(x => x.task_id)
+
+export const dispatchVariant = (r: DispatchResult): "info" | "error" | "warning" | "success" => {
+  const failed = dispatchFailures(r).length
+  const guarded = dispatchGuarded(r).length
+  const unassigned = r.skipped_unassigned.length
+  const benign = r.skipped_per_profile_capped.length + r.skipped_nonspawnable.length
+  if (r.spawned.length === 0 && (failed > 0 || unassigned > 0)) return "error"
+  if (failed > 0 || guarded > 0 || unassigned > 0) return "warning"
+  if (benign > 0) return "info"
+  return "success"
+}
+
+const line = (label: string, xs: string[]): string[] =>
+  xs.length ? [`${label}: ${xs.join(", ")}`] : []
+
+const caps = (r: DispatchResult): string[] => {
+  const map = r.skipped_per_profile_capped.reduce((m, x) => {
+    const key = x.assignee || "unassigned"
+    m.set(key, [...(m.get(key) ?? []), x])
+    return m
+  }, new Map<string, DispatchCapped[]>())
+  if (map.size === 0) return []
+  return [
+    "Deferred at per-profile cap:",
+    ...[...map.entries()].map(([k, xs]) =>
+      `  ${k} (${Math.max(...xs.map(x => x.current))} running): ${xs.map(x => x.task_id).join(", ")}`),
+  ]
+}
+
+export const dispatchDetails = (r: DispatchResult): string => [
+  ...line("Defaulted to kanban.default_assignee", r.auto_assigned_default),
+  ...caps(r),
+  ...line("Unassigned", r.skipped_unassigned),
+  ...line("Non-spawnable lanes", r.skipped_nonspawnable),
+  ...line("Failed/reclaimed · crashed", r.crashed),
+  ...line("Failed/reclaimed · auto-blocked", r.auto_blocked),
+  ...line("Failed/reclaimed · timed out", r.timed_out),
+  ...line("Failed/reclaimed · stale", r.stale),
+  ...line("Respawn guarded", r.respawn_guarded.map(x => `${x.task_id}${x.reason ? ` (${x.reason})` : ""}`)),
+].join("\n")

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -984,7 +984,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
         const capped = r.skipped_per_profile_capped.length
         const defaults = r.auto_assigned_default.length
         const failed = dispatchFailures(r).length
-        const skipped = r.skipped_unassigned.length + r.skipped_nonspawnable.length + failed
+        const skipped = r.skipped_nonspawnable.length + failed
         const parts = [`${spawned} spawned`]
         if (defaults) parts.push(`${defaults} default-assigned`)
         if (capped) parts.push(`${capped} profile-capped`)
@@ -993,7 +993,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
           variant: failed && spawned === 0 ? "error" : capped || skipped ? "info" : "success",
           message: `Dispatch: ${parts.join(" · ")}`,
         })
-      })
+      }).catch((e: Error) => void toast.show({ variant: "error", message: trunc(e.message, 120) }))
     })
   }, [dialog, sh, toast])
 

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -24,7 +24,7 @@ import { HintBar } from "../ui/hint"
 import { KVBlock } from "../ui/kv"
 import { ago, trunc } from "../ui/fmt"
 import { load as loadPrefs, set as setPref, type KanbanPrefs } from "../context/preferences"
-import { parseDispatchResult, dispatchFailures } from "../service/kanban-dispatch"
+import { parseDispatchResult, dispatchFailures, dispatchGuarded, dispatchVariant, dispatchDetails } from "../service/kanban-dispatch"
 
 // Operator surface for every kanban board under ~/.hermes/.
 //
@@ -330,15 +330,16 @@ const fieldsFor = (t: Task): PaneField[] =>
 type Pane =
   | { kind: "detail"; slug: string; d: Detail }
   | { kind: "log"; slug: string; id: string; text: string }
+  | { kind: "dispatch"; slug: string; text: string }
 
 const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] }) => {
   const { theme, syntaxStyle } = useTheme()
-  if (p.pane.kind === "log") return (
+  if (p.pane.kind === "log" || p.pane.kind === "dispatch") return (
     <box flexDirection="column" padding={1} border borderColor={theme.border}
          backgroundColor={theme.backgroundPanel} width="50%">
       <box height={1}><text>
-        <span fg={theme.primary}><strong>{p.pane.id}</strong></span>
-        <span fg={theme.textMuted}>{`  ·  ${p.pane.slug}  ·  worker log (tail)`}</span>
+        <span fg={theme.primary}><strong>{p.pane.kind === "log" ? p.pane.id : "Dispatch"}</strong></span>
+        <span fg={theme.textMuted}>{`  ·  ${p.pane.slug}  ·  ${p.pane.kind === "log" ? "worker log (tail)" : "details"}`}</span>
       </text></box>
       <box height={1} />
       <scrollbox scrollY flexGrow={1}>
@@ -981,17 +982,24 @@ export const Kanban = memo((props: { focused?: boolean }) => {
         if (out == null) return
         const r = parseDispatchResult(out)
         const spawned = r.spawned.length
-        const capped = r.skipped_per_profile_capped.length
+        const deferred = r.skipped_per_profile_capped.length
         const defaults = r.auto_assigned_default.length
+        const unassigned = r.skipped_unassigned.length
+        const nonspawnable = r.skipped_nonspawnable.length
         const failed = dispatchFailures(r).length
-        const skipped = r.skipped_nonspawnable.length + failed
+        const guarded = dispatchGuarded(r).length
         const parts = [`${spawned} spawned`]
-        if (defaults) parts.push(`${defaults} default-assigned`)
-        if (capped) parts.push(`${capped} profile-capped`)
-        if (skipped) parts.push(`${skipped} skipped`)
+        if (defaults) parts.push(`${defaults} defaulted`)
+        if (deferred) parts.push(`${deferred} deferred`)
+        if (unassigned) parts.push(`${unassigned} unassigned`)
+        if (nonspawnable) parts.push(`${nonspawnable} non-spawnable`)
+        if (failed) parts.push(`${failed} failed`)
+        if (guarded) parts.push(`${guarded} guarded`)
+        const more = dispatchDetails(r)
         toast.show({
-          variant: failed && spawned === 0 ? "error" : capped || skipped ? "info" : "success",
+          variant: dispatchVariant(r),
           message: `Dispatch: ${parts.join(" · ")}`,
+          action: more ? { label: "details", run: () => setPane({ kind: "dispatch", slug: live.current.at, text: more }) } : undefined,
         })
       }).catch((e: Error) => void toast.show({ variant: "error", message: trunc(e.message, 120) }))
     })

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -24,6 +24,7 @@ import { HintBar } from "../ui/hint"
 import { KVBlock } from "../ui/kv"
 import { ago, trunc } from "../ui/fmt"
 import { load as loadPrefs, set as setPref, type KanbanPrefs } from "../context/preferences"
+import { parseDispatchResult, dispatchFailures } from "../service/kanban-dispatch"
 
 // Operator surface for every kanban board under ~/.hermes/.
 //
@@ -100,23 +101,6 @@ const recOf = (v: unknown): Record<string, unknown> | null =>
 const assignedByDefault = (d: Detail): boolean =>
   d.events.some(e => e.kind === "assigned"
     && recOf(e.payload)?.source === "kanban.default_assignee")
-
-type DispatchJson = {
-  spawned?: Array<{ task_id?: string; assignee?: string; workspace?: string }>
-  skipped_unassigned?: string[]
-  skipped_nonspawnable?: string[]
-  skipped_per_profile_capped?: Array<{ task_id?: string; assignee?: string; current?: number }>
-  auto_assigned_default?: string[]
-}
-
-const dispatchJson = (out: string): DispatchJson | null => {
-  try {
-    const raw = JSON.parse(out) as unknown
-    return recOf(raw) as DispatchJson | null
-  } catch { return null }
-}
-
-const countOf = <T,>(xs: T[] | undefined): number => Array.isArray(xs) ? xs.length : 0
 
 /** True when `v` survives the group. Absence ⇒ "off". */
 function admits<V>(g: Map<V, Tri>, v: V): boolean {
@@ -995,16 +979,20 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       if (!ok) return
       void sh("dispatch --json").then(out => {
         if (out == null) return
-        const r = dispatchJson(out)
-        const spawned = countOf(r?.spawned)
-        const capped = countOf(r?.skipped_per_profile_capped)
-        const defaults = countOf(r?.auto_assigned_default)
-        const skipped = countOf(r?.skipped_unassigned) + countOf(r?.skipped_nonspawnable)
+        const r = parseDispatchResult(out)
+        const spawned = r.spawned.length
+        const capped = r.skipped_per_profile_capped.length
+        const defaults = r.auto_assigned_default.length
+        const failed = dispatchFailures(r).length
+        const skipped = r.skipped_unassigned.length + r.skipped_nonspawnable.length + failed
         const parts = [`${spawned} spawned`]
         if (defaults) parts.push(`${defaults} default-assigned`)
         if (capped) parts.push(`${capped} profile-capped`)
         if (skipped) parts.push(`${skipped} skipped`)
-        toast.show({ variant: capped || skipped ? "info" : "success", message: `Dispatch: ${parts.join(" · ")}` })
+        toast.show({
+          variant: failed && spawned === 0 ? "error" : capped || skipped ? "info" : "success",
+          message: `Dispatch: ${parts.join(" · ")}`,
+        })
       })
     })
   }, [dialog, sh, toast])

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -789,6 +789,47 @@ describe("Kanban tab", () => {
     t.destroy()
   })
 
+  test("D → confirm → dispatch counts skipped_unassigned once", async () => {
+    const gw = new MockGateway({
+      "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
+        ? { stdout: "[]", stderr: "", code: 0 }
+        : { stdout: JSON.stringify({
+          spawned: [],
+          skipped_unassigned: ["t8"],
+          skipped_nonspawnable: [],
+          skipped_per_profile_capped: [],
+          auto_assigned_default: [],
+          crashed: [],
+          auto_blocked: [],
+          timed_out: [],
+          stale: [],
+        }), stderr: "", code: 0 },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("D") })
+    await until(t, () => t.frame().includes("Dispatch · default"))
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("Dispatch: 0 spawned · 1 skipped"))
+    expect(t.frame()).not.toContain("2 skipped")
+    t.destroy()
+  })
+
+  test("D → confirm → malformed dispatch json surfaces error toast", async () => {
+    const gw = new MockGateway({
+      "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
+        ? { stdout: "[]", stderr: "", code: 0 }
+        : { stdout: "not json", stderr: "", code: 0 },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("D") })
+    await until(t, () => t.frame().includes("Dispatch · default"))
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("JSON Parse error"))
+    t.destroy()
+  })
+
   test("dispatch parser defaults new buckets and excludes capped tasks from failures", () => {
     const old = parseDispatchResult(JSON.stringify({
       reclaimed: 0,

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -9,7 +9,7 @@ import {
   currentBoard, listBoards, parseDiagnostics, maxSeverity, sortDiags,
   boardStateOf, boardErrors, corruptBackupsOf,
 } from "../src/service/hermes-kanban"
-import { parseDispatchResult, dispatchFailures } from "../src/service/kanban-dispatch"
+import { parseDispatchResult, dispatchFailures, dispatchVariant, dispatchDetails } from "../src/service/kanban-dispatch"
 import { Kanban } from "../src/tabs/Kanban"
 
 const now = Math.floor(Date.now() / 1000)
@@ -785,11 +785,11 @@ describe("Kanban tab", () => {
     await act(async () => { await t.keys.typeText("y") })
     await until(t, () => cmds.length === 1)
     expect(cmds[0]).toBe("hermes kanban --board default dispatch --json")
-    await until(t, () => t.frame().includes("Dispatch: 1 spawned · 1 default-assigned · 1 profile-"))
+    await until(t, () => t.frame().includes("Dispatch: 1 spawned · 1 defaulted · 1 deferred"))
     t.destroy()
   })
 
-  test("D → confirm → dispatch counts skipped_unassigned once", async () => {
+  test("D → confirm → dispatch surfaces unassigned separately", async () => {
     const gw = new MockGateway({
       "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
         ? { stdout: "[]", stderr: "", code: 0 }
@@ -810,8 +810,61 @@ describe("Kanban tab", () => {
     await act(async () => { await t.keys.typeText("D") })
     await until(t, () => t.frame().includes("Dispatch · default"))
     await act(async () => { await t.keys.typeText("y") })
-    await until(t, () => t.frame().includes("Dispatch: 0 spawned · 1 skipped"))
-    expect(t.frame()).not.toContain("2 skipped")
+    await until(t, () => t.frame().includes("Dispatch: 0 spawned · 1 unassigned"))
+    expect(t.frame()).not.toContain("skipped")
+    t.destroy()
+  })
+
+  test("D → confirm → dispatch shows failed instead of skipped when no worker spawns", async () => {
+    const gw = new MockGateway({
+      "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
+        ? { stdout: "[]", stderr: "", code: 0 }
+        : { stdout: JSON.stringify({
+          spawned: [],
+          skipped_unassigned: [],
+          skipped_nonspawnable: [],
+          skipped_per_profile_capped: [],
+          auto_assigned_default: [],
+          crashed: ["t8"],
+          auto_blocked: [],
+          timed_out: ["t9"],
+          stale: [],
+        }), stderr: "", code: 0 },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("D") })
+    await until(t, () => t.frame().includes("Dispatch · default"))
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("Dispatch: 0 spawned · 2 failed"))
+    expect(t.frame()).not.toContain("skipped")
+    t.destroy()
+  })
+
+  test("D → confirm → dispatch separates benign and failure labels", async () => {
+    const gw = new MockGateway({
+      "shell.exec": p => /\bdiagnostics\b/.test(p.command as string)
+        ? { stdout: "[]", stderr: "", code: 0 }
+        : { stdout: JSON.stringify({
+          spawned: [{ task_id: "t1", assignee: "builder", workspace: "/tmp/w" }],
+          skipped_unassigned: [],
+          skipped_nonspawnable: [],
+          skipped_per_profile_capped: [{ task_id: "t3", assignee: "researcher", current: 2 }],
+          auto_assigned_default: [],
+          crashed: ["t6"],
+          auto_blocked: [],
+          timed_out: [],
+          stale: [],
+          respawn_guarded: [],
+        }), stderr: "", code: 0 },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("D") })
+    await until(t, () => t.frame().includes("Dispatch · default"))
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("Dispatch: 1 spawned · 1 deferred · 1 failed"))
+    expect(t.frame()).not.toContain("skipped")
     t.destroy()
   })
 
@@ -830,7 +883,7 @@ describe("Kanban tab", () => {
     t.destroy()
   })
 
-  test("dispatch parser defaults new buckets and excludes capped tasks from failures", () => {
+  test("dispatch parser defaults new buckets and separates dispatch variants", () => {
     const old = parseDispatchResult(JSON.stringify({
       reclaimed: 0,
       promoted: 0,
@@ -846,6 +899,7 @@ describe("Kanban tab", () => {
     expect(old.skipped_per_profile_capped).toEqual([])
 
     const cur = parseDispatchResult(JSON.stringify({
+      spawned: [{ task_id: "t1", assignee: "builder", workspace: "" }],
       skipped_per_profile_capped: [{ task_id: "t4", assignee: "builder", current: 1 }],
       auto_assigned_default: ["t5"],
       crashed: ["t6"],
@@ -853,6 +907,26 @@ describe("Kanban tab", () => {
     expect(cur.skipped_per_profile_capped).toEqual([{ task_id: "t4", assignee: "builder", current: 1 }])
     expect(cur.auto_assigned_default).toEqual(["t5"])
     expect(dispatchFailures(cur)).toEqual(["t6"])
+    expect(dispatchVariant(cur)).toBe("warning")
+    expect(dispatchVariant(parseDispatchResult(JSON.stringify({ spawned: [], crashed: ["t6"] })))).toBe("error")
+    expect(dispatchVariant(parseDispatchResult(JSON.stringify({ spawned: [], skipped_per_profile_capped: [{ task_id: "t4", assignee: "builder", current: 1 }] })))).toBe("info")
+    expect(dispatchVariant(parseDispatchResult(JSON.stringify({ spawned: [{ task_id: "t1", assignee: "builder", workspace: "" }], auto_assigned_default: ["t5"] })))).toBe("success")
+    expect(dispatchDetails(parseDispatchResult(JSON.stringify({
+      auto_assigned_default: ["t5"],
+      skipped_per_profile_capped: [{ task_id: "t4", assignee: "builder", current: 1 }],
+      skipped_unassigned: ["t2"],
+      skipped_nonspawnable: ["t3"],
+      crashed: ["t6"],
+      respawn_guarded: [["t7", "active_pr"]],
+    })))).toBe([
+      "Defaulted to kanban.default_assignee: t5",
+      "Deferred at per-profile cap:",
+      "  builder (1 running): t4",
+      "Unassigned: t2",
+      "Non-spawnable lanes: t3",
+      "Failed/reclaimed · crashed: t6",
+      "Respawn guarded: t7 (active_pr)",
+    ].join("\n"))
     expect(() => parseDispatchResult("not json")).toThrow()
   })
 

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -9,6 +9,7 @@ import {
   currentBoard, listBoards, parseDiagnostics, maxSeverity, sortDiags,
   boardStateOf, boardErrors, corruptBackupsOf,
 } from "../src/service/hermes-kanban"
+import { parseDispatchResult, dispatchFailures } from "../src/service/kanban-dispatch"
 import { Kanban } from "../src/tabs/Kanban"
 
 const now = Math.floor(Date.now() / 1000)
@@ -757,10 +758,25 @@ describe("Kanban tab", () => {
     t.destroy()
   })
 
-  test("D → confirm → dispatch", async () => {
+  test("D → confirm → dispatch parses telemetry", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "[]", stderr: "", code: 0 } },
+      "shell.exec": p => {
+        if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string)
+        return { stdout: JSON.stringify({
+          reclaimed: 0,
+          promoted: 1,
+          spawned: [{ task_id: "t1", assignee: "researcher", workspace: "/tmp/w" }],
+          auto_assigned_default: ["t6"],
+          skipped_per_profile_capped: [{ task_id: "t7", assignee: "researcher", current: 2 }],
+          skipped_unassigned: [],
+          skipped_nonspawnable: [],
+          crashed: [],
+          auto_blocked: [],
+          timed_out: [],
+          stale: [],
+        }), stderr: "", code: 0 }
+      },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
@@ -769,7 +785,34 @@ describe("Kanban tab", () => {
     await act(async () => { await t.keys.typeText("y") })
     await until(t, () => cmds.length === 1)
     expect(cmds[0]).toBe("hermes kanban --board default dispatch --json")
+    await until(t, () => t.frame().includes("Dispatch: 1 spawned · 1 default-assigned · 1 profile-"))
     t.destroy()
+  })
+
+  test("dispatch parser defaults new buckets and excludes capped tasks from failures", () => {
+    const old = parseDispatchResult(JSON.stringify({
+      reclaimed: 0,
+      promoted: 0,
+      spawned: [{ task_id: "t1", assignee: "builder", workspace: "" }],
+      skipped_unassigned: ["t2"],
+      skipped_nonspawnable: ["t3"],
+      crashed: [],
+      auto_blocked: [],
+      timed_out: [],
+      stale: [],
+    }))
+    expect(old.auto_assigned_default).toEqual([])
+    expect(old.skipped_per_profile_capped).toEqual([])
+
+    const cur = parseDispatchResult(JSON.stringify({
+      skipped_per_profile_capped: [{ task_id: "t4", assignee: "builder", current: 1 }],
+      auto_assigned_default: ["t5"],
+      crashed: ["t6"],
+    }))
+    expect(cur.skipped_per_profile_capped).toEqual([{ task_id: "t4", assignee: "builder", current: 1 }])
+    expect(cur.auto_assigned_default).toEqual(["t5"])
+    expect(dispatchFailures(cur)).toEqual(["t6"])
+    expect(() => parseDispatchResult("not json")).toThrow()
   })
 
   test("l opens log pane; Esc closes", async () => {


### PR DESCRIPTION
## What

Adds typed handling for `hermes kanban dispatch --json` output in the Kanban tab.

- parses dispatch telemetry in `src/service/kanban-dispatch.ts`
- reports spawned/defaulted/deferred/unassigned/non-spawnable/failed/guarded counts with bucket-specific wording
- treats per-profile cap deferrals as healthy deferred work, not failures
- catches malformed dispatch JSON and surfaces an error toast instead of throwing out of the UI action path
- exposes non-empty dispatch telemetry buckets through a details action with bucketed task IDs/reasons

## Verification

- `bunx tsc --noEmit` — clean
- `bun test test/kanban.test.tsx` — 66 pass / 0 fail
