### PR TITLE
feat(kanban): show task attachments

### DIFF
--- a/src/service/hermes-kanban.ts
+++ b/src/service/hermes-kanban.ts
@@ -35,6 +35,7 @@
 
 import { Database } from "bun:sqlite"
 import { existsSync, readdirSync, statSync, openSync, readSync, closeSync, readFileSync, fstatSync } from "node:fs"
+import { relative as pathRelative, resolve as pathResolve } from "node:path"
 import { hermesPath } from "./hermes-home"
 
 // Order matches the CLI's status enumeration so columns line up
@@ -76,11 +77,23 @@ export type Event = {
   run_id: number | null
 }
 
+export type Attachment = {
+  id: number
+  filename: string
+  name: string
+  size: number | null
+  created_at: number
+  stored_path: string
+  relative_path: string | null
+  path: string | null
+}
+
 export type Detail = Task & {
   parents: string[]; children: string[]
   comments: Array<{ author: string; body: string; at: number }>
   runs: Run[]
   events: Event[]
+  attachments: Attachment[]
   latest_summary: string | null
 }
 
@@ -271,6 +284,22 @@ const dbDir = (s: string) =>
 
 const logsDir = (s: string) =>
   kp(s === DEFAULT ? "kanban/logs" : `kanban/boards/${s}/logs`)
+
+const attachmentsRoot = (s: string): string => {
+  const pin = (process.env.HERMES_KANBAN_ATTACHMENTS_ROOT ?? "").trim()
+  if (pin) return pathResolve(pin)
+  return pathResolve(kp(s === DEFAULT ? "kanban/attachments" : `kanban/boards/${s}/attachments`))
+}
+
+const safeAttachmentPath = (s: string, raw: unknown): string | null => {
+  if (typeof raw !== "string" || !raw) return null
+  const root = attachmentsRoot(s)
+  const path = pathResolve(raw)
+  return path === root || path.startsWith(`${root}/`) ? path : null
+}
+
+const attachmentRelPath = (s: string, path: string | null): string | null =>
+  path ? pathRelative(attachmentsRoot(s), path) : null
 
 const pair = (s: string): Handles => {
   const cached = handles.get(s)
@@ -514,6 +543,22 @@ const toEvent = (r: Record<string, unknown>): Event => {
   }
 }
 
+const toAttachment = (s: string, r: Record<string, unknown>): Attachment => {
+  const filename = String(r.filename ?? "")
+  const size = Number(r.size)
+  const path = safeAttachmentPath(s, r.stored_path)
+  return {
+    id: Number(r.id),
+    filename,
+    name: filename,
+    size: Number.isFinite(size) ? size : null,
+    created_at: Number(r.created_at) || 0,
+    stored_path: String(r.stored_path ?? ""),
+    relative_path: attachmentRelPath(s, path),
+    path,
+  }
+}
+
 /** All non-archived tasks on `s`, grouped by status column. Each
  *  column sorted by (priority desc, updated_at desc) so the
  *  dispatcher's pick-next ordering roughly matches the top of
@@ -575,10 +620,11 @@ export function detailOf(s: string, id: string): Detail | null {
     // return [] so the detail pane keeps working.
     const runs = runsOf(conn, id)
     const events = eventsOf(conn, id)
+    const attachments = attachmentsOf(conn, s, id)
     const latest = latestSummary(conn, id)
     return {
       ...toTask(row), parents, children, comments,
-      runs, events, latest_summary: latest,
+      runs, events, attachments, latest_summary: latest,
     }
   } catch { return null }
 }
@@ -602,6 +648,15 @@ const eventsOf = (conn: Database, id: string): Event[] => {
        FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT ?`,
     ).all(id, EVENT_TAIL) as Array<Record<string, unknown>>
     return rows.map(toEvent).reverse()
+  } catch { return [] }
+}
+
+const attachmentsOf = (conn: Database, s: string, id: string): Attachment[] => {
+  try {
+    return (conn.query(
+      `SELECT id, filename, stored_path, size, created_at
+       FROM task_attachments WHERE task_id = ? ORDER BY created_at ASC, id ASC`,
+    ).all(id) as Array<Record<string, unknown>>).map(r => toAttachment(s, r))
   } catch { return [] }
 }
 

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -25,6 +25,8 @@ import { KVBlock } from "../ui/kv"
 import { ago, trunc } from "../ui/fmt"
 import { load as loadPrefs, set as setPref, type KanbanPrefs } from "../context/preferences"
 import { parseDispatchResult, dispatchFailures, dispatchGuarded, dispatchVariant, dispatchDetails } from "../service/kanban-dispatch"
+import { FileLink } from "../components/ui/FileLink"
+import type { Source } from "../service/hermes-home"
 
 // Operator surface for every kanban board under ~/.hermes/.
 //
@@ -510,18 +512,23 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] 
             <box height={1} marginTop={1}>
               <text fg={theme.textMuted}>{`Attachments (${d.attachments.length})`}</text>
             </box>
-            {d.attachments.map(a => (
-              <box key={a.id} flexDirection="column" paddingLeft={1}>
-                <box height={1}><text>
-                  <span fg={theme.primary}>{`#${a.id} `}</span>
-                  <span fg={theme.text}>{a.name}</span>
-                  <span fg={theme.textMuted}>{`  ${sizeText(a.size)}  ${ago(a.created_at)}`}</span>
-                </text></box>
-                <text wrapMode="word" fg={a.path ? theme.textMuted : theme.error}>
-                  {a.path ?? `unsafe path omitted: ${a.stored_path}`}
-                </text>
-              </box>
-            ))}
+            {d.attachments.map(a => {
+              const source: Source | null = a.path
+                ? { file: a.path, relative: a.relative_path ?? a.path, label: a.name }
+                : null
+              return (
+                <box key={a.id} flexDirection="column" paddingLeft={1}>
+                  <box height={1}><text>
+                    <span fg={theme.primary}>{`#${a.id} `}</span>
+                    <span fg={theme.text}>{a.name}</span>
+                    <span fg={theme.textMuted}>{`  ${sizeText(a.size)}  ${ago(a.created_at)}`}</span>
+                  </text></box>
+                  {source
+                    ? <box height={1} overflow="hidden"><FileLink source={source}>{source.relative}</FileLink></box>
+                    : <text wrapMode="word" fg={theme.error}>{`unsafe path omitted: ${a.stored_path}`}</text>}
+                </box>
+              )
+            })}
           </> : null}
           {d.error
             ? <box flexDirection="column" paddingLeft={1}>

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -399,6 +399,9 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] 
   // not tasks.result, so a raw ``result`` read looks empty even when
   // real work happened.
   const resultText = d.result || d.latest_summary || ""
+  const sizeText = (n: number | null) => n === null ? "size unknown"
+    : n < 1024 ? `${n} B`
+    : n < 1 << 20 ? `${(n / 1024).toFixed(0)} KB` : `${(n / (1 << 20)).toFixed(1)} MB`
   return (
     <box flexDirection="column" padding={1} border borderColor={theme.border}
          backgroundColor={theme.backgroundPanel} width="50%">
@@ -503,6 +506,23 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] 
                 </box>
               </box>
             : null}
+          {d.attachments.length > 0 ? <>
+            <box height={1} marginTop={1}>
+              <text fg={theme.textMuted}>{`Attachments (${d.attachments.length})`}</text>
+            </box>
+            {d.attachments.map(a => (
+              <box key={a.id} flexDirection="column" paddingLeft={1}>
+                <box height={1}><text>
+                  <span fg={theme.primary}>{`#${a.id} `}</span>
+                  <span fg={theme.text}>{a.name}</span>
+                  <span fg={theme.textMuted}>{`  ${sizeText(a.size)}  ${ago(a.created_at)}`}</span>
+                </text></box>
+                <text wrapMode="word" fg={a.path ? theme.textMuted : theme.error}>
+                  {a.path ?? `unsafe path omitted: ${a.stored_path}`}
+                </text>
+              </box>
+            ))}
+          </> : null}
           {d.error
             ? <box flexDirection="column" paddingLeft={1}>
                 <box height={1}><text fg={theme.error}>Error</text></box>

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -2,10 +2,11 @@ import { describe, test, expect, beforeAll, afterEach } from "bun:test"
 import { act } from "react"
 import { Database } from "bun:sqlite"
 import { mkdirSync, writeFileSync, rmSync, chmodSync } from "node:fs"
+import { join } from "node:path"
 import { mountNode, MockGateway, until } from "./harness"
 import { hermesPath } from "../src/service/hermes-home"
 import {
-  board, boardOf, detail, assignees, tailLog, q, resetKanban,
+  board, boardOf, detail, detailOf, assignees, tailLog, q, resetKanban,
   currentBoard, listBoards, parseDiagnostics, maxSeverity, sortDiags,
   boardStateOf, boardErrors, corruptBackupsOf,
 } from "../src/service/hermes-kanban"
@@ -38,6 +39,10 @@ const schema = (db: Database) => {
     id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT, profile TEXT,
     status TEXT, outcome TEXT, started_at INTEGER, ended_at INTEGER,
     summary TEXT, error TEXT, worker_pid INTEGER)`)
+  db.run(`CREATE TABLE IF NOT EXISTS task_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT,
+    filename TEXT, stored_path TEXT, content_type TEXT,
+    size INTEGER, uploaded_by TEXT, created_at INTEGER)`)
 }
 
 
@@ -82,6 +87,13 @@ beforeAll(() => {
   db.run("INSERT INTO task_links (parent_id, child_id) VALUES ('t1','t3'),('t2','t3')")
   db.run("INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?,?,?,?)",
     ["t1", "kaio", "check AWS reserved pricing too", now - 1000])
+  mkdirSync(hermesPath("kanban/attachments/t1"), { recursive: true })
+  const defaultBlob = hermesPath("kanban/attachments/t1/spec.pdf")
+  writeFileSync(defaultBlob, "pdf bytes")
+  db.run(`INSERT INTO task_attachments
+    (task_id, filename, stored_path, content_type, size, uploaded_by, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ["t1", "spec.pdf", defaultBlob, "application/pdf", 9, "kaio", now - 900])
   db.close()
 
   // Second board with its own DB + log dir, and board.json metadata.
@@ -95,6 +107,13 @@ beforeAll(() => {
     `INSERT INTO tasks (id, title, status, priority, created_at)
      VALUES ('m1', 'upgrade forge', 'ready', 1, ?)`, [now - 100],
   )
+  mkdirSync(hermesPath("kanban/boards/atm10/attachments/m1"), { recursive: true })
+  const boardBlob = hermesPath("kanban/boards/atm10/attachments/m1/modpack.txt")
+  writeFileSync(boardBlob, "modpack")
+  db2.run(`INSERT INTO task_attachments
+    (task_id, filename, stored_path, content_type, size, uploaded_by, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ["m1", "modpack.txt", boardBlob, "text/plain", 7, "kaio", now - 50])
   db2.close()
   // Third board — empty, exercises collapsed-by-default + empty-last sort.
   mkdirSync(hermesPath("kanban/boards/zeta"), { recursive: true })
@@ -177,6 +196,64 @@ describe("hermes-kanban readers", () => {
     const d1 = detail("t1")!
     expect(d1.children).toEqual(["t3"])
     expect(d1.comments[0].body).toContain("AWS reserved")
+    expect(d.attachments).toEqual([])
+  })
+
+  test("detail() hydrates safe attachment metadata", () => {
+    const d = detail("t1")!
+    expect(d.attachments).toEqual([{
+      id: 1,
+      filename: "spec.pdf",
+      name: "spec.pdf",
+      size: 9,
+      created_at: now - 900,
+      stored_path: hermesPath("kanban/attachments/t1/spec.pdf"),
+      relative_path: "t1/spec.pdf",
+      path: hermesPath("kanban/attachments/t1/spec.pdf"),
+    }])
+  })
+
+  test("detailOf() uses the selected board attachment root", () => {
+    const d = detailOf("atm10", "m1")!
+    expect(d.attachments[0].path).toBe(hermesPath("kanban/boards/atm10/attachments/m1/modpack.txt"))
+  })
+
+  test("detailOf() validates stored paths against the attachment root", () => {
+    const db = new Database(hermesPath("kanban.db"))
+    db.run(`INSERT INTO task_attachments
+      (task_id, filename, stored_path, content_type, size, uploaded_by, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ["t1", "passwd", "/etc/passwd", "text/plain", 123, "evil", now - 800])
+    db.close()
+    resetKanban()
+
+    const bad = detail("t1")!.attachments.find(a => a.filename === "passwd")!
+    expect(bad.path).toBeNull()
+    expect(bad.relative_path).toBeNull()
+    expect(bad.stored_path).toBe("/etc/passwd")
+  })
+
+  test("detailOf() respects HERMES_KANBAN_ATTACHMENTS_ROOT", () => {
+    const root = hermesPath("custom-attachments")
+    mkdirSync(join(root, "t1"), { recursive: true })
+    const custom = join(root, "t1", "custom.txt")
+    writeFileSync(custom, "custom")
+    const db = new Database(hermesPath("kanban.db"))
+    db.run(`INSERT INTO task_attachments
+      (task_id, filename, stored_path, content_type, size, uploaded_by, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ["t1", "custom.txt", custom, "text/plain", 6, "kaio", now - 700])
+    db.close()
+    process.env.HERMES_KANBAN_ATTACHMENTS_ROOT = root
+    resetKanban()
+    try {
+      const d = detail("t1")!
+      expect(d.attachments.find(a => a.filename === "custom.txt")?.path).toBe(custom)
+      expect(d.attachments.find(a => a.filename === "spec.pdf")?.path).toBeNull()
+    } finally {
+      delete process.env.HERMES_KANBAN_ATTACHMENTS_ROOT
+      resetKanban()
+    }
   })
 
   test("assignees() = profiles-on-disk ∪ board assignees", () => {

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -405,6 +405,8 @@ describe("Kanban tab", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => /Assignee\s+researcher/.test(t.frame()))
     expect(t.frame()).toMatch(/Children\s+t3/)
+    expect(t.frame()).toContain("spec.pdf")
+    expect(t.frame()).not.toContain(hermesPath("kanban/attachments/t1/spec.pdf"))
     expect(t.frame()).toContain("AWS reserved")
     expect(t.frame()).toMatch(/a assign\s+c comment\s+u unblock/)
     act(() => t.keys.pressEscape())


### PR DESCRIPTION
## What changed

- Extends the Kanban service detail model with `attachments`, loaded from the board's `task_attachments` table.
- Resolves attachment roots for the default board and per-project boards, with `HERMES_KANBAN_ATTACHMENTS_ROOT` override support.
- Converts stored attachment rows into UI-safe metadata: name, size, created time, relative path, and optional clickable path.
- Treats stored paths outside the configured attachment root as unsafe: the row is still shown, but the absolute path is not linked.
- Renders an Attachments block in the task detail pane with count, filename, size, age, and a `FileLink` for safe files.

## Review notes

- This is read-only attachment display. It does not add attach/remove mutations from Herm.
- Older boards without `task_attachments` keep rendering; attachment reads fall back to an empty list.
- Absolute attachment paths are intentionally not shown for safe rows. The detail pane shows the root-relative path instead.

## Verification

- `bunx tsc --noEmit`
- `bun test test/kanban.test.tsx` (71 pass, 0 fail)
- `bun test` (1284 pass, 0 fail)
