### PR TITLE
fix(runtime): clamp terminal dimensions before renderer startup

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import { plugins } from "./service/bundled-plugins";
 import * as control from "./app/control";
 import * as preferences from "./context/preferences";
 import { resetTerminalModes, installExitResetHooks } from "./utils/terminal-reset";
+import { clampStdoutDimensions } from "./utils/terminal-size";
 import { warmup as warmTokens } from "./utils/tokens";
 import { prime as primeTheme, DEFAULT_THEME } from "./theme";
 
@@ -48,6 +49,7 @@ const main = async () => {
   resetTerminalModes()
   // And on our own exit paths, so we don't poison the next process.
   installExitResetHooks()
+  clampStdoutDimensions()
 
   perf.mem("pre-renderer")
 

--- a/src/utils/terminal-size.test.ts
+++ b/src/utils/terminal-size.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test"
+import {
+  clampStdoutDimensions,
+  sanitizeTerminalDimension,
+  sanitizeTerminalSize,
+} from "./terminal-size"
+
+describe("terminal-size", () => {
+  it("leaves sane terminal dimensions unchanged", () => {
+    expect(sanitizeTerminalDimension(120, "columns")).toBe(120)
+    expect(sanitizeTerminalDimension(40, "rows")).toBe(40)
+    expect(sanitizeTerminalSize({ columns: 100, rows: 32 })).toEqual({ columns: 100, rows: 32 })
+  })
+
+  it("falls back for zero, NaN, missing, non-number, and too-small values", () => {
+    for (const value of [0, 1, NaN, undefined, null, "120", Infinity, -1]) {
+      expect(sanitizeTerminalDimension(value, "columns")).toBe(80)
+      expect(sanitizeTerminalDimension(value, "rows")).toBe(24)
+    }
+  })
+
+  it("clamps oversized dimensions", () => {
+    expect(sanitizeTerminalSize({ columns: 131_072, rows: 10_000 })).toEqual({ columns: 500, rows: 200 })
+  })
+
+  it("patches stdout dimensions through live getters", () => {
+    let cols: unknown = 100
+    let rows: unknown = 40
+    const out = {}
+    Object.defineProperty(out, "columns", {
+      configurable: true,
+      get: () => cols,
+      set: value => { cols = value },
+    })
+    Object.defineProperty(out, "rows", {
+      configurable: true,
+      get: () => rows,
+      set: value => { rows = value },
+    })
+
+    expect(clampStdoutDimensions(out)).toBe(true)
+    expect((out as { columns: number }).columns).toBe(100)
+    expect((out as { rows: number }).rows).toBe(40)
+
+    cols = 131_072
+    rows = 1
+    expect((out as { columns: number }).columns).toBe(500)
+    expect((out as { rows: number }).rows).toBe(24)
+
+    ;(out as { columns: unknown }).columns = 88
+    ;(out as { rows: unknown }).rows = 33
+    expect(cols).toBe(88)
+    expect(rows).toBe(33)
+    expect((out as { columns: number }).columns).toBe(88)
+    expect((out as { rows: number }).rows).toBe(33)
+  })
+
+  it("patches writable data descriptors without freezing a startup snapshot", () => {
+    const out = { columns: 131_072 as unknown, rows: 10_000 as unknown }
+
+    expect(clampStdoutDimensions(out)).toBe(true)
+    expect(out.columns).toBe(500)
+    expect(out.rows).toBe(200)
+
+    out.columns = 120
+    out.rows = 30
+    expect(out.columns).toBe(120)
+    expect(out.rows).toBe(30)
+  })
+
+  it("does not throw on non-configurable descriptor edges", () => {
+    const out = {}
+    Object.defineProperty(out, "columns", { configurable: false, value: 131_072 })
+    Object.defineProperty(out, "rows", { configurable: true, value: 1 })
+
+    expect(() => clampStdoutDimensions(out)).not.toThrow()
+    expect(clampStdoutDimensions(out)).toBe(true)
+    expect((out as { columns: number }).columns).toBe(131_072)
+    expect((out as { rows: number }).rows).toBe(24)
+  })
+})

--- a/src/utils/terminal-size.ts
+++ b/src/utils/terminal-size.ts
@@ -1,0 +1,84 @@
+type Dim = "columns" | "rows"
+
+type Size = {
+  columns: number
+  rows: number
+}
+
+type StdoutLike = {
+  columns?: unknown
+  rows?: unknown
+}
+
+const DEFAULT_COLUMNS = 80
+const DEFAULT_ROWS = 24
+const MAX_COLUMNS = 500
+const MAX_ROWS = 200
+
+const cfg = {
+  columns: { fallback: DEFAULT_COLUMNS, max: MAX_COLUMNS },
+  rows: { fallback: DEFAULT_ROWS, max: MAX_ROWS },
+} as const
+
+export function sanitizeTerminalDimension(value: unknown, dim: Dim): number {
+  if (typeof value !== "number") return cfg[dim].fallback
+  if (!Number.isFinite(value)) return cfg[dim].fallback
+  const n = Math.floor(value)
+  if (n < 2) return cfg[dim].fallback
+  return Math.min(n, cfg[dim].max)
+}
+
+export function sanitizeTerminalSize(size: Partial<Record<Dim, unknown>>): Size {
+  return {
+    columns: sanitizeTerminalDimension(size.columns, "columns"),
+    rows: sanitizeTerminalDimension(size.rows, "rows"),
+  }
+}
+
+function findDescriptor(stream: object, dim: Dim): PropertyDescriptor | undefined {
+  let cur: object | null = stream
+  while (cur) {
+    const desc = Object.getOwnPropertyDescriptor(cur, dim)
+    if (desc) return desc
+    cur = Object.getPrototypeOf(cur)
+  }
+  return undefined
+}
+
+function patchDimension(stream: StdoutLike, dim: Dim): boolean {
+  const desc = findDescriptor(stream, dim)
+  if (desc && desc.configurable === false) return false
+
+  let raw = desc && "value" in desc ? desc.value : undefined
+  const read = desc?.get
+  const write = desc?.set
+
+  try {
+    Object.defineProperty(stream, dim, {
+      configurable: true,
+      enumerable: desc?.enumerable ?? true,
+      get() {
+        const value = read ? read.call(stream) : raw
+        return sanitizeTerminalDimension(value, dim)
+      },
+      set(value: unknown) {
+        if (write) {
+          write.call(stream, value)
+          return
+        }
+        raw = value
+      },
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function clampStdoutDimensions(stream: StdoutLike = process.stdout): boolean {
+  if (!stream || typeof stream !== "object") return false
+
+  const columns = patchDimension(stream, "columns")
+  const rows = patchDimension(stream, "rows")
+  return columns || rows
+}


### PR DESCRIPTION
## What

Clamps bogus terminal dimensions before OpenTUI renderer startup. `process.stdout.columns` and `rows` are normalized through live getters so zero, tiny, NaN, missing, or oversized dimensions cannot poison renderer initialization.

The patch keeps writable descriptors live instead of freezing a startup snapshot.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test src/utils/terminal-size.test.ts` — 6 pass / 0 fail
