### PR TITLE
fix(composer): keep completion selection and popover bounded

### DIFF
--- a/src/app/useSlashPopover.ts
+++ b/src/app/useSlashPopover.ts
@@ -27,12 +27,14 @@ export function useSlashPopover(input: string, cmds: ReadonlyArray<SlashCommand>
     return m ? rank(cmds, m[1]) : null
   }, [input, cmds])
 
+  const active = popover ? Math.max(0, Math.min(cursor, popover.length - 1)) : 0
+
   // Reset cursor when input changes
   useEffect(() => { setCursor(c => c === 0 ? c : 0) }, [input])
 
   const ghost = useMemo(() => {
     if (!popover || popover.length === 0) return ""
-    const best = popover[Math.min(cursor, popover.length - 1)]
+    const best = popover[active]
     if (!best || best.name.includes(" ")) return ""
     const m = input.match(/^\/(\S*)$/)
     if (!m) return ""
@@ -40,9 +42,9 @@ export function useSlashPopover(input: string, cmds: ReadonlyArray<SlashCommand>
     if (typed.length < 2) return ""
     if (!best.name.toLowerCase().startsWith(typed.toLowerCase())) return ""
     return best.name.slice(typed.length)
-  }, [input, popover, cursor])
+  }, [input, popover, active])
 
   const open = popover !== null && popover.length > 0
 
-  return { popover, cursor, setCursor, ghost, open }
+  return { popover, cursor: active, setCursor, ghost, open }
 }

--- a/src/components/chat/SlashPopover.tsx
+++ b/src/components/chat/SlashPopover.tsx
@@ -13,7 +13,6 @@ import type { RGBA } from "@opentui/core"
 import { useTheme } from "../../theme"
 import type { Theme } from "../../theme"
 import type { SlashCommand, SlashSource } from "../../app/slashCommands"
-import { sort } from "../../app/slashCommands"
 
 type Props = {
   readonly commands: ReadonlyArray<SlashCommand>
@@ -24,9 +23,9 @@ type Props = {
 
 type Row =
   | { type: "header"; cat: string }
-  | { type: "cmd"; cmd: SlashCommand; flat: number }
+  | { type: "cmd"; cmd: SlashCommand; idx: number }
 
-const MAX_VISIBLE = 14
+const MAX_VISIBLE = 10
 
 /** Color for the source badge. Returns null for sources that shouldn't render. */
 function badge(source: SlashSource, theme: Theme): RGBA | null {
@@ -54,30 +53,21 @@ export const SlashPopover = memo(({ commands: cmds, cursor, onCursor, onSelect }
     )
   }
 
-  // Build flat row list with category headers, stable order (sort by category).
   const rows = useMemo(() => {
-    const sorted = sort(cmds)
-    const result: Row[] = []
-    let flat = 0
-    let lastCat = ""
-    for (const cmd of sorted) {
-      if (cmd.category !== lastCat) {
-        result.push({ type: "header", cat: cmd.category })
-        lastCat = cmd.category
-      }
-      result.push({ type: "cmd", cmd, flat: flat++ })
-    }
-    return result
-  }, [cmds])
+    const start = Math.max(0, Math.min(cursor - 2, cmds.length - MAX_VISIBLE))
+    const items = cmds.slice(start, start + MAX_VISIBLE)
+    const cat = cmds[cursor]?.category ?? items[0]?.category ?? "Command"
+    return [
+      { type: "header", cat } satisfies Row,
+      ...items.map((cmd, i) => ({ type: "cmd" as const, cmd, idx: start + i })),
+    ]
+  }, [cmds, cursor])
 
-  // Find the row index of the cursor to drive the sliding window.
-  const cursorRow = rows.findIndex(r => r.type === "cmd" && r.flat === cursor)
-  const start = Math.max(0, Math.min(cursorRow - 2, rows.length - MAX_VISIBLE))
-  const visible = rows.slice(start, start + MAX_VISIBLE)
-  const clipped = rows.length > MAX_VISIBLE
+  const start = rows.find(r => r.type === "cmd")?.idx ?? 0
+  const clipped = cmds.length > MAX_VISIBLE
   const above = clipped && start > 0
-  const below = clipped && start + MAX_VISIBLE < rows.length
-  const height = visible.length + 2 + (above ? 1 : 0) + (below ? 1 : 0)
+  const below = clipped && start + MAX_VISIBLE < cmds.length
+  const height = rows.length + 2 + (above ? 1 : 0) + (below ? 1 : 0)
 
   return (
     <box
@@ -94,7 +84,7 @@ export const SlashPopover = memo(({ commands: cmds, cursor, onCursor, onSelect }
           <text fg={theme.textMuted}>↑ more</text>
         </box>
       ) : null}
-      {visible.map((row) => {
+      {rows.map((row) => {
         if (row.type === "header") {
           return (
             <box key={`h-${row.cat}`} height={1} paddingLeft={1}>
@@ -107,16 +97,16 @@ export const SlashPopover = memo(({ commands: cmds, cursor, onCursor, onSelect }
           )
         }
 
-        const active = row.flat === cursor
+        const active = row.idx === cursor
         const color = badge(row.cmd.source, theme)
 
         return (
           <box
-            key={`c-${row.cmd.name}`}
+            key={`c-${row.idx}-${row.cmd.name}`}
             height={1}
             flexDirection="row"
             backgroundColor={active ? theme.backgroundElement : undefined}
-            onMouseOver={() => onCursor(row.flat)}
+            onMouseOver={() => onCursor(row.idx)}
             onMouseDown={() => onSelect(row.cmd)}
             paddingLeft={2}
             paddingRight={1}

--- a/test/composer.test.tsx
+++ b/test/composer.test.tsx
@@ -29,6 +29,37 @@ async function setup(gw = new MockGateway()) {
   return { t, ref, sent, slashed }
 }
 
+function cmd(name: string, category = "Command"): SlashCommand {
+  return {
+    name,
+    category,
+    description: `${name} command`,
+    aliases: [],
+    argsHint: "",
+    subcommands: [],
+    source: "command",
+    target: "gateway",
+  }
+}
+
+async function withCommands(cmds: ReadonlyArray<SlashCommand>) {
+  const ref = createRef<ComposerHandle>()
+  const slashed: SlashCommand[] = []
+  const t: Harness = await mountNode(
+    <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+      <box flexGrow={1} />
+      <Composer
+        ref={ref}
+        focused canSubmitPrompt={true} ready streaming={false} cmds={cmds}
+        onSend={() => {}} onSlash={c => slashed.push(c)}
+      />
+    </box>,
+    { width: 120, height: 30 },
+  )
+  await until(t, () => t.frame().includes("Ready"))
+  return { t, ref, slashed }
+}
+
 describe("composer", () => {
   test("type + Enter sends and clears", async () => {
     const { t, ref, sent } = await setup()
@@ -187,6 +218,42 @@ describe("composer", () => {
     await t.settle()
     expect(slashed.map(c => c.name)).toEqual(["help"])
     expect(ref.current?.value()).toBe("")
+    t.destroy()
+  })
+
+  test("slash popover selection accepts the top rendered candidate", async () => {
+    const { t, slashed } = await withCommands([
+      cmd("zulu", "Zed"),
+      cmd("alpha", "Client"),
+    ])
+    await act(async () => { await t.keys.typeText("/") })
+    await until(t, () => t.frame().includes("/zulu") && t.frame().includes("/alpha"))
+
+    const line = t.frame().split("\n").find(l => /\/(zulu|alpha)\b/.test(l)) ?? ""
+    const top = line.match(/\/(zulu|alpha)\b/)?.[1]
+    expect(top).toBeDefined()
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    expect(slashed.map(c => c.name)).toEqual([top!])
+    t.destroy()
+  })
+
+  test("slash popover key-repeat keeps one section label inside a bounded viewport", async () => {
+    const cmds = Array.from({ length: 32 }, (_, i) => cmd(`skill-${String(i).padStart(2, "0")}`, `Cat ${String(i).padStart(2, "0")}`))
+    const { t, ref } = await withCommands(cmds)
+    await act(async () => { await t.keys.typeText("/") })
+    await until(t, () => t.frame().includes("/skill-00"))
+
+    for (let n = 0; n < 80; n++) act(() => ref.current?.popNav(1))
+    await t.settle()
+
+    const lines = t.frame().split("\n")
+    const cats = lines.filter(l => /Cat \d\d/.test(l))
+    const items = lines.filter(l => /\/skill-\d\d\b/.test(l))
+    expect(cats.length).toBe(1)
+    expect(items.length).toBeLessThanOrEqual(10)
+    expect(t.frame()).toContain("/skill-31")
     t.destroy()
   })
 


### PR DESCRIPTION
## What

Fixes two composer completion regressions from the slash/path completion work:

- keeps slash popover navigation bounded under key repeat
- removes repeated standalone section labels from the bounded slash viewport
- makes Tab and Enter accept the highlighted slash completion candidate
- preserves existing path/slash completion behavior, including no double-slash acceptance

## Verification

- `bunx tsc --noEmit`
- `bun test test/completion.test.ts test/composer.test.tsx` — 35 pass / 0 fail
- `bun test test/composer.test.tsx --test-name-pattern 'slash popover selection|key-repeat'` — 2 pass / 0 fail
