### PR TITLE
fix: stop nested Kanban column wheel scroll

### DIFF
--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -1148,7 +1148,8 @@ export const EikonStudio = memo((props: {
             <text fg={theme.textMuted}>No eikon open. Enter to create or pick one.</text>
           </box>
         : <>
-            <scrollbox ref={ksb} scrollY flexGrow={1} contentOptions={COL}>
+            <scrollbox id="studio-knob-scroll" ref={ksb} scrollY flexGrow={1} contentOptions={COL}
+                       onMouseScroll={(e: MouseEvent) => e.stopPropagation()}>
               {rows.map((row, i) => {
                 const ni = navRows.findIndex(x => x.i === i)
                 const on = pane === "knobs" && ni === sel

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef, memo } from "react"
 import { useKeyboard, useTerminalDimensions } from "@opentui/react"
-import type { BorderSides, ScrollBoxRenderable } from "@opentui/core"
+import type { BorderSides, MouseEvent, ScrollBoxRenderable } from "@opentui/core"
 import {
   boardStateOf, detailOf, tailLogOf, assignees, q, STATUSES,
   currentBoard, listBoards, resetKanban, patchTask,
@@ -252,7 +252,8 @@ const Column = memo((p: {
           <span fg={theme.textMuted}>{`  ${p.tasks.length}`}</span>
         </text>
       </box>
-      <scrollbox ref={box} scrollY flexGrow={1} verticalScrollbarOptions={NOBAR}>
+      <scrollbox id={`kb-col-${p.slug}-${p.status}`} ref={box} scrollY flexGrow={1} verticalScrollbarOptions={NOBAR}
+                 onMouseScroll={(e: MouseEvent) => e.stopPropagation()}>
         <box flexDirection="column" width="100%">
           {p.tasks.map((t, i) => (
             <Card key={t.id} id={id(i)} t={t} on={p.on && i === p.sel}
@@ -1308,7 +1309,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       <TabShell
         title={`Kanban · ${sections.length} board${sections.length === 1 ? "" : "s"} · ${grand} task${grand === 1 ? "" : "s"}${running ? ` · ${running} running` : ""}`}
       >
-        <scrollbox ref={outer} scrollY flexGrow={1} verticalScrollbarOptions={NOBAR}>
+        <scrollbox id="kb-board-scroll" ref={outer} scrollY flexGrow={1} verticalScrollbarOptions={NOBAR}>
           <box flexDirection="column" width="100%">
             {sections.map(s => {
               const on = s.board.slug === at

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -223,6 +223,52 @@ describe("hermes-kanban readers", () => {
 })
 
 describe("Kanban tab", () => {
+  test("column wheel scroll does not move outer board scroll", async () => {
+    const db = new Database(hermesPath("kanban.db"), { create: true })
+    const ins = db.prepare(
+      "INSERT INTO tasks (id, title, status, priority, created_at) VALUES (?, ?, 'ready', 1, ?)",
+    )
+    for (let i = 0; i < 30; i++)
+      ins.run(`long${i}`, `long ready ${i.toString().padStart(2, "0")}`, now - i)
+    db.close()
+    resetKanban()
+
+    const t = await mountNode(<Kanban focused />, { width: 180, height: 24 })
+    try {
+      await until(t, () => t.frame().includes("long ready 00"))
+      type Node = {
+        id?: string; x: number; y: number; scrollTop: number; scrollHeight: number
+        viewport: { height: number }; getChildren?: () => unknown[]
+      }
+      const root = (t.renderer as unknown as { root: unknown }).root
+      const find = (node: unknown, id: string): Partial<Node> | null => {
+        const n = node as Partial<Node>
+        if (n.id === id) return n
+        for (const c of n.getChildren?.() ?? []) {
+          const r = find(c, id)
+          if (r) return r
+        }
+        return null
+      }
+      const outer = find(root, "kb-board-scroll") as Node | null
+      const col = find(root, "kb-col-default-ready") as Node | null
+      if (!outer || !col) throw new Error("scrollbox probe missing")
+      expect(col.scrollHeight).toBeGreaterThan(col.viewport.height)
+      expect(outer.scrollHeight).toBeGreaterThan(outer.viewport.height)
+      const top = outer.scrollTop
+      await act(async () => { await t.mouse.scroll(col.x + 1, col.y + 1, "down") })
+      await t.settle()
+      expect(col.scrollTop).toBeGreaterThan(0)
+      expect(outer.scrollTop).toBe(top)
+    } finally {
+      t.destroy()
+      const db = new Database(hermesPath("kanban.db"))
+      db.run("DELETE FROM tasks WHERE id LIKE 'long%'")
+      db.close()
+      resetKanban()
+    }
+  })
+
   test("stacks boards, empty last, chips + one-line rows", async () => {
     const t = await mountNode(<Kanban focused />, { width: 180, height: 44 })
     await until(t, () => t.frame().includes("Kanban · 3 boards · 7 tasks"))


### PR DESCRIPTION
Changes:
- Stop wheel propagation from overflowing Kanban task columns so the outer board pane does not also scroll.
- Apply the same containment to Eikon Studio knobs scrollbox found by the sweep.
- Add a Kanban regression covering inner-column scroll without outer-board movement.

Verification:
- bunx tsc --noEmit
- bun test
