### PR TITLE
fix: remove duplicate subtab navigation hint

### DIFF
--- a/src/tabs/Automation.tsx
+++ b/src/tabs/Automation.tsx
@@ -4,7 +4,6 @@ import { Cron } from "./Cron"
 import { Kanban } from "./Kanban"
 import { SubTabBar } from "../components/tabs/SubTabBar"
 import { SUB_TABS, AUTOMATION_TAB } from "../app/tabs"
-import { useKeys } from "../keys"
 
 type Props = {
   focused?: boolean
@@ -19,12 +18,11 @@ type Props = {
 // Each sub-tab owns its own keybindings via useKeyboard({focused}); the
 // group only forwards `focused` to whichever is active.
 export const Automation = memo((props: Props) => {
-  const keys = useKeys()
   const labels = SUB_TABS[AUTOMATION_TAB]
   useEffect(() => {
     if (props.sub >= labels.length) props.setSub(0)
   }, [props.sub, labels.length])
-  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
+  const hint = "shift+←/→ sub"
   return (
     <box flexDirection="column" flexGrow={1} minWidth={0}>
       <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />

--- a/src/tabs/ConfigGroup.tsx
+++ b/src/tabs/ConfigGroup.tsx
@@ -6,7 +6,6 @@ import { Env } from "./Env"
 import { Memory } from "./Memory"
 import { SubTabBar } from "../components/tabs/SubTabBar"
 import { SUB_TABS, CONFIG_TAB } from "../app/tabs"
-import { useKeys } from "../keys"
 
 type Props = {
   focused?: boolean
@@ -18,12 +17,11 @@ type Props = {
 // Config first so a bare click on the top-level tab lands on the most
 // common target; the rest are alphabetical-ish by frequency of use.
 export const ConfigGroup = memo((props: Props) => {
-  const keys = useKeys()
   const labels = SUB_TABS[CONFIG_TAB]
   useEffect(() => {
     if (props.sub >= labels.length) props.setSub(0)
   }, [props.sub, labels.length])
-  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
+  const hint = "shift+←/→ sub"
   return (
     <box flexDirection="column" flexGrow={1} minWidth={0}>
       <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />

--- a/src/tabs/EikonGroup.tsx
+++ b/src/tabs/EikonGroup.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useEffect, useState, type ReactNode } from "react"
 import { SubTabBar } from "../components/tabs/SubTabBar"
 import { SUB_TABS, EIKON_TAB } from "../app/tabs"
-import { useKeys } from "../keys"
 import { EikonStudio } from "./EikonStudio"
 import { EikonGallery } from "./EikonGallery"
 import type { SidebarPreview } from "../components/sidebar/Sidebar"
@@ -18,13 +17,12 @@ type Props = {
 // can hand a name to Studio for editing. A third "Advanced"
 // sub-tab (rasterizer setup) is reserved — see tabs.ts.
 export const EikonGroup = memo((props: Props) => {
-  const keys = useKeys()
   const labels = SUB_TABS[EIKON_TAB]!
   const [target, setTarget] = useState<string | undefined>(undefined)
   useEffect(() => { if (props.sub >= labels.length) props.setSub(0) }, [props.sub, labels.length])
   useEffect(() => { if (props.sub !== 0) props.sidebarPreview?.(undefined) }, [props.sub, props.sidebarPreview])
   const edit = useCallback((name: string) => { setTarget(name); props.setSub(1) }, [props])
-  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
+  const hint = "shift+←/→ sub"
   return (
     <box flexDirection="column" flexGrow={1} minWidth={0} minHeight={0}>
       <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />

--- a/src/tabs/SessionsGroup.tsx
+++ b/src/tabs/SessionsGroup.tsx
@@ -6,7 +6,6 @@ import { Context } from "./Context"
 import { Analytics } from "./Analytics"
 import { SubTabBar } from "../components/tabs/SubTabBar"
 import { SUB_TABS, SESSIONS_TAB } from "../app/tabs"
-import { useKeys } from "../keys"
 
 type Props = {
   focused?: boolean
@@ -31,14 +30,13 @@ type Props = {
 // mounting would duplicate traffic without a visible payoff (state is
 // cheap to rebuild from ~/.hermes on next switch).
 export const SessionsGroup = memo((props: Props) => {
-  const keys = useKeys()
   const labels = SUB_TABS[SESSIONS_TAB]
   // Clamp defensively — if the sub-tab list shrinks later, drifted
   // indices would render nothing.
   useEffect(() => {
     if (props.sub >= labels.length) props.setSub(0)
   }, [props.sub, labels.length])
-  const hint = `${keys.print("tab.prev")}/${keys.print("tab.next")} group  ·  shift+←/→ sub`
+  const hint = "shift+←/→ sub"
   return (
     <box flexDirection="column" flexGrow={1} minWidth={0}>
       <SubTabBar tabs={labels} active={props.sub} onChange={props.setSub} hint={hint} />

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -53,6 +53,21 @@ describe("app", () => {
     t.destroy()
   })
 
+  test("sub-tab hint omits duplicate group navigation", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.keys.pressArrow("right", { meta: true }))
+    await until(t, () => t.frame().includes("Sessions ("))
+
+    const f = t.frame()
+    expect(f).toContain("Alt+←/Alt+→ or Ctrl+X N")
+    expect(f).toContain("shift+←/→ sub")
+    expect(f).not.toContain("Alt+←/Alt+→ group")
+
+    t.destroy()
+  })
+
   test("<leader> <digit> jumps directly to tab N", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))


### PR DESCRIPTION
## Summary
- Removes the repeated group navigation hint from sub-tab bars.
- Leaves sub-tab bars focused on `shift+←/→ sub` while top-level tabs keep the group navigation hint.
- Covers the rendered hint copy in app tests.

## Verification
- `bunx tsc --noEmit`
- `bun test` (`1187 pass`, `0 fail`)
