### PR TITLE
fix: preserve ThoughtCloud code spans while splitting headings

### DIFF
--- a/src/components/chat/ThoughtCloud.tsx
+++ b/src/components/chat/ThoughtCloud.tsx
@@ -74,11 +74,26 @@ function parts(m: Message | undefined): Part[] {
 
 function md(text: string) {
   let out = ""
-  let code = false
+  let fence: { ch: string; n: number } | null = null
   for (let i = 0; i < text.length; i++) {
     const ch = text[i]
-    if (ch === "`") code = !code
-    if (!code && ch === "#" && i > 0 && text[i - 1] !== "\n" && !/\s/.test(text[i - 1])) {
+    const bol = i === 0 || text[i - 1] === "\n"
+    const line = bol ? text.slice(i).match(/^( {0,3})(`{3,}|~{3,})/) : null
+    if (line) {
+      const tick = line[2]
+      if (!fence) fence = { ch: tick[0], n: tick.length }
+      else if (tick[0] === fence.ch && tick.length >= fence.n) fence = null
+    }
+    if (!fence && ch === "`") {
+      const run = text.slice(i).match(/^`+/)?.[0] ?? "`"
+      const end = text.indexOf(run, i + run.length)
+      if (end !== -1) {
+        out += text.slice(i, end + run.length)
+        i = end + run.length - 1
+        continue
+      }
+    }
+    if (!fence && ch === "#" && i > 0 && text[i - 1] !== "\n" && !/\s/.test(text[i - 1])) {
       const m = text.slice(i).match(/^#{1,6} /)
       if (m) out += "\n"
     }

--- a/src/components/chat/ThoughtCloud.tsx
+++ b/src/components/chat/ThoughtCloud.tsx
@@ -72,6 +72,21 @@ function parts(m: Message | undefined): Part[] {
   return m?.parts.filter(p => p.type === "thinking" || p.type === "tool") ?? []
 }
 
+function md(text: string) {
+  let out = ""
+  let code = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (ch === "`") code = !code
+    if (!code && ch === "#" && i > 0 && text[i - 1] !== "\n" && !/\s/.test(text[i - 1])) {
+      const m = text.slice(i).match(/^#{1,6} /)
+      if (m) out += "\n"
+    }
+    out += ch
+  }
+  return out
+}
+
 type Pane = "reasoning" | "tools"
 
 function latest(messages: Message[]): Message | undefined {
@@ -172,7 +187,7 @@ export const ThoughtCloud = memo((props: {
           {body.map((p, i) =>
             p.type === "thinking"
               ? <box key={(p as ThinkingPart).key ?? `th-${i}`} minHeight={1} width="100%" flexShrink={0}>
-                  <markdown content={(p as ThinkingPart).content} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
+                  <markdown content={md((p as ThinkingPart).content)} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
                 </box>
               : <box key={(p as ToolPart).id || `t-${i}`} width="100%" flexShrink={0}>
                   <Tool tool={p as ToolPart} detail={detail === "hidden" ? "hidden" : "collapsed"} />

--- a/test/thoughtcloud.test.tsx
+++ b/test/thoughtcloud.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test"
 import { act } from "react"
 import { useState } from "react"
-import { mountNode } from "./harness"
+import { mountNode, until } from "./harness"
 import { Tail, ThoughtCloud } from "../src/components/chat/ThoughtCloud"
 import type { Message } from "../src/types/message"
 
@@ -59,6 +59,53 @@ describe("ThoughtCloud reasoning", () => {
     expect(f).not.toContain("`scan_skill_commands()`")
     expect(f).not.toContain("**verify**")
     expect(f).not.toContain("Write src/x.ts")
+    t.destroy()
+  })
+
+  test("starts concatenated reasoning headings on their own visual row", async () => {
+    const messages: Message[] = [{
+      id: "a1", role: "assistant", timestamp: 0,
+      parts: [{
+        type: "thinking",
+        content: "Use `scan_skill_commands()` then **verify**. previous sentence## Heading\nbody",
+        streaming: false,
+      }],
+    }]
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%">
+        <ThoughtCloud height={12} messages={messages} onResize={() => {}} />
+      </box>,
+      { width: 100, height: 20 },
+    )
+    await until(t, () => t.frame().includes("verify"), 3000)
+    const f = t.frame()
+    expect(f).not.toContain("previous sentence## Heading")
+    const lines = f.split("\n")
+    const a = lines.findIndex(l => l.includes("previous sentence"))
+    const b = lines.findIndex(l => l.includes("Heading"))
+    expect(a).toBeGreaterThan(-1)
+    expect(b).toBeGreaterThan(a)
+    t.destroy()
+  })
+
+  test("does not split inline hashes or code spans", async () => {
+    const messages: Message[] = [{
+      id: "a1", role: "assistant", timestamp: 0,
+      parts: [{
+        type: "thinking",
+        content: "Use hash#tag and `x## Heading` before text.",
+        streaming: false,
+      }],
+    }]
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%">
+        <ThoughtCloud height={12} messages={messages} onResize={() => {}} />
+      </box>,
+      { width: 100, height: 20 },
+    )
+    await until(t, () => t.frame().includes("before text"), 3000)
+    const f = t.frame()
+    expect(f).toContain("Use hash#tag and x## Heading before text.")
     t.destroy()
   })
 })

--- a/test/thoughtcloud.test.tsx
+++ b/test/thoughtcloud.test.tsx
@@ -108,4 +108,45 @@ describe("ThoughtCloud reasoning", () => {
     expect(f).toContain("Use hash#tag and x## Heading before text.")
     t.destroy()
   })
+
+  test("does not split multi-backtick code spans", async () => {
+    const messages: Message[] = [{
+      id: "a1", role: "assistant", timestamp: 0,
+      parts: [{
+        type: "thinking",
+        content: "Use ``x## Heading`` before text.",
+        streaming: false,
+      }],
+    }]
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%">
+        <ThoughtCloud height={12} messages={messages} onResize={() => {}} />
+      </box>,
+      { width: 100, height: 20 },
+    )
+    await until(t, () => t.frame().includes("before text"), 3000)
+    expect(t.frame()).toContain("Use x## Heading before text.")
+    t.destroy()
+  })
+
+  test("does not split headings inside fenced code", async () => {
+    const messages: Message[] = [{
+      id: "a1", role: "assistant", timestamp: 0,
+      parts: [{
+        type: "thinking",
+        content: "before\n```md\nx## Heading\n```\nafter",
+        streaming: false,
+      }],
+    }]
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%">
+        <ThoughtCloud height={12} messages={messages} onResize={() => {}} />
+      </box>,
+      { width: 100, height: 20 },
+    )
+    await until(t, () => t.frame().includes("after"), 3000)
+    const f = t.frame()
+    expect(f).toContain("x## Heading")
+    t.destroy()
+  })
 })


### PR DESCRIPTION
Provenance:
- Parent review: t_5b9923c3 approved task/t_a615d451-thought-heading at 3280236.
- Integrated branch: task/t_a615d451-thought-heading.

Changes:
- Fix ThoughtCloud reasoning markdown normalization so concatenated headings render on their own row.
- Preserve inline code spans, multi-backtick code spans, and fenced code blocks while normalizing display-only reasoning content.

Verification:
- bun install
- bunx tsc --noEmit
- bun test test/thoughtcloud.test.tsx --timeout 10000
- bun test
