### PR TITLE
fix(stream): keep compression diagnostics nonfatal

### DIFF
--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -39,7 +39,7 @@ export type Action =
   | { kind: "subagent"; event: "start" | "thinking" | "tool" | "progress" | "complete"; payload: SubagentPayload }
   | { kind: "prompt"; id: string; req: PromptReq }
   | { kind: "prompt.answered"; id: string; label: string; ok: boolean }
-  | { kind: "error"; text: string }
+  | { kind: "error"; text: string; fatal?: boolean }
   | { kind: "interrupt.notice"; text: string }
 
 export function turnReducer(state: TurnState, a: Action): TurnState {
@@ -175,14 +175,17 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
         })),
       }
 
-    case "error":
+    case "error": {
+      const msg = systemMessage(`Error: ${sanitize(a.text)}`)
+      if (a.fatal === false) return { ...state, messages: [...state.messages, msg] }
       return {
         ...state,
         streaming: false,
         hasContent: false,
         toolActive: false,
-        messages: [...state.messages, systemMessage(`Error: ${sanitize(a.text)}`)],
+        messages: [...state.messages, msg],
       }
+    }
 
     case "interrupt.notice": {
       const clean = sanitize(a.text)

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -62,6 +62,7 @@ export function useStream(c: Ctx) {
   // emitting after the monitor thread's InterruptedError has already
   // ended the turn.
   const interrupted = useRef(false)
+  const info = useRef(false)
 
   // Delta batching: streamed text/reasoning chunks accumulate in a
   // ref and flush at most once per 16ms. Every delta otherwise
@@ -103,6 +104,7 @@ export function useStream(c: Ctx) {
 
   const handle = useCallback((ev: GatewayEvent) => {
     const x = ctx.current
+    if (ev.type === "gateway.ready") info.current = false
     if (ev.session_id && x.sidRef.current && ev.session_id !== x.sidRef.current && !ev.type.startsWith("gateway.")) return
     // The agent's stream-retry loop (run_agent._call) classifies the
     // force-closed httpx socket from an interrupt as a transient drop
@@ -178,6 +180,10 @@ export function useStream(c: Ctx) {
       onSkin: (s) => x.setSkin(deriveSkin(s)),
     })
     if (!action) return
+    if (ev.type === "session.info") {
+      if (info.current) return
+      info.current = true
+    }
     const d = deltas.current
     if (action.kind === "message.delta") {
       if (d.think) flush()

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -188,11 +188,11 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       // Error-ish stderr lines (tracebacks, HTTP 4xx/5xx, auth failures)
       // surface inline; benign chatter stays in gw.tail() only (/logs).
       // The full untruncated line is always in gw.logs via GatewayClient.log();
-      // the transcript row carries the line verbatim so no traceback context
-      // is lost to a slice here.
+      // stderr is a diagnostic side channel, not the turn lifecycle source
+      // of truth, so it must not end an active stream.
       const line = ev.payload.line
       if (/error|fail|traceback|exception|\b[45]\d\d\b|refused|denied|unauthori/i.test(line))
-        return { kind: "error", text: line }
+        return { kind: "error", text: line, fatal: false }
       return null
     }
 

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1084,6 +1084,33 @@ describe("app", () => {
     t.destroy()
   })
 
+  test("preflight compression stderr does not end the active turn", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => {
+      t.gw.push({ type: "message.start" })
+      t.gw.push({ type: "status.update", payload: { kind: "lifecycle", text: "📦 Preflight compression: ~230,802 tokens >= 217,600 threshold. This may take a moment." } })
+      t.gw.push({ type: "gateway.stderr", payload: { line: "⚠ Compression summary failed: timeout. Inserted a fallback context marker." } })
+      t.gw.push({ type: "status.update", payload: { kind: "warn", text: "⚠ Compression summary failed: timeout. Inserted a fallback context marker." } })
+      t.gw.push({ type: "reasoning.delta", payload: { text: "I need to inspect files." } })
+      t.gw.push({ type: "tool.start", payload: { tool_id: "t1", name: "read_file", context: "src/app.tsx" } })
+    })
+    await until(t, () => {
+      const f = t.frame()
+      return f.includes("Type to queue") && f.includes("I need to inspect files") && f.includes("tools 1")
+    })
+
+    act(() => t.gw.push({ type: "message.complete", payload: { text: "done", usage: { input: 1, output: 1, total: 2 } } }))
+    await t.settle()
+    const n = (t.frame().match(/Connected —/g) ?? []).length
+    act(() => t.gw.push({ type: "session.info", payload: { model: "test-model", session_id: "test-sid", tools: {}, skills: {} } }))
+    await t.settle()
+    expect(t.frame().match(/Connected —/g) ?? []).toHaveLength(n)
+
+    t.destroy()
+  })
+
   test("send() expands {!cmd} via shell.exec before prompt.submit", async () => {
     const t = await mount({ handlers: {
       "shell.exec": p => ({ stdout: `OUT<${p.command}>`, stderr: "", code: 0 }),

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -115,11 +115,11 @@ describe("mapEvent", () => {
     expect(formatProcessNotification("weird shape")).toBe("weird shape")
   })
 
-  test("gateway.stderr: errorish → error (full line, no slice); benign → null", () => {
-    expect(map({ type: "gateway.stderr", payload: { line: "⚠️ API call failed (HTTP 404)" } }).action?.kind)
-      .toBe("error")
-    expect(map({ type: "gateway.stderr", payload: { line: "Traceback (most recent call last):" } }).action?.kind)
-      .toBe("error")
+  test("gateway.stderr: errorish → nonfatal error (full line, no slice); benign → null", () => {
+    expect(map({ type: "gateway.stderr", payload: { line: "⚠️ API call failed (HTTP 404)" } }).action)
+      .toMatchObject({ kind: "error", fatal: false })
+    expect(map({ type: "gateway.stderr", payload: { line: "Traceback (most recent call last):" } }).action)
+      .toMatchObject({ kind: "error", fatal: false })
     expect(map({ type: "gateway.stderr", payload: { line: "INFO: loaded 5 skills" } }).action)
       .toBeNull()
     // Long tracebacks are passed through verbatim — the /logs ring (gw.tail)
@@ -127,7 +127,7 @@ describe("mapEvent", () => {
     // context to an arbitrary slice either.
     const long = "Traceback: " + "x".repeat(500)
     expect(map({ type: "gateway.stderr", payload: { line: long } }).action)
-      .toEqual({ kind: "error", text: long })
+      .toEqual({ kind: "error", text: long, fatal: false })
   })
 
   test("gateway.start_timeout / protocol_error surface", () => {

--- a/test/turnReducer.test.ts
+++ b/test/turnReducer.test.ts
@@ -159,6 +159,18 @@ describe("turnReducer", () => {
     expect(p.type === "text" && p.content).toContain("gateway died")
   })
 
+  test("nonfatal error keeps active stream alive", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "error", text: "compression warning", fatal: false },
+      { kind: "tool.start", id: "t1", name: "read_file" },
+    ])
+    expect(s.streaming).toBe(true)
+    expect(s.toolActive).toBe(true)
+    const p = last(s).parts[0]
+    expect(p.type === "tool" && p.name).toBe("read_file")
+  })
+
   test("reset clears everything", () => {
     const s = run([
       { kind: "user", text: "x" },


### PR DESCRIPTION
## Summary

Compression fallback diagnostics no longer make the chat turn look idle while the model continues working. Error-ish gateway stderr still appears in the transcript, but it is treated as nonfatal unless the gateway sends an actual turn error.

Session info rows now appear once per gateway connection, so a repeated session metadata event does not append a late `Connected — ...` banner after the assistant finishes.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test test/gatewayEvents.test.ts test/turnReducer.test.ts test/app.test.tsx`
