### PR TITLE
fix(compress): preserve live chat transcript

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -144,15 +144,8 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
       .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
   }, [gw, toast])
 
-  // Compress wrapper — re-hydrates transcript + session info from the
-  // RPC response. Gateway-side `agent._compress_context` ends the old
-  // SessionDB session and opens a continuation with a new session_id;
-  // without dispatching `messages` here, `turn.messages` stays stuck on
-  // the pre-compaction list until the user reopens the session, at
-  // which point the old messages vanish, reading as corruption.
-  // Mirrors Ink TUI (ui-tui/src/app/slash/commands/session.ts). Upstream
-  // also emits status.update{kind:"compressing"} events that already
-  // feed the status bar via gatewayEvents.ts.
+  // Manual compression mutates server context only; keep the live chat
+  // transcript visually stable, matching auto-compression.
   const runCompress = useCallback(async () => {
     toast.show({ variant: "info", message: "Compressing session…" })
     const r = await ctx.current.session.compress()
@@ -170,9 +163,6 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
       return { ...(base ?? { input: 0, output: 0, total: 0 }),
                context_used: r.after_tokens, context_max: max }
     })
-    if (Array.isArray(r.messages)) {
-      ctx.current.dispatch({ kind: "load", messages: transcriptToMessages(r.messages) })
-    }
     if (!r.summary) return
     const s = r.summary
     if (s.noop) {

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -22,14 +22,8 @@ const spec = (row: ReturnType<typeof byId>) => {
   return `${row.model} --provider ${row.billing_provider}`
 }
 
-/** session.compress response shape — see upstream fc7f55f49.
- *
- *  `messages` + `info` carry the post-compaction transcript and fresh
- *  session metadata; the gateway rewrites history in place and rotates
- *  session_id (agent._compress_context ends the old DB session and opens
- *  a continuation). Callers MUST re-hydrate local transcript state from
- *  `messages` — otherwise the TUI keeps the pre-compaction list and the
- *  next resume snaps it to the compacted history, looking like data loss. */
+/** session.compress response shape. `messages` is compacted server context;
+ *  the live chat transcript intentionally stays visually unchanged. */
 export type CompressResult = {
   status?: "compressed" | "skipped"
   removed?: number

--- a/test/compress.test.tsx
+++ b/test/compress.test.tsx
@@ -1,13 +1,7 @@
-// Regression: /compress must re-hydrate the local transcript from the
-// gateway's response.  Without this, `turn.messages` stays stuck on the
-// pre-compaction list until the user reopens the session — at which
-// point the old messages vanish from the UI, reading as data loss.
-//
-// Upstream session.compress returns { messages, info, usage, summary, ... };
-// the gateway also rotates session_id (agent._compress_context ends the
-// old DB session and opens a continuation).  See the compress handler
-// in ui-tui/src/app/slash/commands/session.ts for the canonical flow
-// we mirror.
+// Regression: /compress must preserve the live visual transcript, matching
+// auto-compression. The gateway returns compacted `messages`, but replacing
+// `turn.messages` with that response makes the chat appear to delete the
+// earlier conversation immediately after a manual compress.
 
 import { describe, expect, test } from "bun:test"
 import { act } from "react"
@@ -51,35 +45,32 @@ const run = async (t: Awaited<ReturnType<typeof mount>>) => {
 }
 
 describe("/compress", () => {
-  test("re-hydrates transcript from rpc response messages", async () => {
+  test("preserves visible transcript when rpc returns compacted messages", async () => {
     const gw = mkGw()
     const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
     await until(t, () => t.frame().includes("draft the rfc"))
 
     await run(t)
 
-    // Transcript reflects the compacted history: marker row present,
-    // the now-removed pre-compaction turn ("draft the rfc") is gone.
-    await until(t, () => t.frame().includes("MARKER_POST_COMPACT_USER"))
-    expect(t.frame()).not.toContain("draft the rfc")
+    await until(t, () => t.frame().includes("Compacted 4→3 messages"))
+    expect(t.frame()).toContain("draft the rfc")
+    expect(t.frame()).not.toContain("MARKER_POST_COMPACT_USER")
 
     t.destroy()
   })
 
-  test("absorbs info.session_id rotation", async () => {
+  test("keeps follow-up RPCs on the active gateway session", async () => {
     const gw = mkGw()
     const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
     await until(t, () => t.frame().includes("draft the rfc"))
 
     await run(t)
-    await until(t, () => t.frame().includes("MARKER_POST_COMPACT_USER"))
+    await until(t, () => t.frame().includes("Compacted 4→3 messages"))
 
-    // setInfo() fed the new session_id; follow-up RPCs target the
-    // continuation, not the ended parent. session.title after /compress
-    // is the cheapest probe — its response flows back into state.
     await act(async () => { await t.keys.typeText("/title After Compress") })
     act(() => t.keys.pressEnter())
     await until(t, () => t.gw.last("session.title")?.params.title === "After Compress")
+    expect(t.gw.last("session.title")?.params.session_id).toBe("pre-sid")
 
     t.destroy()
   })


### PR DESCRIPTION
## Summary

Manual `/compress` now behaves like auto-compression: the context shrinks, but the visible chat transcript remains in place.

The compacted `messages[]` RPC payload is still modeled as part of the wire response, but Herm no longer treats it as a replacement for the live chat surface. The command still updates compression usage and shows the compression summary.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test`
