### PR TITLE
fix(sessions): derive source filters from history

### DIFF
--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -51,36 +51,63 @@ const cmp = (s: Sort) => {
   return (a: Row, b: Row) => k(b) - k(a)
 }
 
-const badge = (src: string): string => (({
-  cli: "CLI", tui: "TUI", api_server: "API", discord: "Discord",
-  telegram: "Telegram", slack: "Slack", whatsapp: "WhatsApp", signal: "Signal",
-  cron: "Cron",
-} as Record<string, string>)[src] ?? src) || "—"
+const WORD = { api: "API", cli: "CLI", tui: "TUI", whatsapp: "WhatsApp" } as Record<string, string>
+const badge = (s: string): string => s
+  .split(/[_-]+/).filter(Boolean)
+  .map(w => WORD[w.toLowerCase()] ?? (w[0]?.toUpperCase() ?? "") + w.slice(1))
+  .join(" ") || "—"
 
 const label = (r: Row) => r.title.trim() || (r.live ? "-" : "Untitled")
 const src = (r: Row): string => r.detail?.sessionSource || r.source || ""
 
-type View = "conversations" | "cron"
+type View = {
+  id: string
+  label: string
+  count: number
+  source?: string
+  aggregate?: "conversations"
+}
 
-const VIEWS: View[] = ["conversations", "cron"]
-const kind = (r: Row): View => src(r) === "cron" ? "cron" : "conversations"
-const tab = (v: View): string => v === "cron" ? "Cron" : "Conversations"
+const HOME = "conversations"
+const HBAR = { visible: false } as const
+const ROW = { flexDirection: "row" } as const
+const sid = (s: string): string => `source:${s}`
+const chip = (id: string): string => `sessions-source-${id.replace(/[^a-z0-9_-]/gi, "_")}`
+const tick = (r: Row): number => r.detail?.last_active ?? r.started_at
 
-const FilterRow = memo((props: {
-  view: View
-  setView: (v: View) => void
-  counts: Record<View, number>
+const FilterRow = memo((p: {
+  views: View[]
+  view: string
+  setView: (v: string) => void
 }) => {
   const theme = useTheme().theme
+  const ref = useRef<ScrollBoxRenderable | null>(null)
+  useEffect(() => {
+    const move = () => {
+      const node = ref.current
+      const idx = p.views.findIndex(v => v.id === p.view)
+      if (!node || idx < 0) return
+      const left = p.views.slice(0, idx).reduce((n, v, i) =>
+        n + (i === 0 ? 0 : 1) + `${v.label} ${v.count}`.length + 2, 0)
+      const w = `${p.views[idx].label} ${p.views[idx].count}`.length + 2
+      const port = Math.max(1, node.viewport.width - 4)
+      const pos = node.scrollLeft
+      node.scrollLeft = Math.max(0, left < pos ? left : left + w > pos + port ? left + w - port : pos)
+    }
+    move()
+    const id = setTimeout(move, 0)
+    return () => clearTimeout(id)
+  }, [p.view, p.views])
   return (
-    <box height={1} flexDirection="row" paddingLeft={2}>
-      {VIEWS.map((v, i) => (
-        <FilterChip key={v} label={`${tab(v)} ${props.counts[v]}`}
-          state={props.view === v ? "in" : "off"} gap={i === 0 ? 0 : 1}
+    <scrollbox ref={ref} scrollX height={1} paddingLeft={2}
+               horizontalScrollbarOptions={HBAR} contentOptions={ROW}>
+      {p.views.map((v, i) => (
+        <FilterChip key={v.id} id={chip(v.id)} label={`${v.label} ${v.count}`}
+          state={p.view === v.id ? "in" : "off"} gap={i === 0 ? 0 : 1}
           color={theme.primary} textColor={theme.primary}
-          onMouseDown={() => props.setView(v)} />
+          onMouseDown={() => p.setView(v.id)} />
       ))}
-    </box>
+    </scrollbox>
   )
 })
 //
@@ -499,22 +526,40 @@ export const Sessions = memo((props: Props) => {
   // without re-hitting state.db.
   const sort: Sort = prefs.usePref("sessions")?.sort ?? "active"
   const setSort = useCallback((s: Sort) => prefs.set("sessions", { sort: s }), [])
-  const [view, setView] = useState<View>("conversations")
+  const [view, setView] = useState<string>(HOME)
   const active = useMemo(() => [...liveRows].sort((a, b) =>
     Number(Boolean(b.live?.current)) - Number(Boolean(a.live?.current)) ||
     ((b.live?.last_active ?? b.started_at) - (a.live?.last_active ?? a.started_at))), [liveRows])
   const ids = useMemo(() => new Set(active.flatMap(r =>
     [r.id, r.live?.session_key].filter((x): x is string => Boolean(x)))), [active])
   const sorted = useMemo(() => rows.filter(r => !ids.has(r.id)).sort(cmp(sort)), [rows, ids, sort])
-  const split = useMemo(() => sorted.reduce((a, r) => {
-    const v = kind(r)
-    a.counts[v] += 1
-    if (v === view) a.hist.push(r)
-    return a
-  }, { counts: { conversations: 0, cron: 0 }, hist: [] as Row[] }), [sorted, view])
-  const counts = split.counts
-  const hist = split.hist
+  const views = useMemo<View[]>(() => {
+    const stats = sorted.reduce((m, r) => {
+      const s = src(r)
+      if (!s) return m
+      const prev = m.get(s)
+      m.set(s, { count: (prev?.count ?? 0) + 1, last: Math.max(prev?.last ?? 0, tick(r)) })
+      return m
+    }, new Map<string, { count: number; last: number }>())
+    const conv = sorted.filter(r => src(r) !== "cron").length
+    return [
+      ...(conv > 0 ? [{ id: HOME, label: "Conversations", count: conv, aggregate: "conversations" as const }] : []),
+      ...[...stats.entries()]
+        .sort((a, b) => b[1].last - a[1].last || badge(a[0]).localeCompare(badge(b[0])))
+        .map(([source, stat]) => ({ id: sid(source), label: badge(source), count: stat.count, source })),
+    ]
+  }, [sorted])
+  const cur = views.find(v => v.id === view) ?? views[0]
+  const chosen = cur?.id ?? view
+  const hist = useMemo(() => {
+    if (!cur) return []
+    if (cur.aggregate === HOME) return sorted.filter(r => src(r) !== "cron")
+    return sorted.filter(r => src(r) === cur.source)
+  }, [sorted, cur])
   const listed = useMemo(() => [...active, ...hist], [active, hist])
+  useEffect(() => {
+    if (views.length > 0 && !views.some(v => v.id === view)) setView(views[0].id)
+  }, [views, view])
   // Selection is tracked by row identity so that collapsing children
   // (which changes the flat index of every row below) never lands sel
   // on the wrong row. The numeric index consumers use (handleListKey,
@@ -839,8 +884,13 @@ export const Sessions = memo((props: Props) => {
     const prev = keys.match("sessions.prev", key)
     const next = keys.match("sessions.next", key)
     if (prev || next) {
+      if (views.length < 2) return
       const dir = prev ? -1 : 1
-      setView(v => VIEWS[(VIEWS.indexOf(v) + dir + VIEWS.length) % VIEWS.length])
+      setView(v => {
+        const list = views.map(x => x.id)
+        const i = list.indexOf(v)
+        return list[((i < 0 ? 0 : i) + dir + list.length) % list.length]
+      })
       return
     }
   })
@@ -848,12 +898,14 @@ export const Sessions = memo((props: Props) => {
   const empty = searching ? results.length === 0 && query.length > 0 : active.length === 0 && sorted.length === 0
   const action = visible[sel]?.row.live ? "activate live" : "switch"
   const top = (i: number) => Boolean(visible[i]?.row.live && (i === 0 || !visible[i - 1]?.row.live))
-  const tabs = (i: number) => Boolean(hist[0] && !visible[i]?.indent && visible[i]?.row.id === hist[0].id)
+  const tabs = (i: number) => Boolean(views.length > 0 && hist[0] && !visible[i]?.indent && visible[i]?.row.id === hist[0].id)
   const gap = (i: number) => active.length > 0 && tabs(i)
-  const blank = view === "cron" ? "No cron sessions found" : "No conversations found"
+  const blank = cur?.aggregate === HOME ? "No conversations found"
+    : cur ? `No ${cur.label} sessions found` : "No sessions found"
   // Sidebar yields at <140 on non-Chat tabs (app.tsx), so detail can
   // stay mounted down to the shell's own floor.
   const showDetailPanel = dims.width >= 120
+  const nav = views.length > 1 ? [["←→", "filter"] as [string, string]] : []
 
   return (
     <box flexDirection="column" flexGrow={1} minWidth={0}>
@@ -908,7 +960,7 @@ export const Sessions = memo((props: Props) => {
                       ) : null}
                       {gap(i) ? <box height={1} /> : null}
                       {tabs(i) ? <>
-                        <FilterRow view={view} setView={setView} counts={counts} />
+                        <FilterRow views={views} view={chosen} setView={setView} />
                         <box height={1} />
                       </> : null}
                       <Item id={rowId(i)} idx={i}
@@ -916,10 +968,10 @@ export const Sessions = memo((props: Props) => {
                         onActivate={rowActivate} onHover={rowHover} onDelete={rowDelete} />
                     </box>
                   ))}
-              {!searching && hist.length === 0 ? (
+              {!searching && views.length > 0 && hist.length === 0 ? (
                 <box key="sessions-empty-filter" flexDirection="column" height={3 + (active.length > 0 ? 1 : 0)}>
                   {active.length > 0 ? <box height={1} /> : null}
-                  <FilterRow view={view} setView={setView} counts={counts} />
+                  <FilterRow views={views} view={chosen} setView={setView} />
                   <box height={1} />
                   <box height={1} paddingLeft={2}>
                     <text fg={theme.textMuted}>{blank}</text>
@@ -945,7 +997,7 @@ export const Sessions = memo((props: Props) => {
         ]
       : [
           ["↑↓", "navigate"],
-          ["←→", "filter"],
+          ...nav,
           [`${keys.print("list.activate")}/click`, action],
           [keys.print("list.search"), "search"],
           [keys.print("list.toggle"), `sort: ${sort}`],

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -891,13 +891,16 @@ export const Sessions = memo((props: Props) => {
                   ))
                 : visible.map((v, i) => (
                     <box key={`${v.row.id}-${v.indent ? "c" : "p"}`} flexDirection="column"
-                         height={1 + (top(i) ? 1 : 0) + (tabs(i) ? 1 : 0)}>
+                         height={1 + (top(i) ? 1 : 0) + (tabs(i) ? 2 : 0)}>
                       {top(i) ? (
                         <box height={1} paddingLeft={2}>
                           <text fg={theme.primary}>{active.length === 1 ? "Active Session" : "Active Sessions"}</text>
                         </box>
                       ) : null}
-                      {tabs(i) ? <FilterRow view={view} setView={setView} counts={counts} /> : null}
+                      {tabs(i) ? <>
+                        <FilterRow view={view} setView={setView} counts={counts} />
+                        <box height={1} />
+                      </> : null}
                       <Item id={rowId(i)} idx={i}
                         row={v.row} selected={i === sel} indent={v.indent}
                         onActivate={rowActivate} onHover={rowHover} onDelete={rowDelete} />

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -77,7 +77,8 @@ const FilterRow = memo((props: {
       {VIEWS.map((v, i) => (
         <FilterChip key={v} label={`${tab(v)} ${props.counts[v]}`}
           state={props.view === v ? "in" : "off"} gap={i === 0 ? 0 : 1}
-          color={theme.primary} onMouseDown={() => props.setView(v)} />
+          color={theme.primary} textColor={theme.primary}
+          onMouseDown={() => props.setView(v)} />
       ))}
     </box>
   )

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -58,26 +58,30 @@ const badge = (src: string): string => (({
 } as Record<string, string>)[src] ?? src) || "—"
 
 const label = (r: Row) => r.title.trim() || (r.live ? "-" : "Untitled")
+const src = (r: Row): string => r.detail?.sessionSource || r.source || ""
 
 type View = "conversations" | "cron"
 
 const VIEWS: View[] = ["conversations", "cron"]
-const cron = (r: Row): boolean => r.source === "cron" || r.detail?.sessionSource === "cron"
+const kind = (r: Row): View => src(r) === "cron" ? "cron" : "conversations"
 const tab = (v: View): string => v === "cron" ? "Cron" : "Conversations"
 
 const FilterRow = memo((props: {
   view: View
   setView: (v: View) => void
   counts: Record<View, number>
-}) => (
-  <box height={1} flexDirection="row" paddingLeft={2}>
-    {VIEWS.map((v, i) => (
-      <FilterChip key={v} label={`${tab(v)} ${props.counts[v]}`}
-        state={props.view === v ? "in" : "off"} gap={i === 0 ? 0 : 1}
-        onMouseDown={() => props.setView(v)} />
-    ))}
-  </box>
-))
+}) => {
+  const theme = useTheme().theme
+  return (
+    <box height={1} flexDirection="row" paddingLeft={2}>
+      {VIEWS.map((v, i) => (
+        <FilterChip key={v} label={`${tab(v)} ${props.counts[v]}`}
+          state={props.view === v ? "in" : "off"} gap={i === 0 ? 0 : 1}
+          color={theme.primary} onMouseDown={() => props.setView(v)} />
+      ))}
+    </box>
+  )
+})
 //
 // Purpose: decide whether to load a session without replacing the
 // current chat. So: conversation only. Tool chatter is collapsed to
@@ -225,7 +229,7 @@ const Detail = memo((props: {
           <box height={1} />
           <KVBlock rows={[
             ["ID", r.id],
-            ["Source", badge(r.source ?? "")],
+            ["Source", badge(src(r))],
             ["Model", d?.model ?? "—"],
             ["Started", when(r.started_at)],
             ["Last active", lastActive ? `${when(lastActive)}  (${ago(lastActive)})` : "—"],
@@ -388,7 +392,7 @@ const Item = memo((props: {
                bold={props.selected}>
         {label(r)}
       </Marquee>
-      <Col w={9} fg={muted ?? theme.info}>{badge(r.source ?? "")}</Col>
+      <Col w={9} fg={muted ?? theme.info}>{badge(src(r))}</Col>
       <Col w={8} fg={theme.textMuted}>{stamp(r.started_at)}</Col>
       <Col w={10} fg={theme.textMuted} right>{active ? ago(active) : "—"}</Col>
       <Col w={7} fg={theme.textMuted} right>{String(r.message_count)}</Col>
@@ -501,11 +505,14 @@ export const Sessions = memo((props: Props) => {
   const ids = useMemo(() => new Set(active.flatMap(r =>
     [r.id, r.live?.session_key].filter((x): x is string => Boolean(x)))), [active])
   const sorted = useMemo(() => rows.filter(r => !ids.has(r.id)).sort(cmp(sort)), [rows, ids, sort])
-  const counts = useMemo(() => ({
-    conversations: sorted.filter(r => !cron(r)).length,
-    cron: sorted.filter(cron).length,
-  }), [sorted])
-  const hist = useMemo(() => sorted.filter(r => view === "cron" ? cron(r) : !cron(r)), [sorted, view])
+  const split = useMemo(() => sorted.reduce((a, r) => {
+    const v = kind(r)
+    a.counts[v] += 1
+    if (v === view) a.hist.push(r)
+    return a
+  }, { counts: { conversations: 0, cron: 0 }, hist: [] as Row[] }), [sorted, view])
+  const counts = split.counts
+  const hist = split.hist
   const listed = useMemo(() => [...active, ...hist], [active, hist])
   // Selection is tracked by row identity so that collapsing children
   // (which changes the flat index of every row below) never lands sel
@@ -841,6 +848,7 @@ export const Sessions = memo((props: Props) => {
   const action = visible[sel]?.row.live ? "activate live" : "switch"
   const top = (i: number) => Boolean(visible[i]?.row.live && (i === 0 || !visible[i - 1]?.row.live))
   const tabs = (i: number) => Boolean(hist[0] && !visible[i]?.indent && visible[i]?.row.id === hist[0].id)
+  const gap = (i: number) => active.length > 0 && tabs(i)
   const blank = view === "cron" ? "No cron sessions found" : "No conversations found"
   // Sidebar yields at <140 on non-Chat tabs (app.tsx), so detail can
   // stay mounted down to the shell's own floor.
@@ -891,12 +899,13 @@ export const Sessions = memo((props: Props) => {
                   ))
                 : visible.map((v, i) => (
                     <box key={`${v.row.id}-${v.indent ? "c" : "p"}`} flexDirection="column"
-                         height={1 + (top(i) ? 1 : 0) + (tabs(i) ? 2 : 0)}>
+                         height={1 + (top(i) ? 1 : 0) + (tabs(i) ? 2 : 0) + (gap(i) ? 1 : 0)}>
                       {top(i) ? (
                         <box height={1} paddingLeft={2}>
                           <text fg={theme.primary}>{active.length === 1 ? "Active Session" : "Active Sessions"}</text>
                         </box>
                       ) : null}
+                      {gap(i) ? <box height={1} /> : null}
                       {tabs(i) ? <>
                         <FilterRow view={view} setView={setView} counts={counts} />
                         <box height={1} />
@@ -907,8 +916,10 @@ export const Sessions = memo((props: Props) => {
                     </box>
                   ))}
               {!searching && hist.length === 0 ? (
-                <box key="sessions-empty-filter" flexDirection="column" height={2}>
+                <box key="sessions-empty-filter" flexDirection="column" height={3 + (active.length > 0 ? 1 : 0)}>
+                  {active.length > 0 ? <box height={1} /> : null}
                   <FilterRow view={view} setView={setView} counts={counts} />
+                  <box height={1} />
                   <box height={1} paddingLeft={2}>
                     <text fg={theme.textMuted}>{blank}</text>
                   </box>

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -19,6 +19,7 @@ import { KVBlock } from "../ui/kv"
 import { Col, Hdr, Marquee, VBAR } from "../ui/table"
 import { Spinner } from "../ui/spinner"
 import { Ticker, inline } from "../ui/ticker"
+import { FilterChip } from "../ui/filter-chip"
 import { openConfirm } from "../dialogs/confirm"
 import { openTextPrompt } from "../dialogs/text-prompt"
 import { fmt, cost, trunc, ago, when, span, stamp } from "../ui/fmt"
@@ -68,26 +69,15 @@ const FilterRow = memo((props: {
   view: View
   setView: (v: View) => void
   counts: Record<View, number>
-}) => {
-  const theme = useTheme().theme
-  return (
-    <box height={1} flexDirection="row" paddingLeft={2}>
-      {VIEWS.map((v, i) => {
-        const on = props.view === v
-        const fg = on ? theme.primary : theme.textMuted
-        return (
-          <box key={v} height={1} paddingLeft={i === 0 ? 0 : 2}
-               paddingRight={1} onMouseDown={() => props.setView(v)}>
-            <text>
-              <span fg={fg}>{tab(v)}</span>
-              <span fg={fg}>{` ${props.counts[v]}`}</span>
-            </text>
-          </box>
-        )
-      })}
-    </box>
-  )
-})
+}) => (
+  <box height={1} flexDirection="row" paddingLeft={2}>
+    {VIEWS.map((v, i) => (
+      <FilterChip key={v} label={`${tab(v)} ${props.counts[v]}`}
+        state={props.view === v ? "in" : "off"} gap={i === 0 ? 0 : 1}
+        onMouseDown={() => props.setView(v)} />
+    ))}
+  </box>
+))
 //
 // Purpose: decide whether to load a session without replacing the
 // current chat. So: conversation only. Tool chatter is collapsed to

--- a/src/ui/filter-chip.tsx
+++ b/src/ui/filter-chip.tsx
@@ -21,6 +21,7 @@ export type Tri = "off" | "in" | "ex"
 export const cycle = (t: Tri): Tri => t === "off" ? "in" : t === "in" ? "ex" : "off"
 
 export const FilterChip = memo((p: {
+  id?: string
   label: string
   state: Tri
   /** Keyboard cursor is on this chip. */
@@ -43,7 +44,7 @@ export const FilterChip = memo((p: {
     : p.state === "ex" ? (p.selected ? color : theme.borderSubtle)
     : p.selected ? color : text
   return (
-    <box height={1} flexShrink={0} marginLeft={p.gap ?? 1}
+    <box id={p.id} height={1} flexShrink={0} marginLeft={p.gap ?? 1}
          paddingLeft={1} paddingRight={1}
          backgroundColor={bg} onMouseDown={p.onMouseDown}>
       <text fg={fg}

--- a/src/ui/filter-chip.tsx
+++ b/src/ui/filter-chip.tsx
@@ -13,7 +13,7 @@
 // canonical off→in→ex→off step without re-deriving it.
 
 import { memo } from "react"
-import { TextAttributes } from "@opentui/core"
+import { TextAttributes, type ColorInput } from "@opentui/core"
 import { useTheme } from "../theme"
 
 export type Tri = "off" | "in" | "ex"
@@ -27,15 +27,18 @@ export const FilterChip = memo((p: {
   selected?: boolean
   /** Leading gap in cells (default 1). Use 3 between groups. */
   gap?: number
+  /** Include/selected color. Defaults to theme accent. */
+  color?: ColorInput
   onMouseDown?: () => void
 }) => {
   const theme = useTheme().theme
-  const bg = p.state === "in" ? theme.accent
+  const color = p.color ?? theme.accent
+  const bg = p.state === "in" ? color
     : p.state === "ex" ? undefined
     : theme.backgroundElement
   const fg = p.state === "in" ? theme.background
-    : p.state === "ex" ? (p.selected ? theme.accent : theme.borderSubtle)
-    : p.selected ? theme.accent : theme.text
+    : p.state === "ex" ? (p.selected ? color : theme.borderSubtle)
+    : p.selected ? color : theme.text
   return (
     <box height={1} flexShrink={0} marginLeft={p.gap ?? 1}
          paddingLeft={1} paddingRight={1}

--- a/src/ui/filter-chip.tsx
+++ b/src/ui/filter-chip.tsx
@@ -29,16 +29,19 @@ export const FilterChip = memo((p: {
   gap?: number
   /** Include/selected color. Defaults to theme accent. */
   color?: ColorInput
+  /** Off-state text color. Defaults to theme text. */
+  textColor?: ColorInput
   onMouseDown?: () => void
 }) => {
   const theme = useTheme().theme
   const color = p.color ?? theme.accent
+  const text = p.textColor ?? theme.text
   const bg = p.state === "in" ? color
     : p.state === "ex" ? undefined
     : theme.backgroundElement
   const fg = p.state === "in" ? theme.background
     : p.state === "ex" ? (p.selected ? color : theme.borderSubtle)
-    : p.selected ? color : theme.text
+    : p.selected ? color : text
   return (
     <box height={1} flexShrink={0} marginLeft={p.gap ?? 1}
          paddingLeft={1} paddingRight={1}

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -120,7 +120,8 @@ describe("Sessions tab", () => {
 
     expect(t.frame()).toContain("Active Session")
     expect(t.frame()).toContain("TUI")
-    expect(t.frame()).toContain("Conversations")
+    expect(t.frame()).not.toContain("Conversations")
+    expect(t.frame()).not.toContain("[←→] filter")
     expect(t.frame()).not.toContain("History")
 
     t.destroy()
@@ -1082,6 +1083,52 @@ describe("Sessions tab — source filters", () => {
       message_count: 5, started_at: 1700000200 }),
   ]
 
+  test("builds exact source tabs from loaded history", async () => {
+    const rows = [
+      detail({ id: "tui", sessionSource: "tui", title: "TUI chat",
+        message_count: 2, started_at: 1700000100 }),
+      detail({ id: "discord", sessionSource: "discord", title: "Discord chat",
+        message_count: 3, started_at: 1700000200 }),
+      detail({ id: "bridge", sessionSource: "custom_bridge", title: "Bridge chat",
+        message_count: 4, started_at: 1700000300 }),
+      detail({ id: "cron", sessionSource: "cron", title: "Cron job",
+        message_count: 5, started_at: 1700000400 }),
+    ]
+    const gw = new MockGateway({ "session.list": () => ({ sessions: [] }) })
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => rows }} />, { gw, width: 130 })
+    await until(t, () => t.frame().includes("Custom Bridge 1"))
+
+    const f = t.frame()
+    expect(f).toContain("Conversations 3")
+    expect(f).toContain("TUI 1")
+    expect(f).toContain("Discord 1")
+    expect(f).toContain("Custom Bridge 1")
+    expect(f).toContain("Cron 1")
+    expect(f).not.toContain("Slack")
+    expect(f).not.toContain("Telegram")
+    expect(f).toContain("TUI chat")
+    expect(f).toContain("Discord chat")
+    expect(f).toContain("Bridge chat")
+    expect(f).not.toContain("Cron job")
+    t.destroy()
+  })
+
+  test("scrolls an overflowing source filter row to the selected chip", async () => {
+    const rows = Array.from({ length: 10 }, (_, i) => detail({
+      id: `source-${i}`, sessionSource: `source_${i.toString().padStart(2, "0")}`,
+      title: `Source ${i.toString().padStart(2, "0")} row`, message_count: 1,
+      started_at: 1700001000 - i,
+    }))
+    const gw = new MockGateway({ "session.list": () => ({ sessions: [] }) })
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => rows }} />, { gw, width: 70, height: 24 })
+    await until(t, () => t.frame().includes("Source 00 1"))
+
+    for (let i = 0; i < 10; i++) act(() => t.keys.pressArrow("right"))
+    await until(t, () => t.frame().includes("Source 09 1"))
+    expect(t.frame()).toContain("Source 09 row")
+    t.destroy()
+  })
+
   test("defaults to Conversations and ←/→ switches to Cron", async () => {
     const gw = new MockGateway({ "session.list": () => ({ sessions: [] }) })
     const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => disk }} />, { gw, width: 110 })
@@ -1107,7 +1154,7 @@ describe("Sessions tab — source filters", () => {
     t.destroy()
   })
 
-  test("active sessions stay above the source filter", async () => {
+  test("active sessions stay above a source-only filter", async () => {
     const gw = new MockGateway({
       "session.active_list": () => ({ sessions: [
         { id: "live", title: "Live work", preview: "", message_count: 1,
@@ -1116,20 +1163,19 @@ describe("Sessions tab — source filters", () => {
       "session.list": () => ({ sessions: [] }),
     })
     const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => disk.slice(1) }} />, { gw, width: 110 })
-    await until(t, () => t.frame().includes("Live work") && t.frame().includes("Conversations"))
+    await until(t, () => t.frame().includes("Live work") && t.frame().includes("Cron 1"))
 
     let lines = t.frame().split("\n")
     expect(lines.findIndex(l => l.includes("Live work")))
-      .toBeLessThan(lines.findIndex(l => l.includes("Conversations")))
+      .toBeLessThan(lines.findIndex(l => l.includes("Cron 1")))
     expect(t.frame()).toContain("Active Session")
     expect(t.frame()).not.toContain("── Active Session")
-    expect(t.frame()).toContain("No conversations found")
+    expect(t.frame()).not.toContain("Conversations")
+    expect(t.frame()).not.toContain("No conversations found")
 
-    act(() => t.keys.pressArrow("right"))
-    await until(t, () => t.frame().includes("Nightly cron"))
     lines = t.frame().split("\n")
     const live = lines.findIndex(l => l.includes("Live work"))
-    const tabs = lines.findIndex(l => l.includes("Conversations"))
+    const tabs = lines.findIndex(l => l.includes("Cron 1"))
     const cron = lines.findIndex(l => l.includes("Nightly cron"))
     expect(live).toBeGreaterThanOrEqual(0)
     expect(tabs).toBeGreaterThan(live)


### PR DESCRIPTION
## Summary
- Derives Sessions source filter chips from loaded historical rows instead of a fixed Conversations/Cron set.
- Keeps active sessions pinned above the filter row and excludes active-only rows from filter availability.
- Adds no-scrollbar horizontal scrolling so overflowing source chips keep the selected filter in view.

## Verification
- `bun test test/sessions.test.tsx`
- `bunx tsc --noEmit`
