### PR TITLE
feat: add credits notices and model setup hints

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -328,6 +328,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const reset = useCallback(() => {
     stream.interrupted.current = false
+    toast.clear("credits.depleted")
     undone.current = []
     dispatch({ kind: "reset" })
     setUsage(undefined)
@@ -335,7 +336,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     setStatus("")
     setTitle("")
     setAttachments([])
-  }, [])
+  }, [toast])
 
   const newSession = useCallback(async () => {
     const prev = sidRef.current

--- a/src/app/notices.ts
+++ b/src/app/notices.ts
@@ -1,0 +1,40 @@
+import type { ToastContext, ToastVariant } from "../ui/toast"
+import type { NotificationClearPayload, NotificationShowPayload } from "../context/wire"
+
+function variant(level?: string): ToastVariant {
+  switch (level) {
+    case "error": return "error"
+    case "warning":
+    case "warn": return "warning"
+    case "success": return "success"
+    default: return "info"
+  }
+}
+
+function duration(p: NotificationShowPayload): number | null | undefined {
+  if (p.kind === "sticky") return null
+  if (typeof p.ttl_ms === "number") return p.ttl_ms
+  if (typeof p.duration_ms === "number") return p.duration_ms
+  return undefined
+}
+
+export function showNotification(toast: ToastContext, p: NotificationShowPayload | undefined) {
+  const text = String(p?.text ?? "").trim()
+  if (!text) return
+  toast.show({
+    key: p?.key,
+    variant: variant(p?.level),
+    message: text,
+    duration: duration(p ?? { text }),
+  })
+}
+
+export function clearNotification(toast: ToastContext, p: NotificationClearPayload | undefined) {
+  const key = String(p?.key ?? "").trim()
+  // Upstream clear without a key can mean "clear current notice" in clients
+  // with a single notice slot. Herm stores keyed notices independently, so an
+  // unkeyed clear is intentionally a no-op instead of wiping unrelated sticky
+  // notices from another controller path.
+  if (!key) return
+  toast.clear(key)
+}

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -62,7 +62,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "rollback", description: "Browse & restore checkpoints", category: "Client", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "history",  description: "Server-side transcript viewer", category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "status",  description: "Version, model, paths",       category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
-  { name: "usage",   description: "Tokens, context fill, cost",   category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "usage",   description: "Credits, account status, tokens, context fill, cost", category: "Info", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "profile", description: "Active profile details",       category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "steer",   description: "Inject a note mid-turn (no interrupt)", category: "Session", aliases: [], argsHint: "[text]", subcommands: [], source: "local", target: "local" },
   { name: "reload-mcp", description: "Restart MCP servers & rediscover tools", category: "Session", aliases: [], argsHint: "[now|always]", subcommands: ["now", "always"], source: "local", target: "local" },

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -178,6 +178,7 @@ export function useStream(c: Ctx) {
         n.timer = setTimeout(flushProcs, 500)
       },
       onSkin: (s) => x.setSkin(deriveSkin(s)),
+      notices: toast,
     })
     if (!action) return
     if (ev.type === "session.info") {

--- a/src/components/chat/PromptCard.tsx
+++ b/src/components/chat/PromptCard.tsx
@@ -20,6 +20,7 @@ import type { ParsedKey, SubmitEvent } from "@opentui/core"
 import { useTheme } from "../../theme"
 import { useGateway } from "../../context/gateway"
 import { mkApproval, remember } from "../../context/approval-memory"
+import { MaskInput } from "../../ui/mask-input"
 import type { PromptPart, PromptReq, Part } from "../../types/message"
 
 export type PromptCardHandle = {
@@ -330,21 +331,7 @@ const Masked = forwardRef<PromptCardHandle, {
         <text fg={theme.warning}><strong>{p.title}</strong></text>
         <text fg={theme.text}>{p.note}</text>
         <box height={1} />
-        <box flexDirection="row" height={1} position="relative">
-          <text fg={theme.textMuted}>{"> "}</text>
-          <input
-            value={value} onInput={setValue}
-            onSubmit={(() => go(value)) as unknown as (e: SubmitEvent) => void}
-            focused flexGrow={1}
-            textColor={theme.backgroundElement}
-            cursorColor={theme.accent}
-            backgroundColor={theme.backgroundElement}
-            focusedBackgroundColor={theme.backgroundElement}
-          />
-          <box position="absolute" left={2} top={0} height={1}>
-            <text fg={theme.text} bg={theme.backgroundElement}>{"•".repeat(value.length)}</text>
-          </box>
-        </box>
+        <MaskInput value={value} input={setValue} submit={() => go(value)} />
         <text fg={theme.textMuted}>Enter submit · Esc cancel</text>
       </box>
     </Frame>

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -69,6 +69,12 @@ export const readSlots = (raw: Record<string, unknown>): Slot[] => {
 
 export type AssignResult = WriteResult & { warning?: string }
 
+export type AuxSlot = Extract<Slot, { kind: "aux" }>
+
+export const staleAuxForMain = (slots: Slot[], provider: string): AuxSlot[] =>
+  slots.filter((s): s is AuxSlot =>
+    s.kind === "aux" && !s.auto && s.provider !== "" && s.provider !== "auto" && s.provider !== provider)
+
 /** Write a slot. Main goes via the rpc `config.set key=model` alias
  *  (same path as /model --global — live-applies and clears stale
  *  base_url/context_length upstream). Aux writes two cli-lane keys. */

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -3,9 +3,11 @@
 import * as perf from "../utils/perf"
 import * as spawnHistory from "../app/spawnHistory"
 import { shouldRemember } from "./approval-memory"
+import { showNotification, clearNotification } from "../app/notices"
 import type { GatewayEvent, GatewaySkin, SessionInfo } from "../context/wire"
 import type { Action } from "../app/turnReducer"
 import { pid, type Usage } from "../types/message"
+import type { ToastContext } from "../ui/toast"
 
 export type Side = {
   onReady?: () => void
@@ -23,6 +25,7 @@ export type Side = {
   onVoiceTranscript?: (text: string, noSpeechLimit: boolean) => void
   /** status.update with kind=process — debounced client-side to prevent TUI lag. */
   onProcessNotification?: (text: string) => void
+  notices?: ToastContext
 }
 
 function count(o: Record<string, string[]> | undefined): number {
@@ -232,6 +235,15 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       }
       return { kind: "system", text }
     }
+
+    case "notification.show":
+      if (side.notices) showNotification(side.notices, ev.payload)
+      return null
+
+    case "notification.clear":
+      if (side.notices) clearNotification(side.notices, ev.payload)
+      return null
+
     case "voice.status": {
       // Continuous VAD loop reports its internal state: listening,
       // transcribing, or idle. The UI uses this for the recording indicator.

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -2,6 +2,19 @@
 
 import type { Usage } from "../types/message"
 
+export type NotificationShowPayload = {
+  text: string
+  level?: "info" | "warning" | "warn" | "error" | "success" | string
+  kind?: "sticky" | "toast" | "transient" | string
+  key?: string
+  ttl_ms?: number
+  duration_ms?: number
+}
+
+export type NotificationClearPayload = {
+  key?: string
+}
+
 export type GatewayEvent = ({
   session_id?: string
 } & (
@@ -18,6 +31,8 @@ export type GatewayEvent = ({
   | { type: "reasoning.delta"; payload?: { text?: string; verbose?: boolean } }
   | { type: "reasoning.available"; payload?: { text?: string; verbose?: boolean } }
   | { type: "status.update"; payload?: { text?: string; kind?: string } }
+  | { type: "notification.show"; payload?: NotificationShowPayload }
+  | { type: "notification.clear"; payload?: NotificationClearPayload }
   | { type: "tool.start"; payload: { tool_id: string; name?: string; context?: string; args_text?: string; todos?: unknown[] } }
   | { type: "tool.progress"; payload: { name?: string; preview?: string } }
   | { type: "tool.generating"; payload: { name?: string } }

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -259,6 +259,8 @@ export type SessionListResponse = {
 export type SessionUsageResponse = {
   model?: string
   calls?: number
+  credits_lines?: string[]
+  dev_credits_spent_micros?: number
   input?: number
   output?: number
   total?: number

--- a/src/dialogs/info.tsx
+++ b/src/dialogs/info.tsx
@@ -15,12 +15,19 @@ import { hermesPath } from "../service/hermes-home"
 
 type Row = [string, string | undefined, RGBA?]
 
-const InfoDialog = (props: { title: string; rows: Row[]; note?: string }) => {
+const InfoDialog = (props: { title: string; rows: Row[]; lines?: string[]; note?: string }) => {
   const theme = useTheme().theme
   const body = props.rows.filter(r => r[1] !== undefined)
   return (
     <box flexDirection="column" minWidth={52} gap={1}>
       <box height={1}><text fg={theme.primary}><strong>{props.title}</strong></text></box>
+      {props.lines?.length
+        ? <box flexDirection="column">
+            {props.lines.map((line, i) => (
+              <box key={i} height={1}><text fg={theme.text}>{line}</text></box>
+            ))}
+          </box>
+        : null}
       <box flexDirection="column"><KVBlock rows={body} /></box>
       {props.note
         ? <box height={1}><text fg={theme.textMuted}>{props.note}</text></box>
@@ -66,7 +73,7 @@ const UsageDialog = ({ gw }: { gw: Gateway }) => {
     ? `${fmt(u.context_used ?? 0)} / ${fmt(u.context_max)} (${Math.round(u.context_percent ?? 0)}%)`
     : undefined
   return (
-    <InfoDialog title="Usage" note={u.cost_status === "estimated" ? "cost is estimated" : undefined} rows={[
+    <InfoDialog title="Usage" lines={u.credits_lines} note={u.cost_status === "estimated" ? "cost is estimated" : undefined} rows={[
       ["Model",     u.model || "—"],
       ["API calls", String(u.calls ?? 0)],
       ["Input",     fmt(u.input ?? 0)],

--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -9,12 +9,13 @@
 import { useEffect, useState, useCallback } from "react"
 import { useDialog } from "../ui/dialog"
 import { DialogSelect, type SelectOption } from "../ui/dialog-select"
+import { SecretPrompt } from "./secret-prompt"
 import { useTheme } from "../theme"
 import { useToast } from "../ui/toast"
 import type { Gateway } from "../context/gateway"
-import type { ConfigSetResponse, ModelOptionsResponse } from "../context/wire"
+import type { ConfigSetResponse, ModelOptionProvider, ModelOptionsResponse } from "../context/wire"
 
-type Step = "provider" | "model"
+type Step = "provider" | "model" | "setup"
 
 type Props = {
   gw: Gateway
@@ -24,6 +25,38 @@ type Props = {
   title?: string
 }
 
+type SaveKeyResponse = {
+  provider?: ModelOptionProvider
+  warning?: string
+}
+
+const configured = (p: ModelOptionProvider) => (p.models?.length ?? 0) > 0
+
+const setupDescription = (p: ModelOptionProvider): string | undefined => {
+  if (p.warning) return p.warning
+  if (p.auth_type === "api_key" && p.key_env) return `paste ${p.key_env} to activate`
+  if (p.key_env) return p.key_env
+  if (p.auth_type) return `run hermes model to configure (${p.auth_type})`
+  return undefined
+}
+
+const providerDescription = (p: ModelOptionProvider): string | undefined => {
+  if (p.authenticated === false) return setupDescription(p)
+  return p.total_models ? `${p.total_models} models` : undefined
+}
+
+const providerHint = (p: ModelOptionProvider): string | undefined => {
+  if (p.authenticated !== false) return undefined
+  return p.auth_type ? `auth_type=${p.auth_type}` : undefined
+}
+
+const replaceProvider = (
+  data: ModelOptionsResponse, slug: string, next: ModelOptionProvider,
+): ModelOptionsResponse => ({
+  ...data,
+  providers: (data.providers ?? []).map(p => p.slug === slug ? next : p),
+})
+
 const ModelPickerDialog = (props: Props) => {
   const dialog = useDialog()
   const toast = useToast()
@@ -31,13 +64,14 @@ const ModelPickerDialog = (props: Props) => {
   const [data, setData] = useState<ModelOptionsResponse | null>(null)
   const [step, setStep] = useState<Step>("provider")
   const [provider, setProvider] = useState<string | null>(null)
+  const [setupProvider, setSetupProvider] = useState<ModelOptionProvider | null>(null)
   const [global, setGlobal] = useState(false)
 
-  useEffect(() => {
-    props.gw.request<ModelOptionsResponse>("model.options")
-      .then(setData)
-      .catch(() => setData({ providers: [] }))
-  }, [props.gw])
+  const refresh = useCallback(() => props.gw.request<ModelOptionsResponse>("model.options")
+    .then(setData)
+    .catch(() => setData({ providers: [] })), [props.gw])
+
+  useEffect(() => { void refresh() }, [refresh])
 
   const apply = useCallback((model: string, prov: string) => {
     if (props.onApply) return void props.onApply(prov, model)
@@ -53,9 +87,43 @@ const ModelPickerDialog = (props: Props) => {
       .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
   }, [props.gw, props.onApply, global, toast])
 
+  const submitKey = useCallback(async (p: ModelOptionProvider, key: string) => {
+    try {
+      const r = await props.gw.request<SaveKeyResponse>("model.save_key", { slug: p.slug, api_key: key })
+      if (r.warning) toast.show({ variant: "warning", message: r.warning })
+      const next = r.provider ?? (await props.gw.request<ModelOptionsResponse>("model.options"))
+        .providers?.find(pp => pp.slug === p.slug)
+      if (!next) {
+        toast.show({ variant: "warning", message: "Provider saved; refresh model options to continue" })
+        return
+      }
+      setData(d => d ? replaceProvider(d, p.slug, next) : d)
+      if (configured(next)) {
+        setSetupProvider(null)
+        setProvider(next.slug)
+        setStep("model")
+        toast.show({ variant: "success", message: `${next.name} activated` })
+        return
+      }
+      toast.show({ variant: "warning", message: next.warning ?? "Provider saved but no models were returned" })
+    } catch (e) {
+      toast.show({ variant: "error", message: e instanceof Error ? e.message : String(e) })
+    }
+  }, [props.gw, toast])
+
+  const setup = useCallback((p: ModelOptionProvider) => {
+    const msg = setupDescription(p)
+    if (p.auth_type !== "api_key" || !p.key_env) {
+      toast.show({ variant: "warning", message: msg ?? "Run hermes model to configure this provider" })
+      return
+    }
+    setSetupProvider(p)
+    setStep("setup")
+  }, [toast])
+
   const onKey = useCallback((k: { name: string }) => {
     if (k.name === "tab" && !props.onApply) { setGlobal(g => !g); return true }
-    if (k.name === "left" && step === "model") { setStep("provider"); return true }
+    if (k.name === "left" && step !== "provider") { setStep("provider"); return true }
     return false
   }, [step, props.onApply])
 
@@ -73,21 +141,33 @@ const ModelPickerDialog = (props: Props) => {
 
   if (!data) return <box width={50} padding={1}><text>Loading models…</text></box>
 
+  if (step === "setup" && setupProvider?.key_env) return <SecretPrompt
+    title={`Paste ${setupProvider.key_env}`}
+    label={setupDescription(setupProvider) ?? `API key for ${setupProvider.name}`}
+    onSubmit={(key) => { void submitKey(setupProvider, key) }}
+  />
+
   if (step === "provider") {
     const options: SelectOption[] = (data.providers ?? [])
       .toSorted((a, b) => Number(Boolean(b.is_current)) - Number(Boolean(a.is_current)))
       .map(p => ({
         title: p.name,
         value: p.slug,
-        description: p.total_models ? `${p.total_models} models` : undefined,
-        category: p.is_current ? "Current" : "Available",
+        description: providerDescription(p),
+        hint: providerHint(p),
+        category: p.is_current ? "Current" : p.authenticated === false ? "Setup required" : "Available",
       }))
     return (
       <DialogSelect
         title={props.title ?? "Switch Provider"}
         options={options}
         current={data.provider}
-        onSelect={(o) => { setProvider(o.value); setStep("model") }}
+        onSelect={(o) => {
+          const p = data.providers?.find(pp => pp.slug === o.value)
+          if (p?.authenticated === false || (p && !configured(p))) return void setup(p)
+          setProvider(o.value)
+          setStep("model")
+        }}
         onKey={onKey}
         placeholder="Search providers..."
         footer={footer}

--- a/src/dialogs/secret-prompt.tsx
+++ b/src/dialogs/secret-prompt.tsx
@@ -1,0 +1,60 @@
+// Single-line masked secret prompt dialog. Enter submits, Esc cancels.
+
+import { useState } from "react"
+import { useTheme } from "../theme"
+import type { DialogContext } from "../ui/dialog"
+
+type Props = {
+  title: string
+  label?: string
+  onSubmit: (value: string) => void
+}
+
+export const SecretPrompt = (props: Props) => {
+  const theme = useTheme().theme
+  const [value, setValue] = useState("")
+
+  return (
+    <box flexDirection="column" width={60}>
+      <box height={1}><text fg={theme.warning}><strong>{props.title}</strong></text></box>
+      <box height={1} />
+      {props.label ? <box height={1}><text fg={theme.textMuted}>{props.label}</text></box> : null}
+      <box height={1} flexDirection="row" position="relative">
+        <text fg={theme.textMuted}>{"> "}</text>
+        <input
+          value={value}
+          onInput={setValue}
+          onSubmit={() => { const v = value.trim(); if (v) props.onSubmit(v) }}
+          focused
+          flexGrow={1}
+          textColor={theme.backgroundElement}
+          cursorColor={theme.accent}
+          backgroundColor={theme.backgroundElement}
+          focusedBackgroundColor={theme.backgroundElement}
+        />
+        <box position="absolute" left={2} top={0} height={1}>
+          <text fg={theme.text} bg={theme.backgroundElement}>{"•".repeat(value.length)}</text>
+        </box>
+      </box>
+      <box height={1} />
+      <box height={1}><text fg={theme.textMuted}>
+        {value.trim() ? "Enter confirm  ·  Esc cancel" : "Esc cancel"}
+      </text></box>
+    </box>
+  )
+}
+
+export function openSecretPrompt(
+  dialog: DialogContext,
+  opts: { title: string; label?: string },
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    dialog.replace(
+      <SecretPrompt
+        title={opts.title} label={opts.label}
+        onSubmit={(v) => { resolve(v); dialog.clear() }}
+      />,
+      () => resolve(null),
+    )
+  })
+}

--- a/src/dialogs/secret-prompt.tsx
+++ b/src/dialogs/secret-prompt.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { useTheme } from "../theme"
-import type { DialogContext } from "../ui/dialog"
+import { MaskInput } from "../ui/mask-input"
 
 type Props = {
   title: string
@@ -19,42 +19,12 @@ export const SecretPrompt = (props: Props) => {
       <box height={1}><text fg={theme.warning}><strong>{props.title}</strong></text></box>
       <box height={1} />
       {props.label ? <box height={1}><text fg={theme.textMuted}>{props.label}</text></box> : null}
-      <box height={1} flexDirection="row" position="relative">
-        <text fg={theme.textMuted}>{"> "}</text>
-        <input
-          value={value}
-          onInput={setValue}
-          onSubmit={() => { const v = value.trim(); if (v) props.onSubmit(v) }}
-          focused
-          flexGrow={1}
-          textColor={theme.backgroundElement}
-          cursorColor={theme.accent}
-          backgroundColor={theme.backgroundElement}
-          focusedBackgroundColor={theme.backgroundElement}
-        />
-        <box position="absolute" left={2} top={0} height={1}>
-          <text fg={theme.text} bg={theme.backgroundElement}>{"•".repeat(value.length)}</text>
-        </box>
-      </box>
+      <MaskInput value={value} input={setValue}
+                 submit={() => { const v = value.trim(); if (v) props.onSubmit(v) }} />
       <box height={1} />
       <box height={1}><text fg={theme.textMuted}>
         {value.trim() ? "Enter confirm  ·  Esc cancel" : "Esc cancel"}
       </text></box>
     </box>
   )
-}
-
-export function openSecretPrompt(
-  dialog: DialogContext,
-  opts: { title: string; label?: string },
-): Promise<string | null> {
-  return new Promise((resolve) => {
-    dialog.replace(
-      <SecretPrompt
-        title={opts.title} label={opts.label}
-        onSubmit={(v) => { resolve(v); dialog.clear() }}
-      />,
-      () => resolve(null),
-    )
-  })
 }

--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -262,12 +262,12 @@ export const byId = (id: string): SessionRow | null => {
   return r ? toRow(r) : null
 }
 
-/** Newest real TUI/CLI session that actually has messages. Target of
- *  `-c` and source of the splash continue-prompt title.
+/** Newest real TUI/CLI conversation. Target of `-c` and source of the
+ *  splash continue-prompt title.
  *
  *  Newest row with messages (root or continuation — subagents/branches
- *  excluded), then walk the compression chain to its live tip so a
- *  compressed root resolves to the continuation holding the messages. */
+ *  excluded), then walk the compression chain to its live tip. The tip
+ *  can have 0 messages when compaction rotated but no turn landed yet. */
 export const lastReal = (): SessionRow | undefined => {
   const hit = q(`
     SELECT s.id FROM sessions s
@@ -277,8 +277,7 @@ export const lastReal = (): SessionRow | undefined => {
     ORDER BY s.started_at DESC LIMIT 1
   `)?.get() as { id: string } | undefined
   if (!hit) return undefined
-  const row = byId(chainTip(hit.id))
-  return row && row.message_count > 0 ? row : undefined
+  return byId(chainTip(hit.id)) ?? undefined
 }
 
 /** Resolve any id in a compression chain to the live tip. Walks up to

--- a/src/tabs/Config.tsx
+++ b/src/tabs/Config.tsx
@@ -13,7 +13,7 @@ import { stringify as yamlStringify, parse as yamlParse } from "yaml";
 import { writeConfig, verifyWrite, maxEffect } from "../config/lane";
 import { check as checkRule } from "../config/rules";
 import { buildFields, groupOf, sections, GROUPS, EFFECT_GLYPH, type Field, type Section } from "../config";
-import { readSlots, assign, resetAux, AUX_TASKS, type Slot } from "../config/models";
+import { readSlots, assign, resetAux, AUX_TASKS, staleAuxForMain, type Slot } from "../config/models";
 import { openModelPicker } from "../dialogs/model-picker";
 import { managedSystem, makeSource } from "../service/hermes-home";
 import { FileLink } from "../components/ui/FileLink";
@@ -296,6 +296,29 @@ export const Config = memo((props: { focused?: boolean }) => {
 
   const pick = useCallback((s: Slot) => {
     if (managed) return toast.show({ variant: "error", message: `Managed by ${managed}` });
+    const warnStaleAux = async (prov: string) => {
+      const stale = staleAuxForMain(readSlots(raw), prov);
+      if (stale.length === 0) return;
+      const names = stale.map(x => x.label).join(", ");
+      const ok = await openConfirm(dialog, {
+        title: "Auxiliary models still pinned to another provider",
+        body: `${names}\n\nReset these slots to auto so they follow the main model?`,
+        yes: "reset stale", no: "keep",
+      });
+      if (!ok) {
+        toast.show({ variant: "warning", message: `Aux still pinned to another provider: ${names}. Press X to reset all to auto.` });
+        return;
+      }
+      for (const slot of stale) {
+        const r = await resetAux(gw, slot.key);
+        if (r.failed.length) {
+          toast.show({ variant: "error", message: `${slot.label}: ${r.failed.map(f => f.err).join("; ")}` });
+          return;
+        }
+      }
+      toast.show({ variant: "success", message: `Reset ${stale.length} aux slot${stale.length === 1 ? "" : "s"} → auto` });
+      load();
+    };
     openModelPicker(dialog, gw, {
       title: s.kind === "main" ? "Set main model" : `Set auxiliary · ${s.label}`,
       onApply: async (prov, model) => {
@@ -306,9 +329,10 @@ export const Config = memo((props: { focused?: boolean }) => {
           message: s.kind === "main" ? `main → ${prov} · ${model}` : `${s.key} → ${prov} · ${model}` });
         if (r.warning) toast.show({ variant: "warning", message: r.warning });
         load();
+        if (s.kind === "main") await warnStaleAux(prov);
       },
     });
-  }, [gw, dialog, toast, load, managed]);
+  }, [gw, dialog, toast, load, managed, raw]);
 
   const unset = useCallback((s: Slot) => {
     if (managed || s.kind !== "aux" || s.auto) return;

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -622,6 +622,8 @@ export const Sessions = memo((props: Props) => {
 
   const LIMIT = 2000
 
+  const keep = (d: SessionRow) => d.message_count > 0 || d.lineage_root_id != null
+
   const toRow = (d: SessionRow): Row => ({
     id: d.id, title: d.title ?? "", preview: d.lastMessage ?? "",
     message_count: d.message_count, started_at: d.started_at,
@@ -658,7 +660,7 @@ export const Sessions = memo((props: Props) => {
 
     const disk = await fs
     const local = new Map(disk.map(r => [r.id, r]))
-    const diskRows = disk.filter(d => d.message_count > 0).map(toRow)
+    const diskRows = disk.filter(keep).map(toRow)
     setRows(diskRows)
     if (cached) last.rows = diskRows
 

--- a/src/ui/mask-input.tsx
+++ b/src/ui/mask-input.tsx
@@ -1,0 +1,31 @@
+import { useTheme } from "../theme"
+
+type Props = {
+  value: string
+  input: (value: string) => void
+  submit: () => void
+}
+
+export const MaskInput = (props: Props) => {
+  const theme = useTheme().theme
+
+  return (
+    <box flexDirection="row" height={1} position="relative">
+      <text fg={theme.textMuted}>{"> "}</text>
+      <input
+        value={props.value}
+        onInput={props.input}
+        onSubmit={props.submit}
+        focused
+        flexGrow={1}
+        textColor={theme.backgroundElement}
+        cursorColor={theme.accent}
+        backgroundColor={theme.backgroundElement}
+        focusedBackgroundColor={theme.backgroundElement}
+      />
+      <box position="absolute" left={2} top={0} height={1}>
+        <text fg={theme.text} bg={theme.backgroundElement}>{"•".repeat(props.value.length)}</text>
+      </box>
+    </box>
+  )
+}

--- a/src/ui/toast.tsx
+++ b/src/ui/toast.tsx
@@ -15,13 +15,14 @@ import type { ReactNode } from "react"
 import { useTheme } from "../theme"
 import type { RGBA } from "@opentui/core"
 
-type ToastVariant = "info" | "error" | "warning" | "success"
+export type ToastVariant = "info" | "error" | "warning" | "success"
 
-type ToastOptions = {
+export type ToastOptions = {
+  readonly key?: string
   readonly variant: ToastVariant
   readonly title?: string
   readonly message: string
-  readonly duration?: number
+  readonly duration?: number | null
   /** Clickable affordance on the toast (e.g. "view" → open dialog). */
   readonly action?: { label: string; run: () => void }
 }
@@ -30,8 +31,9 @@ type ToastEntry = ToastOptions & {
   readonly id: number
 }
 
-type ToastContext = {
+export type ToastContext = {
   readonly show: (opts: ToastOptions) => void
+  readonly clear: (key: string) => void
   readonly error: (err: Error) => void
 }
 
@@ -50,19 +52,41 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
 
   const show = useCallback((opts: ToastOptions) => {
     const id = ++counter.current
-    setItems(prev => [...prev, { ...opts, id }])
+    setItems(prev => {
+      const drop = opts.key ? prev.filter(t => t.key === opts.key) : []
+      for (const item of drop) {
+        const t = timers.current.get(item.id)
+        if (t) clearTimeout(t)
+        timers.current.delete(item.id)
+      }
+      const next = opts.key ? prev.filter(t => t.key !== opts.key) : prev
+      return [...next, { ...opts, id }]
+    })
     const dur = opts.duration ?? DEFAULT_DURATION
+    if (dur === null) return
     timers.current.set(id, setTimeout(() => {
       timers.current.delete(id)
       setItems(prev => prev.filter(t => t.id !== id))
     }, dur))
   }, [])
 
+  const clear = useCallback((key: string) => {
+    setItems(prev => {
+      for (const item of prev) {
+        if (item.key !== key) continue
+        const t = timers.current.get(item.id)
+        if (t) clearTimeout(t)
+        timers.current.delete(item.id)
+      }
+      return prev.filter(t => t.key !== key)
+    })
+  }, [])
+
   const error = useCallback((err: Error) => {
     show({ variant: "error", title: "Error", message: err.message })
   }, [show])
 
-  const value = useMemo<ToastContext>(() => ({ show, error }), [show, error])
+  const value = useMemo<ToastContext>(() => ({ show, clear, error }), [show, clear, error])
 
   return (
     <Ctx.Provider value={value}>

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -976,6 +976,8 @@ describe("app", () => {
         model: "test-model", calls: 7, input: 1234, output: 567, total: 1801,
         cache_read: 0, cache_write: 0, cost_usd: 0.0412, cost_status: "estimated",
         context_used: 4200, context_max: 200_000, context_percent: 2,
+        credits_lines: ["Credits: 42 remaining", "Account: active"],
+        dev_credits_spent_micros: 123,
       }),
     })
     const t = await mount({ gw })
@@ -992,10 +994,33 @@ describe("app", () => {
     expect(f).toContain("$0.04")      // cost
     expect(f).toContain("2%")         // context percent
     expect(f).toContain("estimated")  // cost_status note
+    expect(f).toContain("Credits: 42 remaining")
+    expect(f).toContain("Account: active")
+    expect(f.indexOf("Credits: 42 remaining")).toBeLessThan(f.indexOf("Account: active"))
+    expect(f).not.toContain("123")
     expect(t.gw.last("slash.exec")).toBeUndefined() // intercepted locally
 
     act(() => t.keys.pressEscape())
     await until(t, () => !t.frame().includes("API calls"))
+    t.destroy()
+  })
+
+  test("/usage handles zero-call sessions without credits", async () => {
+    const gw = new MockGateway({
+      "session.usage": () => ({ calls: 0, credits_lines: [] }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/usage") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("API calls"))
+
+    const f = t.frame()
+    expect(f).toContain("Usage")
+    expect(f).toContain("API calls")
+    expect(f).toContain("0")
+    expect(f).toContain("Total")
     t.destroy()
   })
 

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1005,9 +1005,12 @@ describe("app", () => {
     t.destroy()
   })
 
-  test("/usage handles zero-call sessions without credits", async () => {
+  test("/usage renders credit lines when calls are zero", async () => {
     const gw = new MockGateway({
-      "session.usage": () => ({ calls: 0, credits_lines: [] }),
+      "session.usage": () => ({
+        calls: 0,
+        credits_lines: ["Credits: access paused", "Account: update billing"],
+      }),
     })
     const t = await mount({ gw })
     await until(t, () => t.frame().includes("Ready"))
@@ -1021,6 +1024,9 @@ describe("app", () => {
     expect(f).toContain("API calls")
     expect(f).toContain("0")
     expect(f).toContain("Total")
+    expect(f).toContain("Credits: access paused")
+    expect(f).toContain("Account: update billing")
+    expect(f.indexOf("Credits: access paused")).toBeLessThan(f.indexOf("Account: update billing"))
     t.destroy()
   })
 

--- a/test/config-models.test.tsx
+++ b/test/config-models.test.tsx
@@ -2,7 +2,7 @@ import { describe, test, expect } from "bun:test"
 import { act } from "react"
 import { mountNode, until, MockGateway } from "./harness"
 import { Config } from "../src/tabs/Config"
-import { readSlots, assign, resetAux, AUX_TASKS } from "../src/config/models"
+import { readSlots, assign, resetAux, AUX_TASKS, staleAuxForMain } from "../src/config/models"
 
 describe("config/models — slot projection + write lanes", () => {
   test("readSlots: main from model.*, aux from auxiliary.<task>.*", () => {
@@ -22,6 +22,19 @@ describe("config/models — slot projection + write lanes", () => {
     expect(c.auto).toBe(true)
     // Unconfigured slot → auto.
     expect(s.find(x => x.key === "curator")!.auto).toBe(true)
+  })
+
+  test("staleAuxForMain returns explicit aux slots pinned to another provider", () => {
+    const raw = {
+      model: { provider: "anthropic", default: "claude" },
+      auxiliary: {
+        vision: { provider: "google", model: "gemini" },
+        compression: { provider: "anthropic", model: "claude-haiku" },
+        session_search: { provider: "auto", model: "" },
+      },
+    }
+    const stale = staleAuxForMain(readSlots(raw), "anthropic")
+    expect(stale.map(s => s.key)).toEqual(["vision"])
   })
 
   test("assign(main) → rpc config.set key=model --global; assign(aux) → 2× cli.exec", async () => {
@@ -116,12 +129,16 @@ describe("Config → models category", () => {
     t.destroy()
   })
 
-  test("Enter on main slot opens picker; apply → rpc config.set --global", async () => {
-    const sets: unknown[] = []
+  test("main switch warns about stale aux pins and can reset them to auto", async () => {
+    const cli: string[][] = []
     const gw = new MockGateway({
       "config.get": () => ({ config: cfg }),
-      "model.options": () => opts,
-      "config.set": (p) => { sets.push(p); return { value: p.value } },
+      "model.options": () => ({
+        providers: [{ slug: "anthropic", name: "Anthropic", models: ["claude-opus-4.7"], total_models: 1 }],
+        provider: "openrouter", model: "anthropic/claude-opus-4.7",
+      }),
+      "config.set": () => ({}),
+      "cli.exec": (p) => { cli.push(p.argv as string[]); return { code: 0, output: "" } },
     })
     const t = await mountNode(<Config focused />, { gw, width: 160, height: 40 })
     await until(t, () => t.frame().includes("models (13)"))
@@ -129,14 +146,16 @@ describe("Config → models category", () => {
     act(() => t.keys.pressTab())
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Set main model"))
-    expect(t.frame()).not.toContain("Scope:")   // scope toggle hidden when onApply set
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("claude-opus-4.7"))
     act(() => t.keys.pressEnter())
-    await until(t, () => sets.length === 1)
-    expect(sets[0]).toMatchObject({
-      key: "model", value: "claude-opus-4.7 --provider anthropic --global",
-    })
+    await until(t, () => t.frame().includes("Auxiliary models still pinned to another provider"))
+    expect(t.frame()).toContain("Vision")
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => cli.length === 2)
+    expect(cli[0]).toEqual(["config", "set", "auxiliary.vision.provider", "auto"])
+    expect(cli[1]).toEqual(["config", "set", "auxiliary.vision.model", ""])
     t.destroy()
   })
 })

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -105,6 +105,30 @@ describe("mapEvent", () => {
     expect(calls).toEqual([text])
   })
 
+  test("notification events route to keyed notice controller", () => {
+    const seen: unknown[] = []
+    const notices = {
+      show: (o: unknown) => seen.push(["show", o]),
+      clear: (k: string) => seen.push(["clear", k]),
+      error: () => {},
+    }
+    const show = map({
+      type: "notification.show",
+      payload: { text: "Credit access paused", level: "error", kind: "sticky", key: "credits.depleted" },
+    }, { notices })
+    expect(show.action).toBeNull()
+    expect(seen[0]).toEqual(["show", {
+      key: "credits.depleted",
+      variant: "error",
+      message: "Credit access paused",
+      duration: null,
+    }])
+
+    const clear = map({ type: "notification.clear", payload: { key: "credits.depleted" } }, { notices })
+    expect(clear.action).toBeNull()
+    expect(seen[1]).toEqual(["clear", "credits.depleted"])
+  })
+
   test("formatProcessNotification preserves completion and watch-pattern shapes", () => {
     expect(formatProcessNotification(
       "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]",

--- a/test/hermes-home-sessions.test.ts
+++ b/test/hermes-home-sessions.test.ts
@@ -451,6 +451,22 @@ describe("lastReal() — compression chain walk", () => {
     expect(result?.message_count).toBe(4)
   })
 
+  test("returns zero-message tip when the chain has a real predecessor", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1000, {
+      ended_at: 2000, end_reason: "compression", message_count: 296,
+    })
+    sess(db, "tip", "tui", 2100, {
+      parent_session_id: "root", message_count: 0,
+    })
+    db.close()
+    resetDb()
+
+    const result = lastReal()
+    expect(result?.id).toBe("tip")
+    expect(result?.message_count).toBe(0)
+  })
+
   test("returns CLI session when no TUI sessions exist (CLI sessions are valid for herm -c)", () => {
     const db = seed()
     sess(db, "cli-sess", "cli", 1700000000, {

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -156,6 +156,18 @@ describe("useSession.boot", () => {
     expect(gw.last("session.resume")?.params.session_id).toBe("real")
   })
 
+  test("mode:resume targets zero-message compression tip", async () => {
+    const db = seed()
+    sess(db, "root", "tui", 1000, 296, { ended_at: 2000, end_reason: "compression" })
+    sess(db, "tip", "tui", 2100, 0, { parent_session_id: "root" })
+    db.close()
+    resetDb()
+
+    const gw = new MockGateway()
+    await boot(gw, { mode: "resume" })
+    expect(gw.last("session.resume")?.params.session_id).toBe("tip")
+  })
+
   test("mode:resume switches live model to the stored provider/model", async () => {
     const db = seed()
     sess(db, "past", "tui", 1005, 5, { model: "gpt-5.5", billing_provider: "openai-codex" })

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -82,6 +82,117 @@ describe("model-picker", () => {
     t.destroy()
   })
 
+  test("unauthenticated provider rows show setup metadata and do not advance to empty models", async () => {
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": () => ({
+          provider: "openai",
+          model: "gpt-4",
+          providers: [
+            { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
+            {
+              slug: "anthropic",
+              name: "Anthropic",
+              total_models: 0,
+              models: [],
+              authenticated: false,
+              auth_type: "api_key",
+              key_env: "ANTHROPIC_API_KEY",
+              warning: "paste ANTHROPIC_API_KEY to activate",
+            },
+          ],
+        }),
+      },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+    expect(t.frame()).toContain("Setup required")
+    expect(t.frame()).toContain("paste ANTHROPIC_API_KEY to activate")
+    expect(t.frame()).toContain("auth_type=")
+
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => t.frame().includes("Paste ANTHROPIC_API_KEY"))
+    expect(t.frame()).not.toContain("Switch Model (Anthropic)")
+    t.destroy()
+  })
+
+  test("api-key setup calls model.save_key and advances to refreshed models", async () => {
+    const saves: Array<Record<string, unknown>> = []
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": () => ({
+          providers: [
+            { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
+            {
+              slug: "anthropic",
+              name: "Anthropic",
+              total_models: 0,
+              models: [],
+              authenticated: false,
+              auth_type: "api_key",
+              key_env: "ANTHROPIC_API_KEY",
+              warning: "paste ANTHROPIC_API_KEY to activate",
+            },
+          ],
+        }),
+        "model.save_key": (p) => {
+          saves.push(p)
+          return {
+            provider: {
+              slug: "anthropic",
+              name: "Anthropic",
+              authenticated: true,
+              total_models: 1,
+              models: ["claude-opus"],
+            },
+          }
+        },
+      },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => t.frame().includes("Paste ANTHROPIC_API_KEY"))
+    await act(async () => { await t.keys.typeText("sk-test") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("claude-opus"))
+
+    expect(saves).toEqual([{ slug: "anthropic", api_key: "sk-test" }])
+    expect(t.frame()).toContain("Switch Model (Anthropic)")
+    t.destroy()
+  })
+
+  test("non-api-key unauthenticated providers warn without model.save_key", async () => {
+    const saves: Array<Record<string, unknown>> = []
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": () => ({
+          providers: [
+            { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
+            {
+              slug: "google-oauth",
+              name: "Google OAuth",
+              total_models: 0,
+              models: [],
+              authenticated: false,
+              auth_type: "oauth",
+              warning: "run `hermes model` to configure (oauth)",
+            },
+          ],
+        }),
+        "model.save_key": (p) => { saves.push(p); return {} },
+      },
+    })
+    await until(t, () => t.frame().includes("Google OAuth"))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => t.frame().includes("run `hermes model` to configure (oauth)"))
+
+    expect(saves).toHaveLength(0)
+    expect(t.frame()).not.toContain("Switch Model (Google OAuth)")
+    t.destroy()
+  })
+
   test("provider dialog leads with current provider and Enter selects it", async () => {
     const opts = {
       provider: "anthropic",

--- a/test/notifications.test.tsx
+++ b/test/notifications.test.tsx
@@ -1,0 +1,20 @@
+import { act } from "react"
+import { describe, expect, test } from "bun:test"
+import { mount, until } from "./harness"
+
+describe("notification events", () => {
+  test("sticky credit notice renders and keyed clear removes it", async () => {
+    const t = await mount({ width: 120, height: 32 })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.gw.push({
+      type: "notification.show",
+      payload: { text: "Credit access paused", level: "error", kind: "sticky", key: "credits.depleted" },
+    }))
+    await until(t, () => t.frame().includes("Credit access paused"))
+
+    act(() => t.gw.push({ type: "notification.clear", payload: { key: "credits.depleted" } }))
+    await until(t, () => !t.frame().includes("Credit access paused"))
+    t.destroy()
+  })
+})

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -194,6 +194,19 @@ describe("Sessions tab", () => {
     t.destroy()
   })
 
+  test("keeps 0-msg compression tips from state.db", async () => {
+    const disk = [detail({
+      id: "tip", sessionSource: "tui", title: "Compacted tip",
+      message_count: 0, started_at: 1700000000,
+      parent_session_id: "root", lineage_root_id: "root",
+    })]
+    const gw = new MockGateway({ "session.list": () => ({ sessions: [] }) })
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => disk }} />, { gw })
+    await until(t, () => t.frame().includes("Sessions (1)") && t.frame().includes("Compacted tip"))
+    expect(t.frame()).toContain("0")
+    t.destroy()
+  })
+
   test("sort: defaults to last-activity; Space toggles to started and persists", async () => {
     prefs.reset()
     // "Older Start Fresh Activity" should top "active" sort;


### PR DESCRIPTION
## Summary

Herm now renders the new credits/account information exposed by `session.usage`, including zero-call sessions, and handles gateway credit notices as keyed sticky or transient toasts instead of dropping them as unknown events.

The model picker now treats unauthenticated providers as setup-required rows, can collect API keys through a masked prompt, and Config warns when explicit auxiliary model slots remain pinned to a different provider after the main model changes.

| Area | Behavior |
| --- | --- |
| Usage | Preserves backend `credits_lines` order while keeping token, context, and cost rows intact. |
| Notices | Routes `notification.show` / `notification.clear` into keyed toasts with sticky duration support. |
| Models | Surfaces setup metadata, saves API keys through `model.save_key`, and offers stale-aux reset to auto. |

## Verification

- `bun install --frozen-lockfile`
- `bun test test/gatewayEvents.test.ts test/notifications.test.tsx test/app.test.tsx --timeout 30000 --test-name-pattern 'usage|notification'`
- `bun test test/model-picker.test.tsx test/config-models.test.tsx`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
