### PR TITLE
fix(kanban): route priority changes through select

### DIFF
--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -439,7 +439,7 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] 
               : "—",
             p.on && cur === "assignee" ? "Enter pick" : undefined)}
           {srow("priority", "Priority", d.priority ? `P${d.priority}` : "—",
-            p.on && cur === "priority" ? "↑↓ / Enter" : undefined)}
+            p.on && cur === "priority" ? "Enter select" : undefined)}
           {srow("status", "Status", d.status,
             p.on && cur === "status" ? "Enter change" : undefined)}
           {srow("parents", "Parents", d.parents.length ? d.parents.join(", ") : "—",
@@ -1158,14 +1158,6 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     if (f === "comment") return void comment(t)
   }, [editTitle, editBody, assign, editPriority, editStatus, editParents, editResult, comment])
 
-  // Bump priority with ↑↓ while the priority row is focused — no
-  // modal. Mirrors the new-task form affordance.
-  const bumpPriority = useCallback((t: Task, d: 1 | -1) => {
-    const next = Math.max(0, Math.min(9, t.priority + d))
-    if (next === t.priority) return
-    patchDirect(t.id, { priority: next }, `${t.id} → P${next}`)
-  }, [patchDirect])
-
   type Act = { key: string; title: string; when: (t?: Task) => boolean; run: (t?: Task) => void }
   const ACTS = useMemo<Act[]>(() => [
     { key: "n", title: "New task",      when: () => true,            run: () => void create() },
@@ -1214,13 +1206,11 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       if (!t || !paneOpen) return
       const f = paneFields[Math.min(paneSel, paneFields.length - 1)]
       if (key.name === "up") {
-        if (f === "priority") return bumpPriority(t, 1)
         const n = paneFields.length
         if (n === 0) return
         return setPaneSel(s => (s - 1 + n) % n)
       }
       if (key.name === "down") {
-        if (f === "priority") return bumpPriority(t, -1)
         const n = paneFields.length
         if (n === 0) return
         return setPaneSel(s => (s + 1) % n)

--- a/src/ui/dialog-select.tsx
+++ b/src/ui/dialog-select.tsx
@@ -2,10 +2,10 @@
  * Filterable select dialog — reusable pick-list for dialogs.
  *
  * Keyboard: list.* (↑↓/PgUp/PgDn/Home/End navigate, Enter selects), typing
- * filters. With `filterable: false`, Space also selects (the scrollbox has
- * focus so the filter input never sees it).
- * Mouse: hover highlights, click selects.
- * Grouped by category with headers.
+ * filters. With `filterable: false`, a native OpenTUI select owns ↑↓ and
+ * Space/Enter selects.
+ * Mouse: filterable lists support hover highlights and click selection.
+ * Grouped by category with headers when filterable.
  */
 
 import { useState, useMemo, useEffect, useRef } from "react"
@@ -57,6 +57,17 @@ export const DialogSelect = (props: Props) => {
   const moved = useRef(false)
   const sb = useRef<ScrollBoxRenderable | null>(null)
   const theme = useTheme().theme
+  const opts = useMemo(() => props.options.map(o => ({
+    name: `${props.current == null ? "" : o.value === props.current ? "● " : "  "}${o.title}`,
+    description: o.hint
+      ? [o.description, o.hint].filter(Boolean).join(" — ")
+      : o.description ?? "",
+    value: o.value,
+  })), [props.current, props.options])
+  const sel = props.current == null
+    ? 0
+    : Math.max(0, props.options.findIndex(o => o.value === props.current))
+  const desc = props.options.some(o => !!o.description || !!o.hint)
 
   const filtered = useMemo(() => {
     const lower = filter.toLowerCase()
@@ -106,19 +117,13 @@ export const DialogSelect = (props: Props) => {
   const keys = useKeys()
 
   useKeyboard((key) => {
-    // Space only selects in non-filterable mode (otherwise it's a literal
-    // space for the filter input). Drive through list.toggle so a rebind
-    // of space takes effect here too.
-    const onToggle = !filterable
-      ? () => { const item = filtered[cursor]; if (item) props.onSelect(item) }
-      : undefined
+    if (!filterable) return
     const consumed = handleListKey(keys, key, {
       count: filtered.length,
       setSel: (fn) => { mode.current = "kb"; moved.current = true; setCursor(fn) },
       scrollTo,
       page: Math.max(1, (sb.current?.viewport.height ?? 10) - 1),
       onActivate: () => { const item = filtered[cursor]; if (item) props.onSelect(item) },
-      onToggle,
     })
     if (consumed) return
     if (props.onKey?.(key)) return
@@ -127,6 +132,50 @@ export const DialogSelect = (props: Props) => {
   // Build flat list with index tracking
   let idx = 0
   const entries = Array.from(groups.entries())
+
+  if (!filterable) return (
+    <box flexDirection="column" width={60}>
+      <text fg={theme.text}>
+        <strong>{props.title}</strong>
+      </text>
+      <box height={1} />
+      <select
+        focused={true}
+        width={58}
+        height={Math.min(16, Math.max(1, props.options.length * (desc ? 2 : 1)))}
+        options={opts}
+        selectedIndex={sel}
+        showDescription={desc}
+        showScrollIndicator={props.options.length > 8}
+        backgroundColor={theme.backgroundPanel}
+        focusedBackgroundColor={theme.backgroundPanel}
+        textColor={theme.textMuted}
+        focusedTextColor={theme.text}
+        selectedBackgroundColor={theme.backgroundElement}
+        selectedTextColor={theme.text}
+        descriptionColor={theme.textMuted}
+        selectedDescriptionColor={theme.textMuted}
+        fastScrollStep={Math.max(1, props.options.length)}
+        keyBindings={[
+          { name: "home", action: "move-up-fast" },
+          { name: "end", action: "move-down-fast" },
+          { name: "pageup", action: "move-up-fast" },
+          { name: "pagedown", action: "move-down-fast" },
+          { name: "space", action: "select-current" },
+          { name: " ", action: "select-current" },
+        ]}
+        onChange={(i) => {
+          const item = props.options[i]
+          if (item && props.onMove) props.onMove(item)
+        }}
+        onSelect={(i) => {
+          const item = props.options[i]
+          if (item) props.onSelect(item)
+        }}
+      />
+      {props.footer != null ? <box paddingTop={1}>{props.footer}</box> : null}
+    </box>
+  )
 
   return (
     <box flexDirection="column" width={60}>

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -1090,12 +1090,18 @@ describe("Kanban detail pane", () => {
     t.destroy()
   })
 
-  test("Enter on priority row in pane → DialogSelect → direct write", async () => {
-    // Re-seed t1's priority so we have a known starting value.
+  test("priority row arrows navigate; Enter opens select and writes", async () => {
     const db = new Database(hermesPath("kanban.db"))
     db.run("UPDATE tasks SET priority = 3 WHERE id = 't1'")
     db.close()
     resetKanban()
+    const prio = () => {
+      const check = new Database(hermesPath("kanban.db"), { readonly: true })
+      const row = check.query("SELECT priority FROM tasks WHERE id = 't1'")
+        .get() as { priority: number }
+      check.close()
+      return row.priority
+    }
     const t = await mountNode(<Kanban focused />, { width: 180, height: 48 })
     await until(t, () => t.frame().includes("Kanban · 3 boards"))
     act(() => t.keys.pressArrow("right")); await t.settle()
@@ -1103,22 +1109,21 @@ describe("Kanban detail pane", () => {
     act(() => t.keys.pressArrow("right")); await t.settle()
     act(() => t.keys.pressEnter())
     await until(t, () => /Assignee\s+researcher/.test(t.frame()))
-    // Tab in, then Tab twice more (title → body → assignee → priority).
     act(() => t.keys.pressTab()); await t.settle()
     act(() => t.keys.pressTab()); await t.settle()
     act(() => t.keys.pressTab()); await t.settle()
     act(() => t.keys.pressTab()); await t.settle()
-    // Priority row shows its hint when focused.
-    await until(t, () => t.frame().includes("↑↓ / Enter"))
-    // ↑ bumps priority directly (patchTask path, no dialog).
+    await until(t, () => t.frame().includes("Enter select"))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    expect(prio()).toBe(3)
+    await until(t, () => t.frame().includes("Enter change"))
     act(() => t.keys.pressArrow("up")); await t.settle()
-    // Read back via a fresh RO handle — herm's internal cache is RW/RO
-    // split and the write went through the RW handle.
-    const check = new Database(hermesPath("kanban.db"), { readonly: true })
-    const row = check.query("SELECT priority FROM tasks WHERE id = 't1'")
-      .get() as { priority: number }
-    check.close()
-    expect(row.priority).toBe(4)
+    await until(t, () => t.frame().includes("Enter select"))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Priority for t1"))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => prio() === 4)
     t.destroy()
   })
 })


### PR DESCRIPTION
## Summary
- Kanban detail priority rows now leave ↑/↓ to pane navigation instead of mutating the task.
- Priority edits move behind the Enter-opened picker, using non-filterable OpenTUI select semantics for Space/Enter selection.
- Regression coverage verifies arrow navigation preserves the stored priority and selector confirmation writes the new value.

## Verification
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
