### PR TITLE
Fix branch auto-switch

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -517,7 +517,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   // Non-destructive: session.branch clones full history into a new
   // gateway session; undo N turns *in that session* to land at m;
-  // then switch. Original session is untouched.
+  // then activate the returned live session id. Original session is untouched.
   const fork = useCallback(async (m: Message) => {
     if (turnRef.current.streaming) return
     const n = turnsFrom(m)
@@ -527,11 +527,11 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     if (!res?.session_id) return
     for (let i = 0; i < n; i++)
       await gw.request("session.undo", { session_id: res.session_id }).catch(() => {})
-    await switchSession(res.session_id)
+    await activateSession(res.session_id)
     composer.current?.set(text)
     setFocusRegion("input")
     toast.show({ variant: "success", message: `forked → ${res.title ?? res.session_id}` })
-  }, [gw, toast, switchSession])
+  }, [gw, toast, activateSession])
 
   const msgMenu = useCallback((m: Message) => {
     if (turnRef.current.streaming) return
@@ -556,7 +556,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     dispatch, session, turnRef, queueRef, sendRef, composer, summoned, undone,
     capabilities, info, sid, title, skin,
     setQueue, setFocusRegion, setSplash, setAttachments, setInfo, setUsage, setTitle,
-    newSession, switchSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
+    newSession, switchSession, activateSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
   })
   const send = useCallback(async (raw: string) => {
     // Bare exit/quit/:q — pass through as literals so a

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -75,6 +75,7 @@ export type SlashCtx = {
 
   newSession: () => Promise<void>
   switchSession: (id: string) => Promise<void>
+  activateSession: (id: string) => Promise<void>
   rewind: (m: Message) => Promise<void>
   goTo: (tab: number, sub: number) => void
   attachClipboard: () => void
@@ -176,6 +177,13 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
       message: s.headline ?? `Compressed ${r.before_messages ?? 0}→${r.after_messages ?? 0} messages` })
   }, [toast])
 
+  const branch = useCallback((name?: string) => {
+    const x = ctx.current
+    x.session.branch(name?.trim() || undefined).then(id => id
+      ? void x.activateSession(id)
+      : toast.show({ variant: "error", message: "branch failed" }))
+  }, [toast])
+
   const run = useCallback((c: SlashCommand, arg = "") => {
     const x = ctx.current
     if (c.target === "local") {
@@ -239,9 +247,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           if (arg) { void x.switchSession(arg); return }
           x.goTo(TAB_SLASH.sessions.tab, TAB_SLASH.sessions.sub); return
         case "branch":
-          x.session.branch(arg || undefined).then(id => id
-            ? void x.switchSession(id)
-            : toast.show({ variant: "error", message: "branch failed" }))
+          branch(arg)
           return
         case "compress": void runCompress(); return
         case "undo":
@@ -506,7 +512,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           })
           .catch((e: Error) => x.dispatch({ kind: "system", text: `error: ${e.message}` }))
       })
-  }, [gw, dialog, toast, themeCtx, renderer, destructive, applyTitle, runCompress])
+  }, [gw, dialog, toast, themeCtx, renderer, destructive, applyTitle, runCompress, branch])
 
   // Palette entries. Closures read through `ctx.current` so the effect
   // runs once (cmd is a stable context value) instead of re-registering
@@ -545,8 +551,8 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
     { title: "Redo", value: "redo", action: "session.redo", category: "Session",
       onSelect: () => run({ name: "redo", target: "local" } as SlashCommand) },
     { title: "Branch Session", value: "branch", description: "Fork the current conversation", category: "Session",
-      onSelect: () => ctx.current.session.branch() },
-  ]), [cmd, dialog, themeCtx, gw, toast, destructive, pickEikon, runCompress, run])
+      onSelect: () => branch() },
+  ]), [cmd, dialog, themeCtx, gw, toast, destructive, pickEikon, runCompress, branch, run])
 
   return run
 }

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -77,6 +77,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "quit",   description: "Exit herm",                             category: "Exit",    aliases: ["exit"], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "branch", description: "Fork current conversation",              category: "Session", aliases: ["fork"], argsHint: "[name]", subcommands: [], source: "local", target: "local" },
   { name: "browser", description: "Connect/disconnect a CDP browser",      category: "Session", aliases: [], argsHint: "[connect|disconnect|status] [url]", subcommands: ["connect", "disconnect", "status"], source: "local", target: "local" },
 ]
 

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -611,6 +611,34 @@ describe("app", () => {
     t.destroy()
   })
 
+  test("/branch activates the live branch session id", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/branch", "Branch current session"]] }),
+      "session.branch": () => ({ session_id: "live-branch", title: "Branch 1" }),
+      "session.resume": () => { throw new Error("session not found") },
+      "session.activate": p => ({
+        session_id: p.session_id,
+        session_key: "stored-branch",
+        status: "idle",
+        info: { model: "branch-model", session_id: p.session_id, tools: {}, skills: {} },
+        messages: [{ role: "user", text: "branch seed" }],
+      }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/branch") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("session.activate") !== undefined)
+
+    expect(t.gw.last("session.branch")?.params.session_id).toBe("test-sid")
+    expect(t.gw.last("session.activate")?.params.session_id).toBe("live-branch")
+    expect(t.gw.last("session.resume")).toBeUndefined()
+    expect(t.frame()).toContain("branch seed")
+    expect(t.frame()).not.toContain("Failed to resume")
+    t.destroy()
+  })
+
   test("send() routes arg-bearing slash via resolve(): unique prefix, gateway arg, ambiguous, miss", async () => {
     const t = await mount({ handlers: {
       "commands.catalog": () => ({
@@ -873,10 +901,10 @@ describe("app", () => {
     t.destroy()
   })
 
-  test("action menu → Fork → session.branch + undo-in-branch + switch", async () => {
+  test("action menu → Fork → session.branch + undo-in-branch + activate", async () => {
     const gw = new MockGateway({
       "session.branch": () => ({ session_id: "branch-sid", title: "branch 1" }),
-      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+      "session.activate": p => ({ session_id: p.session_id, messages: [], status: "idle" }),
     })
     const t = await mount({ gw })
     await until(t, () => t.frame().includes("Ready"))
@@ -905,8 +933,8 @@ describe("app", () => {
     // Undo targets the BRANCH session, not the original.
     const u = t.gw.calls.find(c => c.method === "session.undo")
     expect(u?.params.session_id).toBe("branch-sid")
-    // Switched into it.
-    expect(t.gw.last("session.resume")?.params.session_id).toBe("branch-sid")
+    // Activated the returned live runtime session id.
+    expect(t.gw.last("session.activate")?.params.session_id).toBe("branch-sid")
     // Composer seeded.
     expect(t.frame()).toContain("> seed q")
     t.destroy()


### PR DESCRIPTION
## Summary
- Activates the live runtime session returned by `session.branch` instead of trying to resume it as a stored session key.
- Uses the same activation path for `/branch`, the Branch Session palette action, and message-action Fork.
- Adds `/branch` fallback slash metadata plus regression coverage for the live-session activation path.

## Verification
- `bunx tsc --noEmit`
- `bun test` (1208 pass, 0 fail)
- `bun run build`
- `timeout 3 bun run dist/index.js --help`
