### PR TITLE
fix(session): preserve watchers on session switch

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -350,10 +350,11 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     // explicitly, so it isn't affected by the clear.
     gw.setSession("")
     setSid("")
-    // Close the outgoing session so the gateway finalizes it (ends the
-    // DB row, reaps its slash_worker subprocess, drops the AIAgent from
-    // `_sessions`). Fire-and-forget — create() doesn't depend on it.
-    if (prev) void session.close(prev)
+    // Close the outgoing session unless it owns a durable background process.
+    // Older gateways kill terminal(background=true) children as part of
+    // session.close; preserving the live session is safer than SIGTERM'ing a
+    // watcher while /new creates the next conversation.
+    if (prev) void session.close(prev, { preserveBackground: true })
     try {
       const r = await session.create()
       setSid(r.id)
@@ -389,7 +390,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       // user in the outgoing session, which must stay live. Skip when
       // resuming self (prev === res.id), e.g. the boot path reusing an
       // empty stub.
-      if (prev && prev !== res.id) void session.close(prev)
+      if (prev && prev !== res.id) void session.close(prev, { preserveBackground: true })
       setSplash(false)
       summoned.current = false
     } catch (err) {

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -45,6 +45,8 @@ export type CompressResult = {
 type Booted = { id: string; messages: Message[]; note?: string; info?: SessionInfo }
 type Resumed = { id: string; messages: Message[]; info?: SessionInfo }
 type Activated = { id: string; messages: Message[]; info?: SessionInfo; running: boolean; status?: string; startedAt?: number }
+type Agents = { processes?: Array<{ status?: string }> }
+type Close = { preserveBackground?: boolean }
 
 export const normalize = (sid: string): string =>
   sid.trim().replace(/\.json$/i, "").replace(/^session_(?=\d{8}_)/, "")
@@ -56,7 +58,7 @@ type SessionOps = {
   resume: (sid: string) => Promise<Resumed>
   activate: (sid: string) => Promise<Activated>
   /** Finalize a gateway session (best-effort — swallows errors). */
-  close: (sid: string) => Promise<void>
+  close: (sid: string, opts?: Close) => Promise<boolean>
   interrupt: () => Promise<void>
   branch: (name?: string) => Promise<string | null>
   compress: () => Promise<CompressResult | null>
@@ -131,10 +133,26 @@ export function useSession(): SessionOps {
   // useSessionLifecycle.closeSession. Pass `session_id` explicitly so
   // auto-injection doesn't close whatever sid the gateway already
   // switched to.
-  const close = useCallback(async (sid: string) => {
-    if (!sid) return
-    try { await gw.request("session.close", { session_id: sid }) } catch {}
+  const busy = useCallback(async () => {
+    try {
+      const res = await gw.request<Agents>("agents.list")
+      return res.processes?.some(p => p.status === "running") ?? false
+    } catch { return false }
   }, [gw])
+
+  const close = useCallback(async (sid: string, opts?: Close) => {
+    if (!sid) return false
+    // Hermes Agent's session.close tears down the AIAgent, which also kills
+    // terminal(background=true) processes owned by that agent. The gateway
+    // only exposes a global agents.list summary today, not owner session keys,
+    // so preserve the outgoing live session while any durable process is
+    // running rather than risking SIGTERM on a watcher during session switch.
+    if (opts?.preserveBackground && await busy()) return false
+    try {
+      await gw.request("session.close", { session_id: sid })
+      return true
+    } catch { return false }
+  }, [gw, busy])
 
   const boot = useCallback(async (launch: Launch): Promise<Booted> => {
     const fresh = async (note?: string) => ({ ...(await create()), messages: [], note })

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -105,7 +105,9 @@ export function useStream(c: Ctx) {
   const handle = useCallback((ev: GatewayEvent) => {
     const x = ctx.current
     if (ev.type === "gateway.ready") info.current = false
-    if (ev.session_id && x.sidRef.current && ev.session_id !== x.sidRef.current && !ev.type.startsWith("gateway.")) return
+    const shared = ev.type === "background.complete" ||
+      (ev.type === "status.update" && ev.payload?.kind === "process")
+    if (ev.session_id && x.sidRef.current && ev.session_id !== x.sidRef.current && !ev.type.startsWith("gateway.") && !shared) return
     // The agent's stream-retry loop (run_agent._call) classifies the
     // force-closed httpx socket from an interrupt as a transient drop
     // and emits "Reconnecting…" lifecycle status before the top-of-loop

--- a/test/live-session-events.test.tsx
+++ b/test/live-session-events.test.tsx
@@ -31,4 +31,25 @@ describe("live session event routing", () => {
     expect(t.frame()).not.toContain("Ready")
     t.destroy()
   })
+
+  test("surfaces sibling process notifications while stream events stay scoped", async () => {
+    const gw = new MockGateway({
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "sid-b", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.gw.push({
+      type: "status.update",
+      session_id: "sid-a",
+      payload: {
+        kind: "process",
+        text: "Background process proc_watch completed (exit code 0).\nCommand: watch-kanban",
+      },
+    }))
+    await until(t, () => t.frame().includes("proc_watch exited 0"))
+
+    expect(t.frame()).toContain("watch-kanban")
+    t.destroy()
+  })
 })

--- a/test/session-close.test.tsx
+++ b/test/session-close.test.tsx
@@ -1,9 +1,10 @@
-// Regression: /new and session-switch must finalize the outgoing
-// gateway session via session.close. Without it the gateway leaks one
-// slash_worker subprocess + one live AIAgent per hop and leaves the
-// DB row's `ended_at IS NULL`, which breaks lineage classification
-// (sessions-db.ts SUB/CONT predicates) until quit. Parity with Ink
-// TUI's useSessionLifecycle.closeSession.
+// Regression: /new and session-switch finalize idle outgoing gateway
+// sessions via session.close. Without it the gateway leaks one slash_worker
+// subprocess + one live AIAgent per hop and leaves the DB row's
+// `ended_at IS NULL`, which breaks lineage classification until quit.
+// A running background process is the exception: older gateways kill
+// terminal(background=true) children from session.close, so Herm preserves
+// that live session instead of SIGTERM'ing a watcher.
 
 import { afterAll, describe, expect, test } from "bun:test"
 import { act } from "react"
@@ -74,6 +75,49 @@ describe("session.close", () => {
     const ci = gw.calls.findIndex(c => c.method === "session.close")
     expect(ri).toBeGreaterThan(-1)
     expect(ci).toBeGreaterThan(ri)
+
+    t.destroy()
+  })
+
+  test("switchSession preserves prev while a background process runs", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "agents.list": () => ({ processes: [
+        { session_id: "proc_watch", command: "watch", status: "running", uptime: 1 },
+      ] }),
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "first", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/resume second") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.last("agents.list") !== undefined)
+
+    expect(gw.calls.some(c => c.method === "session.resume" && c.params.session_id === "second")).toBe(true)
+    expect(t.gw.last("session.close")).toBeUndefined()
+
+    t.destroy()
+  })
+
+  test("/new preserves prev while a background process runs", async () => {
+    let n = 0
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/new", "new session"]] }),
+      "agents.list": () => ({ processes: [
+        { session_id: "proc_watch", command: "watch", status: "running", uptime: 1 },
+      ] }),
+      "session.create": () => ({ session_id: `sid-${++n}` }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/new now") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.calls.filter(c => c.method === "session.create").length >= 2)
+    await until(t, () => gw.last("agents.list") !== undefined)
+
+    expect(t.gw.last("session.close")).toBeUndefined()
 
     t.destroy()
   })


### PR DESCRIPTION
Summary
- Guard outgoing session close on /new and historical resume when running background processes exist, preserving the live session instead of tearing down watchers.
- Surface process/background completion notifications across session focus changes while keeping sibling stream events scoped.
- Add regression coverage for guarded close and cross-session process notices.

Verification
- PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test test/session-close.test.tsx test/live-session-events.test.tsx
- PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit
- PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test