### PR TITLE
Fix active session rename

### DIFF
--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -832,17 +832,24 @@ export const Sessions = memo((props: Props) => {
     })
     if (name === null) return
     Promise.resolve()
-      .then(() => {
-        if (!io.rename(r.id, name)) throw new Error("not found")
+      .then(async () => {
+        const title = r.live
+          ? (await gw.request<{ title?: string }>("session.title", { session_id: r.id, title: name })).title ?? name
+          : name
+        if (!r.live && !io.rename(r.id, title)) throw new Error("not found")
+        const ids = [r.id, r.live?.session_key].filter((id): id is string => Boolean(id))
         home.invalidate("recentSessions")
         // Patch in place so the row updates without a full RPC reload
         // (session.list is the slow path). reload still happens next r.
-        setRows(prev => prev.map(row => row.id === r.id ? { ...row, title: name } : row))
+        setRows(prev => prev.map(row => ids.includes(row.id) ? { ...row, title } : row))
+        setLiveRows(prev => prev.map(row => row.id === r.id
+          ? { ...row, title, live: row.live ? { ...row.live, title } : row.live }
+          : row))
         toast.show({ variant: "success", message: "Renamed" })
       })
       .catch((e: Error) =>
         toast.show({ variant: "error", message: `Rename failed: ${e.message}` }))
-  }, [dialog, toast, sel])
+  }, [gw, dialog, toast, sel])
 
   const count = searching ? results.length : visible.length
   // Stable ids — include row.id + indent flag so a row moving between

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -127,6 +127,35 @@ describe("Sessions tab", () => {
     t.destroy()
   })
 
+  test("Ctrl+R renames active session via session.title", async () => {
+    const calls: Array<[string, string]> = []
+    const gw = new MockGateway({
+      "session.active_list": () => ({ sessions: [
+        { id: "live-past", session_key: "past", title: "Past Root", preview: "hello", message_count: 2, started_at: 1700000000, status: "idle" },
+      ]}),
+      "session.list": () => ({ sessions: [
+        { id: "past", title: "Past Root", preview: "hello", message_count: 2, started_at: 1700000000, source: "tui" },
+      ]}),
+      "session.title": p => ({ title: p.title }),
+    })
+    const disk = [detail({ id: "past", sessionSource: "tui", title: "Past Root", message_count: 2, started_at: 1700000000 })]
+    const rename = (sid: string, title: string) => { calls.push([sid, title]); return false }
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => disk, rename }} currentId="live-past" />, { gw, width: 120 })
+    await until(t, () => t.frame().includes("Sessions (1)") && t.frame().includes("Past Root"))
+
+    act(() => t.keys.pressKey("r", { ctrl: true }))
+    await until(t, () => t.frame().includes("Rename: Past Root"))
+    await act(async () => { await t.keys.pressKey("u", { ctrl: true }) })
+    for (const c of "Renamed Active") await act(async () => { await t.keys.typeText(c) })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Renamed Active"))
+
+    expect(gw.last("session.title")?.params).toEqual({ session_id: "live-past", title: "Renamed Active" })
+    expect(calls).toEqual([])
+    expect(t.frame()).not.toContain("Past Root")
+    t.destroy()
+  })
+
   test("lists from session.list RPC and switches on Enter", async () => {
     const gw = new MockGateway({ "session.list": () => ({ sessions: ROWS }) })
     let switched = ""


### PR DESCRIPTION
## Summary
- Routes active session renames through `session.title` so live runtime IDs resolve through the gateway.
- Keeps persisted history rows on the local DB rename path.
- Patches active and history row state after rename so the visible title updates immediately.

## Verification
- `bunx tsc --noEmit`
- `bun test` (1209 pass)
- `bun run build`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This is a local TUI interaction fix covered by regression tests.
