### PR TITLE
fix(sidebar): refresh session title display

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -116,7 +116,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [usage, setUsage] = useState<Usage | undefined>(undefined)
   const [info, setInfo] = useState<SessionInfo | null>(null)
   const [title, setTitle] = useState("")
-  const titleRef = useRef(title); titleRef.current = title
+  const caption = title.trim()
+  const titleRef = useRef(caption); titleRef.current = caption
   // Real SIGINT (terminal multiplexer, focus-stolen widget, kernel-delivered
   // ctrl+c that bypasses the React keyboard tree) goes through the same
   // quit() path as /quit so the resume banner always lands. Replaces the
@@ -555,7 +556,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const sendRef = useRef<(raw: string) => void>(() => {})
   const slash = useSlash({
     dispatch, session, turnRef, queueRef, sendRef, composer, summoned, undone,
-    capabilities, info, sid, title, skin,
+    capabilities, info, sid, title: caption, skin,
     setQueue, setFocusRegion, setSplash, setAttachments, setInfo, setUsage, setTitle,
     newSession, switchSession, activateSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
   })
@@ -563,7 +564,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     // Bare exit/quit/:q — pass through as literals so a
     // reflex `exit⏎` works without the leading slash.
     if (["exit", "quit", ":q", ":q!", ":wq"].includes(raw.trim()))
-      return quit(renderer, sid, title, gw)
+      return quit(renderer, sidRef.current, titleRef.current, gw)
     // Slash-shaped input resolves against the merged catalog: exact
     // name/alias wins, else unique prefix. This covers the "typed with
     // arg" path the popover can't — e.g. `/mod gpt-4`, `/q follow-up`.
@@ -715,7 +716,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     // the head once turn.streaming flips false.
     queued: queue.length,
     onFlushQueue: stream.doInterrupt,
-    onQuit: () => quit(renderer, sid, title, gw),
+    onQuit: () => quit(renderer, sid, caption, gw),
     onQuitArm: (label) =>
       toast.show({ variant: "info", message: `${label} again to quit` }),
     onInterruptNotice: () => {
@@ -867,7 +868,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           {sidebarVisible ? (
             <Profiler id="sidebar" onRender={perf.onRender}>
               <Sidebar agentState={agentState} info={info} usage={usage} eikon={eikon} profile={activeProfileName()}
-                       title={title}
+                       title={caption}
                        preview={sidebarPreview}
                        cloud={tab === 0 && cloud} pulse={turn.streaming}
                        onAvatar={onAvatar} onAvatarHold={onAvatarHold} />

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -3,7 +3,7 @@
 // calls out to. Pulled from AppInner so the shell only wires setters.
 
 import type React from "react"
-import { useCallback, useRef, type RefObject } from "react"
+import { useCallback, useEffect, useRef, type RefObject } from "react"
 import * as spawnHistory from "./spawnHistory"
 import * as preferences from "../context/preferences"
 import { useGateway, useGatewayEvent } from "../context/gateway"
@@ -46,6 +46,7 @@ const STREAM_EVENTS = new Set<GatewayEvent["type"]>([
   "message.delta", "reasoning.delta", "reasoning.available", "thinking.delta",
   "tool.start", "tool.progress", "tool.generating",
 ])
+const TITLE_DELAYS = [1200, 5000, 15000, 30000] as const
 
 export function useStream(c: Ctx) {
   const gw = useGateway()
@@ -53,6 +54,12 @@ export function useStream(c: Ctx) {
   const toast = useToast()
   const bg = useBackground()
   const ctx = useRef(c); ctx.current = c
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([])
+
+  useEffect(() => () => {
+    timers.current.forEach(clearTimeout)
+    timers.current = []
+  }, [])
 
   // Client-side interrupt latch: flipped on Esc×2 before the gateway
   // has confirmed the stop. Stream-mutation events still in the stdio
@@ -102,6 +109,21 @@ export function useStream(c: Ctx) {
     })
   }, [])
 
+  const sync = useCallback((ms = 0) => {
+    const run = () => gw.request<{ title?: string; session_key?: string }>("session.title")
+      .then(r => {
+        ctx.current.setTitle(r.title ?? "")
+        if (r.session_key) preferences.set("lastSessionId", r.session_key)
+      })
+      .catch(() => {})
+    if (ms <= 0) return run()
+    const id = setTimeout(() => {
+      timers.current = timers.current.filter(t => t !== id)
+      run()
+    }, ms)
+    timers.current.push(id)
+  }, [gw])
+
   const handle = useCallback((ev: GatewayEvent) => {
     const x = ctx.current
     if (ev.type === "gateway.ready") info.current = false
@@ -136,10 +158,7 @@ export function useStream(c: Ctx) {
           kind: "system",
           text: `MCP: ${bad.length} server(s) failed to connect — ${bad.map(s => s.name + (s.error ? ` (${s.error})` : "")).join(", ")}`,
         })
-        gw.request<{ title: string; session_key?: string }>("session.title").then(r => {
-          x.setTitle(r.title ?? "")
-          if (r.session_key) preferences.set("lastSessionId", r.session_key)
-        }).catch(() => {})
+        sync()
         gw.request<{ value?: string }>("config.get", { key: "busy" }).then(r => {
           const m = r.value
           if (m === "queue" || m === "steer" || m === "interrupt") x.setBusy(m)
@@ -150,6 +169,7 @@ export function useStream(c: Ctx) {
         x.setStatus("")
         spawnHistory.flush(gw, x.sidRef.current)
         x.goalHook.check(x.sidRef.current)
+        TITLE_DELAYS.forEach(sync)
       },
       onBackground: (tid, text) => {
         bg.unregister(tid)

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -606,6 +606,7 @@ describe("app", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Title: my overnight run")) // system line
 
+    expect(t.frame()).toMatch(/Title\s+my overnight run/)
     expect(t.gw.last("session.title")?.params.title).toBe("my overnight run")
     expect(t.gw.last("prompt.submit")).toBeUndefined() // intercepted
     t.destroy()
@@ -636,6 +637,19 @@ describe("app", () => {
     expect(t.gw.last("session.resume")).toBeUndefined()
     expect(t.frame()).toContain("branch seed")
     expect(t.frame()).not.toContain("Failed to resume")
+    t.destroy()
+  })
+
+  test("sidebar title stays unset until a session title exists", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("quick title seed") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    expect(t.frame()).toMatch(/Title\s+—/)
+    expect(t.frame()).not.toMatch(/Title\s+quick title seed/)
     t.destroy()
   })
 


### PR DESCRIPTION
## Summary
- Keeps the sidebar Title row tied to the canonical session title instead of stale local state.
- Refreshes the session title after turns so async auto-title generation can populate the sidebar when it becomes available.
- Leaves the Title row on its placeholder until a real session title exists.

## Verification
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun install --frozen-lockfile`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test test/app.test.tsx test/sidebar.test.tsx` → 52 pass, 0 fail
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
- `git diff --check`
