### PR TITLE
feat(theme): add light mode toggle

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -198,7 +198,17 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             { title: "Start a new session?", body: "Ends the current session and starts a fresh one. The existing session remains saved and resumable.", yes: "new session" },
             () => { void x.newSession() })
           return
-        case "theme": openThemePicker(dialog, themeCtx); return
+        case "theme": {
+          const mode = arg.trim().toLowerCase()
+          if (!mode) { openThemePicker(dialog, themeCtx); return }
+          if (mode === "light" || mode === "dark") {
+            themeCtx.setMode(mode)
+            x.dispatch({ kind: "system", text: `theme mode → ${mode}` })
+            return
+          }
+          toast.show({ variant: "error", message: "usage: /theme [light|dark]" })
+          return
+        }
         case "help": dialog.replace(<HelpDialog />); return
         case "keys": openKeys(dialog); return
         case "logs": openLogs(dialog); return

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -54,7 +54,7 @@ export const LOCAL_NAMES = new Set([
 export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "clear", description: "Clear chat messages",       category: "Client", aliases: [],       argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "new",   description: "Start a new session",        category: "Client", aliases: ["reset"], argsHint: "", subcommands: [], source: "local", target: "local" },
-  { name: "theme", description: "Switch color theme",         category: "Client", aliases: [],       argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "theme", description: "Switch color theme or mode", category: "Client", aliases: [],       argsHint: "[light|dark]", subcommands: [], source: "local", target: "local" },
   { name: "help",  description: "Show keyboard shortcuts",    category: "Client", aliases: [],       argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "keys",  description: "Rebind keyboard shortcuts",  category: "Client", aliases: [],       argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "logs",  description: "Show gateway stderr log",    category: "Client", aliases: [],       argsHint: "", subcommands: [], source: "local", target: "local" },

--- a/src/context/preferences.ts
+++ b/src/context/preferences.ts
@@ -23,6 +23,8 @@ interface TuiPreferences {
   $schema?: string
   /** Theme name — must match a built-in or custom theme */
   theme?: string
+  /** Theme palette mode */
+  themeMode?: "dark" | "light"
   /** Mouse capture enabled */
   mouse?: boolean
   /** Target render FPS */

--- a/src/dialogs/theme-picker.tsx
+++ b/src/dialogs/theme-picker.tsx
@@ -27,6 +27,26 @@ const ThemePickerDialog = ({ onConfirm }: { onConfirm: () => void }) => {
     dialog.clear()
   }, [ctx, dialog, onConfirm])
 
+  const flip = useCallback(() => {
+    ctx.setMode(ctx.mode === "dark" ? "light" : "dark")
+  }, [ctx])
+
+  const onKey = useCallback((key: { name: string }) => {
+    if (key.name !== "tab") return false
+    flip()
+    return true
+  }, [flip])
+
+  const footer = (
+    <box height={1} onMouseDown={flip}>
+      <text fg={ctx.theme.textMuted}>
+        <span>Mode: </span>
+        <span fg={ctx.mode === "light" ? ctx.theme.warning : ctx.theme.accent}>{ctx.mode}</span>
+        <span> · Tab/click: toggle</span>
+      </text>
+    </box>
+  )
+
   return (
     <DialogSelect
       title="Switch Theme"
@@ -34,7 +54,9 @@ const ThemePickerDialog = ({ onConfirm }: { onConfirm: () => void }) => {
       current={ctx.name}
       onSelect={onSelect}
       onMove={onMove}
+      onKey={onKey}
       placeholder="Search themes..."
+      footer={footer}
     />
   )
 }
@@ -42,9 +64,14 @@ const ThemePickerDialog = ({ onConfirm }: { onConfirm: () => void }) => {
 /** Open the theme picker, reverting on close without selection */
 export const openThemePicker = (dialog: ReturnType<typeof useDialog>, ctx: ReturnType<typeof useTheme>) => {
   const saved = ctx.name
+  const mode = ctx.mode
   let confirmed = false
   dialog.replace(
     <ThemePickerDialog onConfirm={() => { confirmed = true }} />,
-    () => { if (!confirmed) ctx.set(saved) }
+    () => {
+      if (confirmed) return
+      ctx.set(saved)
+      ctx.setMode(mode)
+    }
   )
 }

--- a/src/plugins/api.tsx
+++ b/src/plugins/api.tsx
@@ -24,6 +24,7 @@ type ThemeSnap = {
   name: string
   mode: "dark" | "light"
   set: (name: string) => boolean
+  setMode: (mode: "dark" | "light") => void
   has: (name: string) => boolean
 }
 
@@ -74,6 +75,7 @@ export function createApi(input: ApiInput): HermPluginApi {
       get name() { return input.theme.current.name },
       get mode() { return input.theme.current.mode },
       set: name => input.theme.current.set(name),
+      setMode: mode => input.theme.current.setMode(mode),
       has: name => input.theme.current.has(name),
     },
     get keys() { return input.keys.current },

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -61,6 +61,7 @@ export type HermPluginApi = {
     readonly name: string
     readonly mode: "dark" | "light"
     set(name: string): boolean
+    setMode(mode: "dark" | "light"): void
     has(name: string): boolean
   }
   readonly keys: Keys

--- a/src/theme/context.tsx
+++ b/src/theme/context.tsx
@@ -6,7 +6,7 @@
  *   <ThemeProvider><App /></ThemeProvider>
  *
  *   // In any component:
- *   const { theme, name, set, names } = useTheme();
+ *   const { theme, name, mode, set, setMode, names } = useTheme();
  *   <box backgroundColor={theme.backgroundPanel}>
  *   <text fg={theme.text}>
  */
@@ -33,6 +33,8 @@ interface ThemeContext {
   mode: "dark" | "light"
   /** Switch to a theme by name. Returns false if not found. */
   set: (name: string) => boolean
+  /** Switch between dark and light variants. */
+  setMode: (mode: "dark" | "light") => void
   /** All available theme names, sorted */
   names: readonly string[]
   /** Check if a theme exists */
@@ -60,8 +62,9 @@ export const ThemeProvider = ({
   // install); production passes initial=prefs.theme so they agree at
   // boot and the pref drives thereafter.
   const pref = preferences.usePref("theme")
+  const modePref = preferences.usePref("themeMode")
   const active = pref ?? initial ?? DEFAULT_THEME
-  const [mode] = useState(initialMode)
+  const mode = modePref === "light" || modePref === "dark" ? modePref : initialMode
   const [tick, force] = useState(0)
 
   // Theme bodies load lazily — each call to `set(name)` triggers an
@@ -99,6 +102,10 @@ export const ThemeProvider = ({
     return true
   }, [])
 
+  const setMode = useCallback((mode: "dark" | "light") => {
+    preferences.set("themeMode", mode)
+  }, [])
+
   const has = useCallback((name: string) => THEMES_SET.has(name), [])
 
   const syntaxStyle = useMemo(
@@ -114,10 +121,11 @@ export const ThemeProvider = ({
       name: active,
       mode,
       set,
+      setMode,
       names: THEME_NAMES,
       has,
     }
-  }, [resolved, syntaxStyle, active, mode, set, has])
+  }, [resolved, syntaxStyle, active, mode, set, setMode, has])
 
   if (!value) return null
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { mount as mountApp, until, MockGateway } from "./harness"
+import { tmpHome } from "./fixture/home"
 import * as prefs from "../src/context/preferences"
 import * as exit from "../src/app/exit"
 import { DOUBLE_TAB_MS, QUIT_MS } from "../src/app/useAppKeys"
@@ -610,6 +611,23 @@ describe("app", () => {
     expect(t.gw.last("session.title")?.params.title).toBe("my overnight run")
     expect(t.gw.last("prompt.submit")).toBeUndefined() // intercepted
     t.destroy()
+  })
+
+  test("/theme light|dark sets theme mode locally", async () => {
+    await using h = await tmpHome({ prefs: { theme: "tokyonight", themeMode: "dark" } })
+    await using t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/theme light") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("theme mode → light"))
+    expect(prefs.get("themeMode")).toBe("light")
+    expect(t.gw.last("prompt.submit")).toBeUndefined()
+
+    await act(async () => { await t.keys.typeText("/theme dark") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("theme mode → dark"))
+    expect(prefs.get("themeMode")).toBe("dark")
   })
 
   test("/branch activates the live branch session id", async () => {

--- a/test/theme-picker.test.tsx
+++ b/test/theme-picker.test.tsx
@@ -2,11 +2,12 @@ import { test, expect } from "bun:test"
 import { createRef } from "react"
 import { act } from "react"
 import { mountNode, until } from "./harness"
+import { tmpHome } from "./fixture/home"
 import { openThemePicker } from "../src/dialogs/theme-picker"
 import { useDialog } from "../src/ui/dialog"
 import { useTheme } from "../src/theme"
 
-type Handle = { open: () => void; theme: () => string }
+type Handle = { open: () => void; theme: () => string; mode: () => "dark" | "light" }
 
 const Probe = ({ handle }: { handle: React.RefObject<Handle | null> }) => {
   const dialog = useDialog()
@@ -14,6 +15,7 @@ const Probe = ({ handle }: { handle: React.RefObject<Handle | null> }) => {
   handle.current = {
     open: () => openThemePicker(dialog, ctx),
     theme: () => ctx.name,
+    mode: () => ctx.mode,
   }
   return <text>{"probe"}</text>
 }
@@ -40,4 +42,27 @@ test("theme picker: open + navigate does not loop, preview applies", async () =>
   act(() => t.keys.pressEscape())
   await until(t, () => !t.frame().includes("Switch Theme"))
   expect(handle.current!.theme()).toBe(before)
+})
+
+test("theme picker: Tab toggles mode, Esc reverts, Enter keeps it", async () => {
+  await using h = await tmpHome({ prefs: { theme: "tokyonight", themeMode: "dark" } })
+  const handle = createRef<Handle>()
+  await using t = await mountNode(<Probe handle={handle} />)
+
+  act(() => handle.current!.open())
+  await until(t, () => t.frame().includes("Mode: dark"))
+
+  act(() => t.keys.pressTab())
+  await until(t, () => handle.current!.mode() === "light" && t.frame().includes("Mode: light"))
+  act(() => t.keys.pressEscape())
+  await until(t, () => !t.frame().includes("Switch Theme"))
+  expect(handle.current!.mode()).toBe("dark")
+
+  act(() => handle.current!.open())
+  await until(t, () => t.frame().includes("Mode: dark"))
+  act(() => t.keys.pressTab())
+  await until(t, () => handle.current!.mode() === "light")
+  act(() => t.keys.pressEnter())
+  await until(t, () => !t.frame().includes("Switch Theme"))
+  expect(handle.current!.mode()).toBe("light")
 })


### PR DESCRIPTION
## Summary
- Theme mode is now persisted separately from the selected theme, so light/dark selection survives restarts.
- `/theme light` and `/theme dark` switch palette mode locally while `/theme` without arguments still opens the picker.
- The theme picker can preview mode changes with Tab or click, then either revert on Esc or keep them on Enter.
- Plugin theme APIs now expose the same mode setter as the app context.

## Test Plan
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test`
