### PR TITLE
Support gzip Eikon runtime artifacts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@opentui/core": "0.2.2",
         "@opentui/react": "0.2.2",
-        "eikon": "github:liftaris/eikon#8d42cff3017c829f9221fc211475fe3763571208",
+        "eikon": "github:liftaris/eikon#5b4d82d864e640d51f6cf8cd62c08015302a28a8",
         "gpt-tokenizer": "^3.4.0",
         "open": "^11.0.0",
         "react": "^19.2.5",
@@ -295,7 +295,7 @@
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
-    "eikon": ["eikon@github:liftaris/eikon#8d42cff", { "dependencies": { "@opentui/core": "^0.1.99", "@opentui/react": "^0.1.99", "react": "19.2.7", "react-dom": "19.2.7", "ssh2": "^1.16.0" }, "bin": { "eikon": "./src/cli.tsx" } }, "liftaris-eikon-8d42cff", "sha512-c67dud1bI4VGywby76y9rq09rQdKYTYh21UlgnxAT+t7/vEtKBwF3Fwu2QsZPsqaTTvLH324NzgTlprYD6c7rQ=="],
+    "eikon": ["eikon@github:liftaris/eikon#5b4d82d", { "dependencies": { "@opentui/core": "^0.1.99", "@opentui/react": "^0.1.99", "react": "19.2.7", "react-dom": "19.2.7", "ssh2": "^1.16.0" }, "bin": { "eikon": "./src/cli.tsx" } }, "liftaris-eikon-5b4d82d", "sha512-zNjPmNL2vMdrZS3u0cSKQIJrNf1LJwtyA8CviA3WSK8kbl3gZpMVHaY8AnfcmJmzYWc3d7MMrqtCwoCblLlkQA=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@opentui/core": "0.2.2",
     "@opentui/react": "0.2.2",
-    "eikon": "github:liftaris/eikon#8d42cff3017c829f9221fc211475fe3763571208",
+    "eikon": "github:liftaris/eikon#5b4d82d864e640d51f6cf8cd62c08015302a28a8",
     "gpt-tokenizer": "^3.4.0",
     "open": "^11.0.0",
     "react": "^19.2.5",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -26,7 +26,7 @@ import { lastReal } from "./service/sessions-db"
 import { readChangelog } from "./service/hermes-home"
 import { openMessage } from "./dialogs/message"
 import { openTextPrompt } from "./dialogs/text-prompt"
-import { parseEikon, type ParsedEikon } from "./components/avatar/eikon"
+import { parseEikonFile, type ParsedEikon } from "./components/avatar/eikon"
 import { bundledEikonPath } from "./components/avatar/bundled"
 import { pending as pendingPrompt, type PromptCardHandle } from "./components/chat/PromptCard"
 import type { PromptWire } from "./components/chat/MessageItem"
@@ -475,9 +475,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   }, [reset, goToTab, gwRestart, toast, gw])
 
   const loadEikon = useCallback((path: string) => {
-    Bun.file(path).text()
-      .then(t => setEikon(parseEikon(t)))
-      .catch(() => {})
+    try { setEikon(parseEikonFile(path)) }
+    catch { setEikon(undefined) }
   }, [])
 
   // Precedence: user pref (by name) → bundled eikon matching active

--- a/src/components/avatar/eikon.ts
+++ b/src/components/avatar/eikon.ts
@@ -4,7 +4,7 @@
 
 import { readdirSync, readFileSync } from "node:fs"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
-import { parse, header as peek, type Eikon, type Clip, type Meta } from "eikon"
+import { parse, header as peek, decodeRuntimeFile, type Eikon, type Clip, type Meta } from "eikon"
 
 export type EikonMeta = Meta
 export type EikonState = Clip
@@ -29,6 +29,10 @@ function readManifestEntrypoint(path: string): string | undefined {
 export function parseEikon(text: string): ParsedEikon {
   const e = parse(text)
   return { meta: e.meta, states: e.clips }
+}
+
+export function parseEikonFile(path: string): ParsedEikon {
+  return parseEikon(decodeRuntimeFile(path))
 }
 
 export function listEikons(dirs: string[]): ListedEikon[] {

--- a/src/dialogs/eikon-picker.tsx
+++ b/src/dialogs/eikon-picker.tsx
@@ -2,7 +2,6 @@
 // preview. ↑/↓ to navigate, Enter to select, Esc closes (via DialogProvider).
 
 import { useMemo, useState } from "react"
-import { readFileSync } from "fs"
 import { homedir } from "os"
 import { join } from "path"
 import { useListKeys } from "../keys"
@@ -10,7 +9,7 @@ import { useTheme } from "../theme"
 import { useDialog } from "../ui/dialog"
 import { AnimatedAvatar } from "../components/avatar/AnimatedAvatar"
 import { BUNDLED_EIKON_DIR } from "../components/avatar/bundled"
-import { listEikons, parseEikon, type ParsedEikon } from "../components/avatar/eikon"
+import { listEikons, parseEikonFile, type ParsedEikon } from "../components/avatar/eikon"
 
 const trunc = (s: string, n: number) => s.length <= n ? s : s.slice(0, n - 1) + "…"
 
@@ -35,7 +34,7 @@ export const EikonPickerDialog = (props: {
   const cur = found[cursor]
   const parsed = useMemo<ParsedEikon | undefined>(() => {
     if (!cur) return undefined
-    try { return parseEikon(readFileSync(cur.path, "utf8")) }
+    try { return parseEikonFile(cur.path) }
     catch { return undefined }
   }, [cur])
 

--- a/src/service/eikon-marketplace.ts
+++ b/src/service/eikon-marketplace.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
 import { createHash } from "node:crypto"
 import { basename, dirname, extname, join } from "node:path"
-import { loadCatalog, searchCatalog, publicCatalogUrl, downloadBytes, entries as packageEntries, type Catalog, type PublicCatalogEntry as CatalogEntry, type CatalogOptions, type DownloadOptions } from "eikon"
+import { downloadBytes, entries as packageEntries, type Catalog, type PublicCatalogEntry as CatalogEntry, type CatalogOptions, type DownloadOptions } from "eikon"
+import { loadCatalog, loadRuntimeArtifact, publicCatalogUrl, searchCatalog } from "eikon/catalog"
 import { eikon } from "./eikon"
 import * as prefs from "../context/preferences"
 import { listEikons } from "../components/avatar/eikon"
@@ -220,8 +221,15 @@ function cacheKey(entry: CatalogEntry) {
   return entry.identityKey || entry.sourceKey || entry.id
 }
 
-function previewTarget(entry: CatalogEntry) {
-  return entry.preview || entry.runtimeUrl
+function blob(url: string) {
+  return /\/blobs\/sha256\/[^/?#]+/.test(url)
+}
+
+function artifact(entry: CatalogEntry): CatalogEntry {
+  if (!entry.preview || entry.preview === entry.runtimeUrl) return entry
+  const out = { ...entry, runtimeUrl: entry.preview } as Partial<CatalogEntry>
+  delete out.trust
+  return out as CatalogEntry
 }
 
 type Trust = { manifestDigest?: string; runtimeDigest?: string; digest?: string }
@@ -429,6 +437,16 @@ export class MarketplaceService {
     return { allowPrivate: this.allowPrivate, fetcher: (input, init) => fetcher(input, signal ? { ...init, signal } : init) }
   }
 
+  private runtime(entry: CatalogEntry, signal?: AbortSignal): Fetcher {
+    return async input => {
+      const url = target(input)
+      const bound = keyIdentity(url) === keyIdentity(entry.runtimeUrl) && (!!entry.trust?.runtimeDigest || blob(url))
+      const raw = await downloadBytes(url, { ...this.dl(signal), rejectContentEncoding: bound })
+      const buf = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength) as ArrayBuffer
+      return new Response(buf, { headers: { "content-length": String(raw.length) } })
+    }
+  }
+
   private cached(url: string, raw: Uint8Array): Fetcher {
     const key = keyIdentity(url)
     return async (input, init) => {
@@ -467,8 +485,8 @@ export class MarketplaceService {
     const out = await eikon.fetchSource(entry.packageUrl, { name: entry.name, media: opts.media === true, downloader: this.dl(undefined, this.cached(entry.packageUrl, raw)) })
     const ef = eikon.file(out.name)
     if (!existsSync(ef)) {
-      const text = await this.preview(entry.identityKey)
-      writeFileSync(ef, text)
+      const art = await loadRuntimeArtifact(entry, this.runtime(entry))
+      await Bun.write(ef, art.bytes)
       eikon.notifyRevision()
     }
     const mf = join(eikon.dir(out.name), "manifest.json")
@@ -530,7 +548,8 @@ export class MarketplaceService {
     const off = () => ctl.abort()
     opts.signal?.addEventListener("abort", off, { once: true })
     try {
-      const text = dec.decode(await downloadBytes(previewTarget(entry), this.dl(ctl.signal)))
+      const item = artifact(entry)
+      const text = (await loadRuntimeArtifact(item, this.runtime(item, ctl.signal), { signal: ctl.signal })).text
       this.cache.set(cacheKey(entry), text)
       while (this.cache.size > this.previewCacheLimit) this.cache.delete(this.cache.keys().next().value!)
       return text

--- a/src/service/eikon.ts
+++ b/src/service/eikon.ts
@@ -18,12 +18,12 @@
 
 import { existsSync, mkdirSync, readdirSync, copyFileSync, readFileSync, writeFileSync, rmSync, statSync } from "node:fs"
 import { join, extname, basename, dirname } from "node:path"
-import { install, resolve, peek, entries as packageEntries, dirty, header as peekHeader, serializeLaunchStream, defaultSignalMappings,
-         type LaunchStreamRecord, type Installed as Got, type Resolved as ResolvedEikon, type Origin as EikonOrigin, type TrustState, type SourceKind, type DownloadOptions } from "eikon"
+import { install, resolve, peek, entries as packageEntries, dirty, header as peekHeader, serializeLaunchStream, defaultSignalMappings, decodeRuntimeBytes,
+         type LaunchStreamRecord, type Installed as Got, type Resolved as ResolvedEikon, type Origin as EikonOrigin, type TrustState, type SourceKind, type DownloadOptions, type RuntimeDescriptor } from "eikon"
 import { DEFAULT_PUBLIC_CATALOG } from "eikon/catalog"
 import { hermesPath } from "./hermes-home"
 import * as prefs from "../context/preferences"
-import { parseEikon, listEikons } from "../components/avatar/eikon"
+import { parseEikon, parseEikonFile, listEikons } from "../components/avatar/eikon"
 import { BUNDLED_EIKON_DIR } from "../components/avatar/bundled"
 import type { AvatarState } from "../components/avatar/states"
 import { BUILTIN, cached, probe, W, H, type Rasterizer, type Frame } from "../utils/eikon-render"
@@ -485,7 +485,7 @@ export type PackageManifest = {
   display?: { title?: string; author?: string; description?: string; glyph?: string; tags?: string[] }
   compatibility: { eikon: string; hosts?: Record<string, string> }
   entrypoints: { default: string; [key: string]: string }
-  files?: Array<{ path: string; mediaType?: string; size?: number; digest?: string; role?: string }>
+  files?: Array<{ path: string; mediaType?: string; size?: number; digest?: string; role?: string; encoding?: string; decodedSize?: number; decodedDigest?: string }>
   source?: { base?: string; states?: Partial<Record<string, { file: string; role?: string }>> }
   poster?: string
   preview?: string
@@ -679,6 +679,15 @@ async function loadText(url: string, fetcher: typeof fetch = fetch): Promise<str
   return await res.text()
 }
 
+async function loadBytes(url: string, fetcher: typeof fetch = fetch, desc?: RuntimeDescriptor): Promise<Uint8Array> {
+  if (url.startsWith("file://")) return new Uint8Array(readFileSync(new URL(url)))
+  const res = await fetcher(url)
+  if (!res.ok) throw new Error(`fetch: ${res.status} ${url}`)
+  const enc = res.headers.get("content-encoding")
+  if (enc && enc.toLowerCase() !== "identity" && desc?.digest) throw pkgErr("runtime", `artifact must be served without Content-Encoding: ${enc}`)
+  return new Uint8Array(await res.arrayBuffer())
+}
+
 async function loadJson(url: string, fetcher: typeof fetch = fetch): Promise<unknown> {
   return JSON.parse(await loadText(url, fetcher))
 }
@@ -705,27 +714,36 @@ async function loadPackage(url: string, fetcher: typeof fetch = fetch): Promise<
   return { man, base: url.slice(0, url.lastIndexOf("/") + 1) }
 }
 
+function runtimeDesc(man: PackageManifest, path = man.entrypoints.default): RuntimeDescriptor | undefined {
+  const file = man.files?.find(f => f.path === path) ?? man.files?.find(f => f.role === "runtime")
+  if (!file || (!file.digest && file.size == null && !file.encoding && file.decodedSize == null && !file.decodedDigest)) return undefined
+  return { digest: file.digest, size: file.size, encoding: file.encoding, decodedSize: file.decodedSize, decodedDigest: file.decodedDigest }
+}
+
+async function loadRuntime(man: PackageManifest, base: string, fetcher: typeof fetch = fetch, path = man.entrypoints.default): Promise<{ text: string; bytes: Uint8Array }> {
+  const desc = runtimeDesc(man, path)
+  const bytes = await loadBytes(new URL(path, base).toString(), fetcher, desc)
+  return { bytes, text: decodeRuntimeBytes(bytes, { descriptor: desc }) }
+}
+
 export async function previewPackage(entry: CatalogPackage, fetcher: typeof fetch = fetch): Promise<AdaptedPackage> {
   const { man, base } = await loadPackage(entry.packageUrl, fetcher)
-  const streamUrl = new URL(man.entrypoints.default, base).toString()
-  return adaptPackage(man, await loadText(streamUrl, fetcher))
+  return adaptPackage(man, (await loadRuntime(man, base, fetcher)).text)
 }
 
 async function installLaunch(url: string, opts: { name?: string; fetcher?: typeof fetch } = {}): Promise<Fetched> {
   const { man, base } = await loadPackage(url, opts.fetcher)
   const name = opts.name ?? man.name
-  const streamUrl = new URL(man.entrypoints.default, base).toString()
-  const text = await loadText(streamUrl, opts.fetcher)
-  const adapted = await adaptPackage(man, text)
+  const run = await loadRuntime(man, base, opts.fetcher)
+  const adapted = await adaptPackage(man, run.text)
   const paths = ensure(name)
   const clips = new Map<AvatarState, Frame[]>()
   for (const st of STATES) clips.set(st, adapted.eikon.states.get(st)?.frames ?? [[""]])
-  const packed = serialize(name, adapted.eikon.states.get("idle")?.fps ?? 12, clips)
-  await Bun.write(paths.file, packed)
+  await Bun.write(paths.file, run.bytes)
   await Bun.write(join(paths.dir, "manifest.json"), JSON.stringify({ ...man, origin: { source: url, at: new Date().toISOString() } }, null, 2) + "\n")
   writeStudio(name, { ...toStudio(fresh(name, pick())), sources: {} })
   bump()
-  return { name, sources: {}, n: 1, bytes: text.length }
+  return { name, sources: {}, n: 1, bytes: run.bytes.length }
 }
 
 export async function installPackage(src: string | CatalogPackage, opts: { name?: string; fetcher?: DownloadOptions["fetcher"] } = {}): Promise<Fetched> {
@@ -733,5 +751,5 @@ export async function installPackage(src: string | CatalogPackage, opts: { name?
   return fetchSource(url, { name: opts.name, downloader: opts.fetcher ? { fetcher: opts.fetcher } : undefined })
 }
 
-export { parseEikon, probe }
+export { parseEikon, parseEikonFile, probe }
 export * as eikon from "./eikon"

--- a/src/tabs/EikonGallery.tsx
+++ b/src/tabs/EikonGallery.tsx
@@ -14,7 +14,7 @@ import { openNewEikon } from "../dialogs/new-eikon"
 import * as submitSvc from "../service/eikon-submit"
 import { useKeyboard } from "@opentui/react"
 import { AnimatedAvatar } from "../components/avatar/AnimatedAvatar"
-import { listEikons, parseEikon, type ParsedEikon } from "../components/avatar/eikon"
+import { listEikons, parseEikonFile, type ParsedEikon } from "../components/avatar/eikon"
 import { BUNDLED_EIKON_DIR } from "../components/avatar/bundled"
 import { hermesPath } from "../service/hermes-home"
 import * as prefs from "../context/preferences"
@@ -74,7 +74,7 @@ export const EikonGallery = memo((props: Props) => {
   const cur = rows[sel]
   const parsed = useMemo<ParsedEikon | undefined>(() => {
     if (!cur) return undefined
-    try { return parseEikon(readFileSync(cur.path, "utf8")) } catch { return undefined }
+    try { return parseEikonFile(cur.path) } catch { return undefined }
   }, [cur])
 
   const activate = (row = cur) => {

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -14,7 +14,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import { extend, useKeyboard, useTerminalDimensions } from "@opentui/react"
 import { SliderRenderable } from "@opentui/core"
 import type { ParsedKey, ScrollBoxRenderable } from "@opentui/core"
-import { readFileSync, statSync } from "node:fs"
+import { statSync } from "node:fs"
 import { basename } from "node:path"
 import type { ReactNode } from "react"
 import { useTheme } from "../theme"
@@ -561,7 +561,7 @@ export const EikonStudio = memo((props: {
     if (live || !s) return undefined
     const p = eikon.baked(s.name)
     if (!p) return undefined
-    try { return eikon.parseEikon(readFileSync(p, "utf8")) } catch { return undefined }
+    try { return eikon.parseEikonFile(p) } catch { return undefined }
   }, [live, s?.name])
   const url = useMemo(() => {
     if (!s) return undefined

--- a/test/eikon-marketplace-ui.test.tsx
+++ b/test/eikon-marketplace-ui.test.tsx
@@ -83,7 +83,7 @@ function local(name: string) {
 
 function packageCatalog(extra: Route[] = []) {
   const runtime = {
-    kind: "eikon.package", schemaVersion: "1.0", id: "liftaris/ares", name: "ares",
+    kind: "eikon.package", schemaVersion: "1.0", id: "liftaris/ares", name: "ares", version: "1.0.0",
     display: { title: "Ares", author: "Kaio", description: "red warrior" },
     compatibility: { eikon: ">=1 <2" }, entrypoints: { default: "ares.eikon" },
     files: [{ path: "ares.eikon", role: "runtime", mediaType: "application/vnd.eikon.stream+jsonl", size: body.length, digest: digest(body) }], poster: "poster.txt", preview: "ares.eikon",
@@ -291,7 +291,7 @@ describe("EikonMarketplace tab", () => {
     eikon.ensure("ares")
     writeFileSync(eikon.file("ares"), body)
     writeFileSync(join(eikon.dir("ares"), "manifest.json"), JSON.stringify({
-      kind: "eikon.package", schemaVersion: "1.0", id: "liftaris/ares", name: "ares",
+      kind: "eikon.package", schemaVersion: "1.0", id: "liftaris/ares", name: "ares", version: "1.0.0",
       compatibility: { eikon: ">=1 <2" }, entrypoints: { default: "ares.eikon" },
       files: [{ path: "ares.eikon", role: "runtime", mediaType: "application/vnd.eikon.stream+jsonl", size: body.length, digest: digest(body) }],
       origin: { sourceKey: `${fx.base}/ares/`, identityKey: `${fx.base}/ares/`, packageUrl: `${fx.base}/ares/manifest.json` },

--- a/test/eikon-marketplace.test.ts
+++ b/test/eikon-marketplace.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { createHash } from "node:crypto"
-import type { Catalog } from "eikon"
+import { runtimeDescriptor, type Catalog } from "eikon"
 import * as market from "../src/service/eikon-marketplace"
 import { eikon } from "../src/service/eikon"
 import * as prefs from "../src/context/preferences"
@@ -17,6 +17,7 @@ const launch = [
 ].join("\n") + "\n"
 const png = new Uint8Array([137, 80, 78, 71])
 const digest = (data: string | Uint8Array) => `sha256:${createHash("sha256").update(data).digest("hex")}`
+const wire = (bytes: Uint8Array) => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
 
 function pack(name: string, text = launch) {
   return {
@@ -24,6 +25,7 @@ function pack(name: string, text = launch) {
     schemaVersion: "1.0",
     id: `liftaris/${name}`,
     name,
+    version: "1.0.0",
     compatibility: { eikon: ">=1 <2" },
     entrypoints: { default: `${name}.eikon` },
     files: [
@@ -31,6 +33,41 @@ function pack(name: string, text = launch) {
       { path: "source.png", role: "source.base", mediaType: "image/png", size: png.length, digest: digest(png) },
     ],
     source: { base: "source.png" },
+  }
+}
+
+function gzip(name: string) {
+  const info = runtimeDescriptor(launch, { encoding: "gzip" })
+  return {
+    bytes: info.bytes,
+    trust: {
+      runtimeDigest: info.digest,
+      runtimeSize: info.size,
+      runtimeEncoding: info.encoding,
+      runtimeDecodedSize: info.decodedSize,
+      runtimeDecodedDigest: info.decodedDigest,
+    },
+    manifest: {
+      kind: "eikon.package",
+      schemaVersion: "1.0",
+      id: `liftaris/${name}`,
+      name,
+      version: "1.0.0",
+      compatibility: { eikon: ">=1 <2" },
+      entrypoints: { default: `${name}.eikon` },
+      files: [
+        {
+          path: `${name}.eikon`,
+          role: "runtime",
+          mediaType: "application/vnd.eikon.stream+jsonl",
+          encoding: "gzip",
+          size: info.size,
+          digest: info.digest,
+          decodedSize: info.decodedSize,
+          decodedDigest: info.decodedDigest,
+        },
+      ],
+    },
   }
 }
 
@@ -247,6 +284,55 @@ describe("service/eikon-marketplace", () => {
     fx.srv.stop()
   })
 
+  test("preview decodes gzip runtime bytes and rejects transport gzip", async () => {
+    const gz = gzip("zip")
+    const srv = serve([
+      { path: "/eikons/index.json", body: req => [catalogRow({ name: "zip", source: "zip/", trust: gz.trust }, `${new URL(req.url).origin}/eikons/`)] },
+      { path: "/eikons/zip/manifest.json", body: gz.manifest },
+      { path: "/eikons/zip/zip.eikon", body: gz.bytes },
+    ])
+    const state = await market.load({ catalog: `http://localhost:${srv.port}/eikons`, allowPrivate: true })
+
+    expect(await state.service!.preview(state.rows[0]!.entry.identityKey)).toBe(launch)
+    srv.stop()
+
+    const bad = serve([
+      { path: "/eikons/index.json", body: req => [catalogRow({ name: "zip", source: "zip/", trust: gz.trust }, `${new URL(req.url).origin}/eikons/`)] },
+      { path: "/eikons/zip/manifest.json", body: gz.manifest },
+      { path: "/eikons/zip/zip.eikon", body: gz.bytes, headers: { "content-encoding": "gzip" } },
+    ])
+    const broken = await market.load({ catalog: `http://localhost:${bad.port}/eikons`, allowPrivate: true })
+
+    await expect(broken.service!.preview(broken.rows[0]!.entry.identityKey)).rejects.toThrow(/content-encoding/i)
+    bad.stop()
+  })
+
+  test("preview keeps explicit preview URLs and allows unverified transport gzip", async () => {
+    const prev = launch.replace("abcd", "prev")
+    const gz = runtimeDescriptor(launch, { encoding: "gzip" })
+    const cat: Catalog = {
+      base: "https://example.com/eikons",
+      entries: [entry({ name: "split", preview: "preview.eikon", runtimeUrl: "runtime.eikon" })],
+      load: async () => "",
+    }
+    const seen: string[] = []
+    const svc = new market.MarketplaceService(cat, {
+      fetcher: async input => {
+        seen.push(String(input))
+        if (String(input).endsWith("preview.eikon")) return new Response(prev)
+        return new Response(wire(gz.bytes), { headers: { "content-encoding": "gzip" } })
+      },
+    })
+
+    expect(await svc.preview(cat.entries[0]!.identityKey)).toBe(prev)
+    expect(seen.some(u => u.endsWith("preview.eikon"))).toBe(true)
+
+    const raw: Catalog = { ...cat, entries: [entry({ name: "raw", runtimeUrl: "runtime.eikon" })] }
+    const open = new market.MarketplaceService(raw, { fetcher: async () => new Response(wire(gz.bytes), { headers: { "content-encoding": "gzip" } }) })
+
+    expect(await open.preview(raw.entries[0]!.identityKey)).toBe(launch)
+  })
+
   test("preview deduplicates concurrent requests and caps cached entries", async () => {
     const fx = fixture()
     const state = await market.load({ catalog: fx.base, allowPrivate: true, previewCacheLimit: 1 })
@@ -322,6 +408,23 @@ describe("service/eikon-marketplace", () => {
     const man = JSON.parse(readFileSync(join(eikon.dir("ares"), "manifest.json"), "utf8"))
     expect(man.origin.source).toBe(`${fx.base}/ares/manifest.json`)
     fx.srv.stop()
+  })
+
+  test("marketplace install preserves gzip runtime stored bytes", async () => {
+    const gz = gzip("zip")
+    const srv = serve([
+      { path: "/eikons/index.json", body: req => [catalogRow({ name: "zip", source: "zip/", trust: gz.trust }, `${new URL(req.url).origin}/eikons/`)] },
+      { path: "/eikons/zip/manifest.json", body: gz.manifest },
+      { path: "/eikons/zip/zip.eikon", body: gz.bytes },
+    ])
+    const state = await market.load({ catalog: `http://localhost:${srv.port}/eikons`, allowPrivate: true })
+
+    const out = await state.service!.install(state.rows[0]!.entry.identityKey)
+
+    expect(out.name).toBe("zip")
+    expect(Buffer.from(readFileSync(eikon.file("zip"))).equals(Buffer.from(gz.bytes))).toBe(true)
+    expect(eikon.parseEikonFile(eikon.file("zip")).states.get("idle")!.frames[0]).toEqual(["abcd", "efgh"])
+    srv.stop()
   })
 
   test("marketplace installs launch package catalog entries from explicit manifest URLs", async () => {
@@ -414,7 +517,7 @@ describe("service/eikon-marketplace", () => {
     let seen = 0
     const cat: Catalog = {
       base: "https://example.com/eikons",
-      entries: [entry({ name: "secret", preview: "http://127.0.0.1:65530/secret.eikon" })],
+      entries: [entry({ name: "secret", runtimeUrl: "http://127.0.0.1:65530/secret.eikon" })],
       load: async () => "",
     }
     const svc = new market.MarketplaceService(cat, { fetcher: async () => { seen += 1; return new Response(launch) } })

--- a/test/eikon-picker.test.tsx
+++ b/test/eikon-picker.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { mkdtempSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
+import { runtimeDescriptor } from "eikon"
 import { mountNode, until } from "./harness"
 import { EikonPickerDialog } from "../src/dialogs/eikon-picker"
 
@@ -15,7 +16,7 @@ const FIXTURE = [
 describe("EikonPickerDialog", () => {
   test("lists fixture and renders live preview", async () => {
     const dir = mkdtempSync(join(tmpdir(), "eikon-pick-"))
-    writeFileSync(join(dir, "tiny.eikon"), FIXTURE)
+    writeFileSync(join(dir, "tiny.eikon"), runtimeDescriptor(FIXTURE, { encoding: "gzip" }).bytes)
 
     let picked = ""
     const t = await mountNode(

--- a/test/eikon-service.test.ts
+++ b/test/eikon-service.test.ts
@@ -3,15 +3,17 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { spawnSync } from "node:child_process"
 import { createHash } from "node:crypto"
 import { join } from "node:path"
+import { runtimeDescriptor } from "eikon"
 import { eikon } from "../src/service/eikon"
 import { knobs } from "../src/utils/eikon-knobs"
 import { native, caps, type Rasterizer } from "../src/utils/eikon-render"
-import { parseEikon } from "../src/components/avatar/eikon"
+import { parseEikon, parseEikonFile } from "../src/components/avatar/eikon"
 import * as prefs from "../src/context/preferences"
 
 const HH = process.env.HERMES_HOME!
 if (!HH || HH.includes("/.hermes")) throw new Error("sandbox not applied")
 const digest = (data: string | Uint8Array) => `sha256:${createHash("sha256").update(data).digest("hex")}`
+const wire = (bytes: Uint8Array) => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
 
 describe("service/eikon: layout", () => {
   test("ensure creates folder form", () => {
@@ -132,6 +134,7 @@ describe("service/eikon: fetchSource", () => {
       schemaVersion: "1.0",
       id: "liftaris/ares",
       name: "ares",
+      version: "1.0.0",
       compatibility: { eikon: ">=1 <2" },
       entrypoints: { default: "ares.eikon" },
       files: [
@@ -213,6 +216,123 @@ describe("service/eikon: fetchSource", () => {
     expect(seen).toContain("/pkg/ares.eikon")
     expect(existsSync(eikon.file("ares"))).toBe(true)
   })
+
+  test("fetchSource installs gzip runtime packages as stored bytes", async () => {
+    const info = runtimeDescriptor(launch, { encoding: "gzip" })
+    const srv = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const name = new URL(req.url).pathname.split("/").pop()!
+        if (name === "manifest.json") return Response.json({
+          kind: "eikon.package",
+          schemaVersion: "1.0",
+          id: "liftaris/gzip",
+          name: "gzip",
+          version: "1.0.0",
+          compatibility: { eikon: ">=1 <2" },
+          entrypoints: { default: "gzip.eikon" },
+          files: [{
+            path: "gzip.eikon",
+            role: "runtime",
+            mediaType: "application/vnd.eikon.stream+jsonl",
+            encoding: "gzip",
+            size: info.size,
+            digest: info.digest,
+            decodedSize: info.decodedSize,
+            decodedDigest: info.decodedDigest,
+          }],
+        })
+        if (name === "gzip.eikon") return new Response(wire(info.bytes))
+        return new Response("404", { status: 404 })
+      },
+    })
+
+    const out = await eikon.fetchSource(`http://localhost:${srv.port}/pkg/`, { media: false })
+
+    expect(out.name).toBe("gzip")
+    expect(Buffer.from(readFileSync(eikon.file("gzip"))).equals(Buffer.from(info.bytes))).toBe(true)
+    expect(parseEikonFile(eikon.file("gzip")).states.get("idle")!.frames[0]).toEqual(["abcd", "efgh"])
+    srv.stop()
+  })
+
+  test("fetchSource rejects digest-bound gzip runtime served with Content-Encoding", async () => {
+    const info = runtimeDescriptor(launch, { encoding: "gzip" })
+    const srv = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const name = new URL(req.url).pathname.split("/").pop()!
+        if (name === "manifest.json") return Response.json({
+          kind: "eikon.package",
+          schemaVersion: "1.0",
+          id: "liftaris/wiregzip",
+          name: "wiregzip",
+          version: "1.0.0",
+          compatibility: { eikon: ">=1 <2" },
+          entrypoints: { default: "wiregzip.eikon" },
+          files: [{
+            path: "wiregzip.eikon",
+            role: "runtime",
+            mediaType: "application/vnd.eikon.stream+jsonl",
+            encoding: "gzip",
+            size: info.size,
+            digest: info.digest,
+            decodedSize: info.decodedSize,
+            decodedDigest: info.decodedDigest,
+          }],
+        })
+        if (name === "wiregzip.eikon") return new Response(wire(info.bytes), { headers: { "content-encoding": "gzip" } })
+        return new Response("404", { status: 404 })
+      },
+    })
+
+    await expect(eikon.fetchSource(`http://localhost:${srv.port}/pkg/`, { media: false })).rejects.toThrow(/content-encoding/i)
+    expect(existsSync(eikon.file("wiregzip"))).toBe(false)
+    srv.stop()
+  })
+
+  test("previewPackage decodes gzip package entrypoints", async () => {
+    const names = ["idle", "listening", "thinking", "speaking", "working", "error"]
+    const full = [
+      JSON.stringify({ type: "header", eikon: 1, size: { cols: 4, rows: 2 }, defaultSignal: "state.idle", signals: Object.fromEntries(names.map(name => [`state.${name}`, { clip: name }])) }),
+      ...names.flatMap(name => [
+        JSON.stringify({ type: "clip", name, fps: 12, frameCount: 1 }),
+        JSON.stringify({ type: "frame", clip: name, index: 0, rows: ["abcd", "efgh"] }),
+      ]),
+    ].join("\n") + "\n"
+    const info = runtimeDescriptor(full, { encoding: "gzip" })
+    const srv = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const name = new URL(req.url).pathname.split("/").pop()!
+        if (name === "manifest.json") return Response.json({
+          kind: "eikon.package",
+          schemaVersion: "1.0",
+          id: "liftaris/preview-gzip",
+          name: "preview-gzip",
+          version: "1.0.0",
+          compatibility: { eikon: ">=1 <2" },
+          entrypoints: { default: "preview-gzip.eikon" },
+          files: [{
+            path: "preview-gzip.eikon",
+            role: "runtime",
+            mediaType: "application/vnd.eikon.stream+jsonl",
+            encoding: "gzip",
+            size: info.size,
+            digest: info.digest,
+            decodedSize: info.decodedSize,
+            decodedDigest: info.decodedDigest,
+          }],
+        })
+        if (name === "preview-gzip.eikon") return new Response(wire(info.bytes))
+        return new Response("404", { status: 404 })
+      },
+    })
+
+    const out = await eikon.previewPackage({ packageUrl: `http://localhost:${srv.port}/pkg/manifest.json` } as Parameters<typeof eikon.previewPackage>[0])
+
+    expect(out.eikon.states.get("idle")!.frames[0]).toEqual(["abcd", "efgh"])
+    srv.stop()
+  })
 })
 
 describe("service/eikon: lifecycle", () => {
@@ -293,6 +413,7 @@ describe("service/eikon: lifecycle", () => {
           schemaVersion: "1.0",
           id: "liftaris/pkgonly",
           name: "pkgonly",
+          version: "1.0.0",
           compatibility: { eikon: ">=1 <2" },
           entrypoints: { default: "pkgonly.eikon" },
           files: [

--- a/test/eikon-submit.test.tsx
+++ b/test/eikon-submit.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test"
 import { act } from "react"
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
+import { runtimeDescriptor } from "eikon"
 import { mountNode, until, type Harness } from "./harness"
 import { EikonGallery } from "../src/tabs/EikonGallery"
 import { eikon } from "../src/service/eikon"
@@ -94,6 +95,17 @@ describe("Eikon submit dialog", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Submitted") && t.frame().includes("pull/7"))
     expect(fn).toHaveBeenCalledWith({ path: eikon.file("draft") })
+  })
+
+  test("preflight preview accepts gzip runtime drafts", async () => {
+    await seed("draft")
+    const raw = await Bun.file(eikon.file("draft")).text()
+    writeFileSync(eikon.file("draft"), runtimeDescriptor(raw, { encoding: "gzip" }).bytes)
+
+    const seen = await submit.preview({ path: eikon.file("draft") })
+
+    expect(seen.name).toBe("draft")
+    expect(seen.files.map(f => f.path)).toContain("manifest.json")
   })
 
   test("preflight setup guidance does not submit", async () => {

--- a/test/eikon.test.ts
+++ b/test/eikon.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { dirname, join } from "path"
-import { parseEikon, listEikons } from "../src/components/avatar/eikon"
+import { runtimeDescriptor } from "eikon"
+import { parseEikon, parseEikonFile, listEikons } from "../src/components/avatar/eikon"
 import { bundledEikonPath } from "../src/components/avatar/bundled"
 
 const FIXTURE = [
@@ -113,6 +114,18 @@ describe("parseEikon", () => {
     expect(e.states.get("idle")!.frames[0]).toEqual([" o ", "/|\\"])
     expect(e.states.get("error")!.loopFrom).toBe(1)
   })
+
+  test("parses gzip runtime files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "eikon-gzip-"))
+    const info = runtimeDescriptor(LAUNCH_FIXTURE, { encoding: "gzip" })
+    const p = join(dir, "tiny.eikon")
+    writeFileSync(p, info.bytes)
+
+    const e = parseEikonFile(p)
+
+    expect(e.meta.name).toBe("tiny launch")
+    expect(e.states.get("idle")!.frames[0]).toEqual([" o ", "/|\\"])
+  })
 })
 
 describe("listEikons", () => {
@@ -154,6 +167,36 @@ describe("listEikons", () => {
     expect(paths.some(p => p.endsWith("extra.eikon"))).toBe(false)
   })
 
+  test("scans gzip runtime package entrypoints", () => {
+    const dir = mkdtempSync(join(tmpdir(), "eikon-gzip-list-"))
+    const info = runtimeDescriptor(LAUNCH_FIXTURE, { encoding: "gzip" })
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+      kind: "eikon.package",
+      schemaVersion: "1.0",
+      id: "test/gzip",
+      name: "gzip",
+      compatibility: { eikon: ">=1 <2" },
+      entrypoints: { default: "streams/gzip.eikon" },
+      files: [{
+        path: "streams/gzip.eikon",
+        role: "runtime",
+        mediaType: "application/vnd.eikon.stream+jsonl",
+        encoding: "gzip",
+        size: info.size,
+        digest: info.digest,
+        decodedSize: info.decodedSize,
+        decodedDigest: info.decodedDigest,
+      }],
+    }))
+    mkdirSync(join(dir, "streams"))
+    writeFileSync(join(dir, "streams", "gzip.eikon"), info.bytes)
+
+    const found = listEikons([dir])
+
+    expect(found).toHaveLength(1)
+    expect(found[0].meta.name).toBe("tiny launch")
+  })
+
   test("bundled eikons ship only Nous as a package runtime stream", () => {
     const p = bundledEikonPath("nous")!
     expect(bundledEikonPath("default")).toBe(p)
@@ -165,7 +208,7 @@ describe("listEikons", () => {
     expect(man.version).toBe("1.0.0")
     expect(man.origin.identityKey).toBe("registry:eikon.liftaris.dev:liftaris/nous@1.0.0")
     expect(man.origin.packageUrl).toBe("https://eikon.liftaris.dev/packages/liftaris/nous/1.0.0.json")
-    const e = parseEikon(readFileSync(p, "utf8"))
+    const e = parseEikonFile(p)
     expect(e.meta.width).toBe(48)
     expect(e.states.has("idle")).toBe(true)
     const found = listEikons([join(import.meta.dir, "../assets/eikons")])


### PR DESCRIPTION
## Provenance

Eikon runtime artifacts now support stored-byte gzip descriptors. This updates Herm to the merged Eikon runtime API so installed avatars and marketplace previews handle compressed `.eikon` files without changing artifact byte identity.

## Summary

- Pin Eikon to merged main commit `5b4d82d864e640d51f6cf8cd62c08015302a28a8`
- Decode local avatar files through Eikon runtime byte APIs in app, gallery, picker, and Studio paths
- Preserve stored runtime bytes during marketplace installs and reject transport `Content-Encoding` for digest-bound artifacts
- Keep explicit preview URLs working and allow non-digest transport gzip behavior

## Verification

- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
