### PR TITLE
fix(eikon): recognize downloaded package source in Studio

### DIFF
--- a/src/service/eikon-marketplace.ts
+++ b/src/service/eikon-marketplace.ts
@@ -511,7 +511,7 @@ export class MarketplaceService {
     const dir = eikon.ensure(usable.inst.name).source
     const pairs = await Promise.all(xs.map(async ([r, rel]) => {
       const data = await sourceBytes(man, base, rel, this.dl())
-      return [r, `${r}${extname(rel).toLowerCase()}`, data] as const
+      return [r, eikon.sourceName(man, r, rel), data] as const
     }))
     const sources: eikon.Sources = {}
     await Promise.all(pairs.map(async ([r, fname, data]) => {

--- a/src/service/eikon.ts
+++ b/src/service/eikon.ts
@@ -16,7 +16,7 @@
 // (scope-tracked — deactivate unregisters). Studio reads the registry
 // live on every open of the rasterizer picker.
 
-import { existsSync, mkdirSync, readdirSync, copyFileSync, readFileSync, writeFileSync, rmSync, statSync } from "node:fs"
+import { existsSync, mkdirSync, readdirSync, copyFileSync, readFileSync, writeFileSync, rmSync, statSync, renameSync } from "node:fs"
 import { join, extname, basename, dirname } from "node:path"
 import { install, resolve, peek, entries as packageEntries, dirty, header as peekHeader, serializeLaunchStream, defaultSignalMappings, decodeRuntimeBytes,
          type LaunchStreamRecord, type Installed as Got, type Resolved as ResolvedEikon, type Origin as EikonOrigin, type TrustState, type SourceKind, type DownloadOptions, type RuntimeDescriptor } from "eikon"
@@ -235,6 +235,13 @@ export function lifecycle(name: string, opts: { dirty?: boolean } = {}): Lifecyc
   }
 }
 
+export function sourceFetchUrl(name: string): string | undefined {
+  const man = manifest(name)
+  const head = header(file(name))
+  const info = sourceInfo(man, head)
+  return info.packageUrl ?? info.origin
+}
+
 /** List folder-form eikons under ~/.hermes/eikons/. Flat legacy
  *  <name>.eikon at the root is still readable by listEikons() in
  *  components/avatar/eikon.ts but doesn't appear here (no studio). */
@@ -244,11 +251,12 @@ export function list(): Installed[] {
   return readdirSync(root, { withFileTypes: true })
     .filter(e => e.isDirectory() && existsSync(join(root, e.name, `${e.name}.eikon`)))
     .map(e => {
-      const src = join(root, e.name, "source")
-      const has = existsSync(src) && readdirSync(src).length > 0
-      const man = manifest(e.name)
-      const head = header(join(root, e.name, `${e.name}.eikon`))
       const name = e.name
+      normalizeStoredSources(name)
+      const src = join(root, e.name, "source")
+      const has = !!findSource(name)
+      const man = manifest(name)
+      const head = header(join(root, name, `${name}.eikon`))
       return {
         name, file: join(root, name, `${name}.eikon`),
         source: src, hasSource: has,
@@ -271,6 +279,80 @@ export function raw(): string[] {
 
 const IMG = /\.(png|jpe?g|webp|gif|bmp)$/i
 const VID = /\.(mp4|webm|mov|mkv)$/i
+const MEDIA_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/bmp": ".bmp",
+  "video/mp4": ".mp4",
+  "video/webm": ".webm",
+  "video/quicktime": ".mov",
+  "video/x-matroska": ".mkv",
+}
+
+type SourceFile = { path?: string; mediaType?: string }
+type SourceManifest = { files?: SourceFile[] }
+
+function sourceRole(role: string): role is keyof Sources & string {
+  return role === "base" || STATES.includes(role as AvatarState)
+}
+
+export function sourceExt(man: SourceManifest | undefined, rel: string): string {
+  const ext = extname(rel).toLowerCase()
+  if (ext) return ext
+  const type = man?.files?.find(f => f.path === rel)?.mediaType?.split(";")[0]?.trim().toLowerCase()
+  return type ? MEDIA_EXT[type] ?? "" : ""
+}
+
+export function sourceName(man: SourceManifest | undefined, role: string, rel: string): string {
+  return `${role}${sourceExt(man, rel)}`
+}
+
+function sourceRefs(man: SourceManifest | undefined): Map<string, string> {
+  if (!man) return new Map()
+  try {
+    return new Map(packageEntries(man as never)
+      .filter(([role]) => sourceRole(String(role)))
+      .map(([role, rel]) => [String(role), rel]))
+  } catch {
+    return new Map()
+  }
+}
+
+function normalizeSources(name: string, sources: Sources): Sources {
+  const man = manifest(name) as SourceManifest | undefined
+  const refs = sourceRefs(man)
+  const root = sourceDir(name)
+  return Object.fromEntries(Object.entries(sources).map(([role, fname]) => {
+    if (!fname) return [role, fname]
+    const rel = refs.get(role)
+    const next = rel ? sourceName(man, role, rel) : fname
+    if (next === fname) return [role, fname]
+    const from = join(root, fname)
+    const to = join(root, next)
+    if (existsSync(from) && !existsSync(to)) renameSync(from, to)
+    return [role, existsSync(to) ? next : fname]
+  })) as Sources
+}
+
+function sameSources(a: Sources, b: Sources): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function normalizeStudioSources(name: string, s: Studio): Studio {
+  const prev = s.sources ?? {}
+  const sources = normalizeSources(name, prev)
+  if (sameSources(prev, sources)) return s
+  const next = { ...s, sources }
+  writeFileSync(studioFile(name), JSON.stringify(next, null, 2) + "\n", "utf8")
+  return next
+}
+
+function normalizeStoredSources(name: string): void {
+  try { readStudio(name) } catch {}
+}
 
 /** Resolve the effective source path for a state: per-state file →
  *  base.* → idle.* → first image → first video. Returns absolute path. */
@@ -301,7 +383,7 @@ export function readStudio(name: string): Studio | undefined {
   const raw = JSON.parse(readFileSync(p, "utf8")) as Partial<Studio>
   // Minimal shape-check; absent fields fall back at fresh() time.
   if (!raw || typeof raw !== "object") return undefined
-  return raw as Studio
+  return normalizeStudioSources(name, raw as Studio)
 }
 
 export function writeStudio(name: string, s: Studio) {
@@ -568,8 +650,9 @@ export async function fetchSource(src: string, opts?: { name?: string; media?: b
                                    progress?: (d: number, t: number) => void }): Promise<Fetched> {
   const out: Got = await install(src, ROOT(), opts)
   stripManifestTrust(out.name)
-  attachSources(out.name, out.sources)
-  return { name: out.name, sources: out.sources, n: out.n, bytes: out.bytes }
+  const sources = normalizeSources(out.name, out.sources)
+  attachSources(out.name, sources)
+  return { name: out.name, sources, n: out.n, bytes: out.bytes }
 }
 
 const SAFE = /^[a-zA-Z0-9._/-]+$/

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -565,6 +565,8 @@ export const EikonStudio = memo((props: {
   }, [live, s?.name])
   const url = useMemo(() => {
     if (!s) return undefined
+    const src = eikon.sourceFetchUrl(s.name)
+    if (src) return src
     const p = eikon.baked(s.name)
     return p ? eikon.header(p)?.source_url as string | undefined : undefined
   }, [s?.name])

--- a/test/eikon-marketplace.test.ts
+++ b/test/eikon-marketplace.test.ts
@@ -634,6 +634,45 @@ describe("service/eikon-marketplace", () => {
     srv.stop()
   })
 
+  test("downloadSource preserves extensions for content-addressed source blobs", async () => {
+    const old = launch.replace("abcd", "OLDX")
+    const next = launch.replace("abcd", "NEWX")
+    const mp4 = new Uint8Array(1024)
+    const man = {
+      ...pack("blob", next),
+      files: [
+        { path: "blob.eikon", role: "runtime", mediaType: "application/vnd.eikon.stream+jsonl", size: next.length, digest: digest(next) },
+        { path: "blobs/sha256/base", role: "source.base", mediaType: "image/png", size: png.length, digest: digest(png) },
+        { path: "blobs/sha256/idle", role: "source.idle", mediaType: "video/mp4", size: mp4.length, digest: digest(mp4) },
+      ],
+      source: { base: "blobs/sha256/base", states: { idle: { file: "blobs/sha256/idle" } } },
+    }
+    const srv = serve([
+      { path: "/eikons/index.json", body: req => [catalogRow({ name: "blob", source: "blob/" }, `${new URL(req.url).origin}/eikons/`)] },
+      { path: "/eikons/blob/manifest.json", body: man },
+      { path: "/eikons/blob/blob.eikon", body: next },
+      { path: "/eikons/blob/blobs/sha256/base", body: png },
+      { path: "/eikons/blob/blobs/sha256/idle", body: mp4 },
+    ])
+    eikon.ensure("blob")
+    writeFileSync(eikon.file("blob"), old)
+    writeFileSync(join(eikon.dir("blob"), "manifest.json"), JSON.stringify({
+      ...man,
+      origin: { sourceKey: `http://localhost:${srv.port}/eikons/blob/`, identityKey: `http://localhost:${srv.port}/eikons/blob/`, packageUrl: `http://localhost:${srv.port}/eikons/blob/manifest.json` },
+    }, null, 2))
+
+    const state = await market.load({ catalog: `http://localhost:${srv.port}/eikons`, allowPrivate: true })
+    const out = await state.service!.downloadSource(state.rows[0]!.entry.identityKey)
+
+    expect(out.name).toBe("blob")
+    expect(existsSync(join(eikon.sourceDir("blob"), "base.png"))).toBe(true)
+    expect(existsSync(join(eikon.sourceDir("blob"), "idle.mp4"))).toBe(true)
+    expect(eikon.findSource("blob")).toEndWith("base.png")
+    expect(eikon.findSource("blob", "idle")).toEndWith("idle.mp4")
+    expect(eikon.readStudio("blob")!.sources).toEqual({ base: "base.png", idle: "idle.mp4" })
+    srv.stop()
+  })
+
   test("bundled Nous satisfies the registry package identity", () => {
     prefs.set("eikon", "nous")
     const cat: Catalog = {

--- a/test/eikon-service.test.ts
+++ b/test/eikon-service.test.ts
@@ -184,6 +184,46 @@ describe("service/eikon: fetchSource", () => {
     srv.stop()
   })
 
+  test("fetchSource preserves media extensions for content-addressed source blobs", async () => {
+    const mp4 = new Uint8Array(1024)
+    const srv = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname
+        if (path.endsWith("manifest.json")) return Response.json({
+          kind: "eikon.package",
+          schemaVersion: "1.0",
+          id: "liftaris/blobbed",
+          name: "blobbed",
+          version: "1.0.0",
+          compatibility: { eikon: ">=1 <2" },
+          entrypoints: { default: "blobbed.eikon" },
+          files: [
+            { path: "blobbed.eikon", role: "runtime", mediaType: "application/vnd.eikon.stream+jsonl", size: launch.length, digest: digest(launch) },
+            { path: "blobs/sha256/base", role: "source.base", mediaType: "image/png", size: png.length, digest: digest(png) },
+            { path: "blobs/sha256/idle", role: "source.idle", mediaType: "video/mp4", size: mp4.length, digest: digest(mp4) },
+          ],
+          source: { base: "blobs/sha256/base", states: { idle: { file: "blobs/sha256/idle" } } },
+        })
+        if (path.endsWith("blobbed.eikon")) return new Response(launch)
+        if (path.endsWith("/base")) return new Response(png)
+        if (path.endsWith("/idle")) return new Response(mp4)
+        return new Response("404", { status: 404 })
+      },
+    })
+
+    const out = await eikon.fetchSource(`http://localhost:${srv.port}/pkg/manifest.json`)
+
+    expect(out.sources.base).toBe("base.png")
+    expect(out.sources.idle).toBe("idle.mp4")
+    expect(existsSync(join(eikon.sourceDir("blobbed"), "base.png"))).toBe(true)
+    expect(existsSync(join(eikon.sourceDir("blobbed"), "idle.mp4"))).toBe(true)
+    expect(eikon.findSource("blobbed")).toEndWith("base.png")
+    expect(eikon.findSource("blobbed", "idle")).toEndWith("idle.mp4")
+    expect(eikon.readStudio("blobbed")!.sources).toEqual({ base: "base.png", idle: "idle.mp4" })
+    srv.stop()
+  })
+
   test("legacy {files:[]} manifest: role from basename", async () => {
     const srv = Bun.serve({
       port: 0,

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { act, useState } from "react"
 import { mkdirSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
+import { createHash } from "node:crypto"
 import { mountNode, until } from "./harness"
 import { EikonGroup } from "../src/tabs/EikonGroup"
 import { EikonGallery } from "../src/tabs/EikonGallery"
@@ -13,6 +14,12 @@ import * as prefs from "../src/context/preferences"
 
 const HH = process.env.HERMES_HOME!
 const PX = new Uint8Array([137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,1,0,0,0,1,8,0,0,0,0,58,126,155,85,0,0,0,10,73,68,65,84,120,156,99,104,0,0,0,130,0,129,119,205,114,182,0,0,0,0,73,69,78,68,174,66,96,130])
+const STREAM = [
+  JSON.stringify({ type: "header", eikon: 1, size: { cols: 4, rows: 2 }, defaultSignal: "state.idle", signals: { "state.idle": { clip: "idle" } } }),
+  JSON.stringify({ type: "clip", name: "idle", fps: 12, frameCount: 1 }),
+  JSON.stringify({ type: "frame", clip: "idle", index: 0, rows: ["abcd", "efgh"] }),
+].join("\n") + "\n"
+const digest = (data: string | Uint8Array) => `sha256:${createHash("sha256").update(data).digest("hex")}`
 const run = caps.ffmpeg ? test : test.skip
 
 // Stub rasterizer — deterministic, no binaries.
@@ -51,6 +58,40 @@ describe("EikonStudio tab", () => {
     await until(t, () => t.frame().includes("Create a local draft before submitting"))
     expect(t.frame()).not.toContain("Submit eikon")
     un()
+  })
+
+  test("runtime-only package installs expose Studio fetch from manifest origin", async () => {
+    const srv = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname
+        if (path.endsWith("manifest.json")) return Response.json({
+          kind: "eikon.package",
+          schemaVersion: "1.0",
+          id: "liftaris/bare",
+          name: "bare",
+          version: "1.0.0",
+          compatibility: { eikon: ">=1 <2" },
+          entrypoints: { default: "bare.eikon" },
+          files: [
+            { path: "bare.eikon", role: "runtime", mediaType: "application/vnd.eikon.stream+jsonl", size: STREAM.length, digest: digest(STREAM) },
+            { path: "source.png", role: "source.base", mediaType: "image/png", size: PX.length, digest: digest(PX) },
+          ],
+          source: { base: "source.png" },
+        })
+        if (path.endsWith("bare.eikon")) return new Response(STREAM)
+        if (path.endsWith("source.png")) return new Response(PX)
+        return new Response("404", { status: 404 })
+      },
+    })
+    await eikon.fetchSource(`http://localhost:${srv.port}/pkg/manifest.json`, { media: false })
+    prefs.set("eikon", "bare")
+
+    await using t = await mountNode(<EikonStudio focused />, { width: 160, height: 48 })
+
+    await until(t, () => t.frame().includes("fetch source"))
+    expect(t.frame()).toContain("download to edit")
+    srv.stop()
   })
 
   run("renders three panes; knob nav via handleListKey; ←→ adjusts cycle knob", async () => {


### PR DESCRIPTION
## Summary

- Studio now recognizes package sources downloaded from content-addressed blob paths by deriving local media extensions from package `mediaType` descriptors.
- Marketplace source-only downloads use the same filename normalization, so downloaded source remains editable instead of appearing as baked-only runtime frames.
- Studio fetch source now uses installed package/origin metadata, not only legacy launch-stream `source_url`, so runtime-only package installs can expose a source download action.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun install --frozen-lockfile`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test test/eikon-service.test.ts test/eikon-marketplace.test.ts test/eikon-studio.test.tsx`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test`
