### PR TITLE
fix(chat): render ThoughtCloud tools as trail rows

### DIFF
--- a/src/components/chat/ThoughtCloud.tsx
+++ b/src/components/chat/ThoughtCloud.tsx
@@ -7,8 +7,8 @@
 import { memo, useEffect, useRef, useState } from "react"
 import type { BorderCharacters, MouseEvent } from "@opentui/core"
 import type { Message, Part, ThinkingPart, ToolPart } from "../../types/message"
-import { Tool } from "./tool"
-import { usePref } from "../../context/preferences"
+import { Tool, cost, visible } from "./tool"
+import { usePref, type DetailMode } from "../../context/preferences"
 import { useTheme } from "../../theme"
 
 export const CLOUD_MIN = 12
@@ -81,10 +81,10 @@ function latest(messages: Message[]): Message | undefined {
 }
 
 // Rough row cost — enough for auto-grow between MIN and MAX.
-function rows(list: Part[]): number {
+function rows(list: Part[], detail: DetailMode): number {
   return list.reduce((n, p) =>
     n + (p.type === "thinking" ? Math.ceil(p.content.length / 80) || 1
-       : p.type === "tool" && p.diff ? 6
+       : p.type === "tool" ? cost(p, detail)
        : 1), 0)
 }
 
@@ -101,18 +101,19 @@ export const ThoughtCloud = memo((props: {
   const all = parts(src)
   const think = all.filter((p): p is ThinkingPart => p.type === "thinking")
   const tools = all.filter((p): p is ToolPart => p.type === "tool")
+  const seen = tools.filter(t => visible(t, detail))
   const [pane, setPane] = useState<Pane>("reasoning")
   useEffect(() => {
-    if (pane === "reasoning" && think.length === 0 && tools.length > 0) setPane("tools")
-    if (pane === "tools" && tools.length === 0 && think.length > 0) setPane("reasoning")
-  }, [pane, think.length, tools.length])
-  const body = pane === "reasoning" ? think : tools
+    if (pane === "reasoning" && think.length === 0 && seen.length > 0) setPane("tools")
+    if (pane === "tools" && seen.length === 0 && think.length > 0) setPane("reasoning")
+  }, [pane, think.length, seen.length])
+  const body = pane === "reasoning" ? think : seen
 
   // Auto-grow: track content until the user drags; then their size
   // sticks. `want` is the dep so growth follows streamed thinking text,
   // not just part count.
   const manual = useRef(false)
-  const want = Math.min(CLOUD_MAX, Math.max(CLOUD_MIN, rows(body) + 3))
+  const want = Math.min(CLOUD_MAX, Math.max(CLOUD_MIN, rows(body, detail) + 3))
   const resize = props.onResize
   useEffect(() => {
     if (!manual.current) resize(want)
@@ -156,7 +157,7 @@ export const ThoughtCloud = memo((props: {
     >
       <box height={1} flexShrink={0} flexDirection="row">
         {pill("reasoning", "reasoning", null)}
-        {pill("tools", "tools", tools.length)}
+        {pill("tools", "tools", seen.length)}
         <box flexGrow={1} />
         {detail !== "expanded" ? (
           <box marginRight={1}><text fg={theme.textMuted}>⟨{detail}⟩</text></box>
@@ -175,7 +176,7 @@ export const ThoughtCloud = memo((props: {
                   <markdown content={(p as ThinkingPart).content} fg={theme.markdownText} syntaxStyle={syntaxStyle} />
                 </box>
               : <box key={(p as ToolPart).id || `t-${i}`} width="100%" flexShrink={0}>
-                  <Tool tool={p as ToolPart} detail={detail === "hidden" ? "hidden" : "collapsed"} />
+                  <Tool branch={i === body.length - 1 ? "last" : "mid"} tool={p as ToolPart} detail={detail} />
                 </box>,
           )}
         </box>

--- a/src/components/chat/tool/Subagent.tsx
+++ b/src/components/chat/tool/Subagent.tsx
@@ -1,16 +1,12 @@
-// delegate_task / subagent renderer — oc's `Task` match.
-//
-// Collapsed: InlineTool row with goal + a sub-line:
-//   running:  ↳ {last tool} {preview}     (or ↳ N toolcalls)
-//   done:     └ N toolcalls · duration
-// Click → expand to the full child trail, each as its own inline row
-// using the same spec() glyphs as top-level tools.
+// delegate_task / subagent renderer. The parent task stays a terse
+// ThoughtCloud trail row; clicking opens the child tool trail.
 
 import { memo, useState } from "react"
 import type { ToolPart as Part } from "../../../types/message"
 import { useTheme } from "../../../theme"
 import { useSpinnerGlyph } from "../../../ui/spinner"
 import { spec } from "./preview"
+import { lead, rail, type Branch } from "./frame"
 
 function dur(d?: number): string {
   if (d == null) return ""
@@ -18,7 +14,7 @@ function dur(d?: number): string {
   return s < 60 ? `${s.toFixed(1)}s` : `${Math.floor(s / 60)}m${Math.round(s % 60)}s`
 }
 
-export const Subagent = memo(({ tool }: { tool: Part }) => {
+export const Subagent = memo(({ branch = "last", tool }: { branch?: Branch; tool: Part }) => {
   const theme = useTheme().theme
   const [open, setOpen] = useState(false)
   const running = tool.status === "running"
@@ -26,6 +22,7 @@ export const Subagent = memo(({ tool }: { tool: Part }) => {
   const spin = useSpinnerGlyph(running)
   const trail = tool.trail ?? []
   const last = trail[trail.length - 1]
+  const stem = rail(branch)
 
   const fg = failed ? theme.error : running ? theme.text : theme.textMuted
   const goal = (tool.goal ?? tool.preview ?? "").replace(/\s+/g, " ").trim()
@@ -34,14 +31,14 @@ export const Subagent = memo(({ tool }: { tool: Part }) => {
     ? last
       ? `↳ ${spec(last.name).verb || last.name} ${last.preview ?? ""}`
       : trail.length ? `↳ ${trail.length} toolcalls` : ""
-    : `└ ${trail.length} toolcall${trail.length === 1 ? "" : "s"}${tool.duration ? ` · ${dur(tool.duration)}` : ""}`
+    : `└─ ${trail.length} toolcall${trail.length === 1 ? "" : "s"}${tool.duration ? ` · ${dur(tool.duration)}` : ""}`
 
   return (
-    <box flexDirection="column" paddingLeft={3 + (tool.depth ?? 0) * 2}
-         onMouseDown={trail.length ? () => setOpen(o => !o) : undefined}>
+    <box flexDirection="column" onMouseDown={trail.length ? () => setOpen(o => !o) : undefined}>
       <box height={1}>
         <text>
-          <span fg={running ? theme.warning : fg}>{running ? spin : "⊙"} </span>
+          <span fg={theme.textMuted}>{lead(branch)}</span>
+          <span fg={running ? theme.warning : fg}>{running ? spin : "●"} </span>
           <span fg={fg}>Task — {goal || "delegating…"}</span>
         </text>
       </box>
@@ -53,21 +50,21 @@ export const Subagent = memo(({ tool }: { tool: Part }) => {
             return (
               <box key={i} height={1}>
                 <text>
-                  <span fg={theme.textMuted}>{i < trail.length - 1 ? "├─ " : "└─ "}</span>
+                  <span fg={theme.textMuted}>{stem}{i < trail.length - 1 ? "├─ " : "└─ "}</span>
                   <span fg={theme.textMuted}>{s.icon} {lbl}</span>
                 </text>
               </box>
             )
           })}
           {tool.result ? (
-            <box minHeight={1} marginTop={1}>
-              <text fg={theme.textMuted} wrapMode="word">{tool.result}</text>
+            <box minHeight={1}>
+              <text fg={theme.textMuted} wrapMode="word">{stem}   {tool.result}</text>
             </box>
           ) : null}
         </box>
       ) : sub ? (
         <box height={1}>
-          <text fg={theme.textMuted}>{sub}</text>
+          <text fg={theme.textMuted}>{stem}{sub}</text>
         </box>
       ) : null}
     </box>

--- a/src/components/chat/tool/frame.tsx
+++ b/src/components/chat/tool/frame.tsx
@@ -1,6 +1,5 @@
-// InlineTool — the single shape every tool renders into in the
-// ThoughtCloud. Diffs that warrant a body render as InlineDiff chips
-// in the assistant message body (MessageItem), not here.
+// InlineTool — one terse ThoughtCloud trail row with optional nested
+// details. Diff bodies stay in MessageItem/DiffTabs, never here.
 
 import { memo, useState, type ReactNode } from "react"
 import type { RGBA } from "@opentui/core"
@@ -16,10 +15,12 @@ function ms(d?: number): string {
   return `${Math.floor(d / 60000)}m${Math.round((d % 60000) / 1000)}s`
 }
 
-export type Detail = { label: string; text: string }
+export type Branch = "mid" | "last"
+export type Detail = { label: string; text: string; tone?: "error" | "muted" }
 
 type InlineProps = {
   part: ToolPart
+  branch?: Branch
   /** Content for the collapsed row; usually preview text. */
   children: ReactNode
   /** True once enough input exists to show `children` instead of pending. */
@@ -29,10 +30,39 @@ type InlineProps = {
   onClick?: () => void
 }
 
+export const lead = (branch: Branch) => branch === "mid" ? "├─ " : "└─ "
+export const rail = (branch: Branch) => branch === "mid" ? "│  " : "   "
+
+const DetailRow = memo((p: { branch: Branch; detail: Detail; last: boolean }) => {
+  const theme = useTheme().theme
+  const fg = p.detail.tone === "error" ? theme.error : theme.textMuted
+  const stem = rail(p.branch)
+  const fork = p.last ? "└─ " : "├─ "
+  const pad = p.last ? "   " : "│  "
+  const lines = p.detail.text.replace(/\t/g, "  ").split("\n")
+
+  return (
+    <box flexDirection="column">
+      <box height={1}>
+        <text>
+          <span fg={theme.textMuted}>{stem}{fork}</span>
+          <span fg={fg}>{p.detail.label}</span>
+        </text>
+      </box>
+      {lines.map((line, i) => (
+        <box key={i} minHeight={1}>
+          <text fg={fg} wrapMode="word">{stem}{pad}{line || " "}</text>
+        </box>
+      ))}
+    </box>
+  )
+})
+
 export const InlineTool = memo((p: InlineProps) => {
   const theme = useTheme().theme
   const [hover, setHover] = useState(false)
   const s = spec(p.part.name)
+  const branch = p.branch ?? "last"
   const running = p.part.status === "running"
   const failed = p.part.status === "error"
   const spin = useSpinnerGlyph(running)
@@ -45,14 +75,14 @@ export const InlineTool = memo((p: InlineProps) => {
   return (
     <box
       flexDirection="column"
-      paddingLeft={3}
       onMouseOver={p.onClick ? () => setHover(true) : undefined}
       onMouseOut={p.onClick ? () => setHover(false) : undefined}
       onMouseDown={p.onClick}
     >
       <box height={1}>
         <text>
-          <span fg={running ? theme.warning : p.iconColor ?? fg}>{running ? spin : s.icon} </span>
+          <span fg={theme.textMuted}>{lead(branch)}</span>
+          <span fg={running ? theme.warning : p.iconColor ?? fg}>{running ? spin : "●"} </span>
           {p.complete ?? true
             ? <span fg={fg}>{p.children}</span>
             : <span fg={fg}>~ {s.pending}</span>}
@@ -61,18 +91,9 @@ export const InlineTool = memo((p: InlineProps) => {
             : null}
         </text>
       </box>
-      {failed && p.part.result ? (
-        <box minHeight={1} paddingLeft={2}>
-          <text fg={theme.error} wrapMode="word">{p.part.result}</text>
-        </box>
-      ) : null}
-      {p.details?.map(d => (
-        <box key={d.label} flexDirection="column" paddingLeft={2} marginTop={1}>
-          <box height={1}><text fg={theme.textMuted}>{d.label}</text></box>
-          <box minHeight={1}><text fg={theme.textMuted} wrapMode="word">{d.text}</text></box>
-        </box>
+      {p.details?.map((detail, i, list) => (
+        <DetailRow key={detail.label} branch={branch} detail={detail} last={i === list.length - 1} />
       ))}
     </box>
   )
 })
-

--- a/src/components/chat/tool/index.tsx
+++ b/src/components/chat/tool/index.tsx
@@ -1,16 +1,16 @@
-// Per-tool dispatch — oc's `<Switch>` over part.tool. Each hermes
-// tool name maps to either an InlineTool row or a BlockTool card.
-//
-// Gateway rows stay compact by default: context/summary/inline_diff
-// feed the one-line row, while redacted verbose args/results render
-// only when the existing detail mode is expanded.
+// Per-tool dispatch. Each hermes tool name maps to a terse trail row;
+// verbose args/results become nested rows only in expanded detail mode.
 
-import { memo } from "react"
+import { memo, useMemo } from "react"
 import type { ToolPart as Part } from "../../../types/message"
 import type { DetailMode } from "../../../context/preferences"
-import { InlineTool, type Detail } from "./frame"
+import { isDiff } from "../DiffBlock"
+import { InlineTool, type Branch, type Detail } from "./frame"
 import { Subagent } from "./Subagent"
 import { spec } from "./preview"
+
+const CHARS = 800
+const LINES = 12
 
 function short(s: string | undefined, n = 120): string {
   if (!s) return ""
@@ -18,29 +18,66 @@ function short(s: string | undefined, n = 120): string {
   return one.length > n ? one.slice(0, n - 1) + "…" : one
 }
 
-const Inline = memo(({ tool }: { tool: Part }) => {
+function cap(s: string): string {
+  const raw = s.trim()
+  let n = 1
+  for (let i = 0; i < raw.length; i++) {
+    if (i >= CHARS) return `${raw.slice(0, i).trimEnd()}\n…`
+    if (raw[i] === "\n" && ++n > LINES) return `${raw.slice(0, i).trimEnd()}\n…`
+  }
+  return raw
+}
+
+function lines(s: string): number {
+  let n = 1
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "\n" && ++n >= 5) return 6
+  }
+  return n + 1
+}
+
+const Inline = memo(({ branch, details, tool }: { branch?: Branch; details?: Detail[]; tool: Part }) => {
   const s = spec(tool.name)
-  const body = tool.preview ? short(tool.preview) : ""
+  const body = tool.preview && !isDiff(tool.preview) ? short(tool.preview) : ""
+  const label = s.verb && body ? `${s.verb} ${body}` : body || s.verb || tool.name
   return (
-    <InlineTool part={tool} complete={!!body || tool.status !== "running"}>
-      {s.verb ? `${s.verb} ${body}` : body || tool.name}
+    <InlineTool branch={branch} part={tool} complete={!!body || tool.status !== "running"} details={details}>
+      {label}
     </InlineTool>
   )
 })
 
-export const Tool = memo(({ tool, detail = "expanded" }: { tool: Part; detail?: DetailMode }) => {
-  if (detail === "hidden" && tool.status !== "running") return null
-  if (tool.trail || tool.name === "delegate_task") return <Subagent tool={tool} />
-  if (detail !== "expanded") return <Inline tool={tool} />
-  const details = [
-    tool.verboseArgs ? { label: "Args", text: tool.verboseArgs } : undefined,
-    tool.verboseResult ? { label: tool.status === "error" ? "Error" : "Result", text: tool.verboseResult } : undefined,
-  ].filter((d): d is Detail => !!d)
-  const s = spec(tool.name)
-  const body = tool.preview ? short(tool.preview) : ""
-  return (
-    <InlineTool part={tool} complete={!!body || tool.status !== "running"} details={details}>
-      {s.verb ? `${s.verb} ${body}` : body || tool.name}
-    </InlineTool>
-  )
+export function visible(tool: Part, mode: DetailMode): boolean {
+  return mode !== "hidden" || tool.status === "running"
+}
+
+export function details(tool: Part, mode: DetailMode): Detail[] {
+  const full = tool.verboseResult && !isDiff(tool.verboseResult) ? tool.verboseResult : undefined
+  const sum = tool.result && !isDiff(tool.result) ? tool.result : undefined
+  const err: Detail | undefined = tool.status === "error" && (full || sum)
+    ? { label: "Error", text: cap(full ?? sum!), tone: "error" }
+    : undefined
+
+  if (mode !== "expanded") return err ? [err] : []
+
+  const out: Detail[] = []
+  if (tool.verboseArgs) out.push({ label: "Args", text: cap(tool.verboseArgs) })
+  if (err) out.push(err)
+  if (tool.verboseResult && tool.status !== "error" && !isDiff(tool.verboseResult)) {
+    out.push({ label: "Result", text: cap(tool.verboseResult) })
+  }
+  return out
+}
+
+export function cost(tool: Part, mode: DetailMode): number {
+  if (!visible(tool, mode)) return 0
+  if (tool.trail || tool.name === "delegate_task") return 2
+  return 1 + details(tool, mode).reduce((n, d) => n + lines(d.text), 0)
+}
+
+export const Tool = memo(({ branch, tool, detail = "expanded" }: { branch?: Branch; tool: Part; detail?: DetailMode }) => {
+  const list = useMemo(() => details(tool, detail), [tool, detail])
+  if (!visible(tool, detail)) return null
+  if (tool.trail || tool.name === "delegate_task") return <Subagent branch={branch} tool={tool} />
+  return <Inline branch={branch} details={list} tool={tool} />
 })

--- a/test/messagelist.test.tsx
+++ b/test/messagelist.test.tsx
@@ -120,14 +120,14 @@ describe("MessageList", () => {
 })
 
 describe("tool/inline", () => {
-  test("terminal + read_file render icon/verb rows", async () => {
+  test("terminal + read_file render trail rows", async () => {
     let t = await tool(turn[1].parts[1] as ToolPart)
-    await until(t, () => t.frame().includes("$ bun run build"))
+    await until(t, () => t.frame().includes("● bun run build"))
     expect(t.frame()).toContain("87ms")
     t.destroy()
 
     t = await tool(turn[1].parts[2] as ToolPart)
-    await until(t, () => t.frame().includes("→ Read src/index.tsx"))
+    await until(t, () => t.frame().includes("● Read src/index.tsx"))
     t.destroy()
   })
 
@@ -148,7 +148,7 @@ describe("tool/inline", () => {
       preview: "rm -rf /", status: "error", duration: 5,
       result: "permission denied",
     })
-    await until(t, () => t.frame().includes("$ rm -rf /"))
+    await until(t, () => t.frame().includes("● rm -rf /"))
     expect(t.frame()).toContain("permission denied")
     t.destroy()
   })
@@ -206,6 +206,19 @@ describe("tool/file-edit", () => {
       status: "done", duration: 5, diff: UDIFF,
     })
     await until(t, () => t.frame().includes("Edit") && !t.frame().includes("changed"))
+    t.destroy()
+  })
+
+  test("file-edit diff preview falls back to terse edit label", async () => {
+    const t = await tool({
+      type: "tool", id: "td", name: "patch", args: "",
+      preview: UDIFF, status: "done", duration: 5, diff: UDIFF,
+    })
+    await until(t, () => t.frame().includes("Edit"))
+    const f = t.frame()
+    expect(f).not.toContain("--- a/foo.ts")
+    expect(f).not.toContain("@@")
+    expect(f).not.toContain("+new line")
     t.destroy()
   })
 

--- a/test/subagent.test.tsx
+++ b/test/subagent.test.tsx
@@ -80,11 +80,11 @@ describe("Subagent renderer", () => {
     return t
   }
 
-  test("collapsed: goal + footer row (└ N toolcalls · dur)", async () => {
+  test("collapsed: goal + footer row (└─ N toolcalls · dur)", async () => {
     const t = await setup({})
-    await until(t, () => t.frame().includes("⊙ Task — refactor foo"))
+    await until(t, () => t.frame().includes("● Task — refactor foo"))
     const f = t.frame()
-    expect(f).toContain("└ 3 toolcalls · 4.2s")
+    expect(f).toContain("└─ 3 toolcalls · 4.2s")
     expect(f).not.toContain("├─")
     expect(f).not.toContain("bun test")
     t.destroy()
@@ -101,8 +101,8 @@ describe("Subagent renderer", () => {
 
   test("click expands to ├─/└─ trail with per-child glyphs + summary", async () => {
     const t = await setup({})
-    await until(t, () => t.frame().includes("⊙ Task — refactor foo"))
-    const p = locate(t, "⊙ Task")
+    await until(t, () => t.frame().includes("● Task — refactor foo"))
+    const p = locate(t, "● Task")
     await act(async () => { await t.mouse.pressDown(p.x, p.y) })
     await until(t, () => t.frame().includes("├─"))
 
@@ -111,7 +111,7 @@ describe("Subagent renderer", () => {
     expect(f).toContain("├─ $ bun test")
     expect(f).toContain("└─ ← Edit src/a.ts")
     expect(f).toContain("3 files changed")
-    expect(f).not.toContain("└ 3 toolcalls")
+    expect(f).not.toContain("└─ 3 toolcalls")
     t.destroy()
   })
 })

--- a/test/thoughtcloud.test.tsx
+++ b/test/thoughtcloud.test.tsx
@@ -1,8 +1,9 @@
 import { describe, test, expect } from "bun:test"
 import { act } from "react"
 import { useState } from "react"
-import { mountNode } from "./harness"
+import { mountNode, until } from "./harness"
 import { Tail, ThoughtCloud } from "../src/components/chat/ThoughtCloud"
+import * as prefs from "../src/context/preferences"
 import type { Message } from "../src/types/message"
 
 // Tail animates by mutating span .children out of React's view. The
@@ -60,5 +61,64 @@ describe("ThoughtCloud reasoning", () => {
     expect(f).not.toContain("**verify**")
     expect(f).not.toContain("Write src/x.ts")
     t.destroy()
+  })
+})
+
+describe("ThoughtCloud tools", () => {
+  test("renders expanded tool details as nested trail rows while keeping diffs out", async () => {
+    prefs.reset()
+    prefs.set("toolDetails", "expanded")
+    const diff = "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n"
+    const messages: Message[] = [{
+      id: "a1", role: "assistant", timestamp: 0,
+      parts: [{
+        type: "tool", id: "tw", name: "patch", args: "",
+        preview: "src/x.ts", status: "done", duration: 9,
+        diff, verboseArgs: "{\"path\":\"src/x.ts\"}", verboseResult: "patched result",
+      }],
+    }]
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%">
+        <ThoughtCloud height={12} messages={messages} onResize={() => {}} />
+      </box>,
+      { width: 100, height: 20 },
+    )
+    await until(t, () => t.frame().includes("● Edit src/x.ts"))
+    const f = t.frame()
+    expect(f).toContain("└─ ● Edit src/x.ts")
+    expect(f).toContain("Args")
+    expect(f).toContain("Result")
+    expect(f).toContain("patched result")
+    expect(f).not.toContain("@@")
+    expect(f).not.toContain("+new")
+    t.destroy()
+    prefs.reset()
+  })
+
+  test("hidden mode counts and branches only visible running tools", async () => {
+    prefs.reset()
+    prefs.set("toolDetails", "hidden")
+    const messages: Message[] = [{
+      id: "a1", role: "assistant", timestamp: 0,
+      parts: [
+        { type: "tool", id: "a", name: "read_file", args: "", preview: "src/a.ts", status: "done" },
+        { type: "tool", id: "b", name: "search_files", args: "", preview: "needle", status: "running" },
+        { type: "tool", id: "c", name: "terminal", args: "", preview: "bun test", status: "done" },
+      ],
+    }]
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%">
+        <ThoughtCloud height={12} messages={messages} onResize={() => {}} />
+      </box>,
+      { width: 100, height: 20 },
+    )
+    await until(t, () => t.frame().includes("tools 1"))
+    const f = t.frame()
+    expect(f).toContain("└─")
+    expect(f).toContain("needle")
+    expect(f).not.toContain("src/a.ts")
+    expect(f).not.toContain("bun test")
+    t.destroy()
+    prefs.reset()
   })
 })

--- a/test/tool-detail.test.tsx
+++ b/test/tool-detail.test.tsx
@@ -85,6 +85,20 @@ describe("Tool > detail mode", () => {
     t.destroy()
   })
 
+  test("expanded error mode prefers verbose error detail", async () => {
+    const verbose: ToolPart = {
+      type: "tool", id: "t4", name: "terminal", args: "",
+      preview: "bun test", status: "error", duration: 10,
+      result: "failed", verboseResult: "failed\ntraceback line",
+    }
+    const t = await mount(verbose, "expanded")
+    await until(t, () => t.frame().includes("traceback line"))
+    const f = t.frame()
+    expect(f).toContain("Error")
+    expect(f).toContain("traceback line")
+    t.destroy()
+  })
+
   test("collapsed mode keeps verbose details hidden", async () => {
     const verbose: ToolPart = {
       type: "tool", id: "t3", name: "patch", args: "",


### PR DESCRIPTION
## Summary

ThoughtCloud tool calls now render as a compact vertical trail instead of relying on the broken side-detail view. Simple tools stay as terse status rows, while expanded mode nests bounded args/results/error details under the tool row.

Diff bodies remain in the existing assistant-message diff tabs, so patch/write output does not leak into the process trail.

## Verification

- `bunx tsc --noEmit`
- `git diff --check`
- `bun test`
