### PR TITLE
fix(chat): size nested ThoughtCloud tool rows

### DIFF
--- a/src/components/chat/tool/Subagent.tsx
+++ b/src/components/chat/tool/Subagent.tsx
@@ -35,8 +35,8 @@ export const Subagent = memo(({ branch = "last", tool }: { branch?: Branch; tool
 
   return (
     <box flexDirection="column" onMouseDown={trail.length ? () => setOpen(o => !o) : undefined}>
-      <box height={1}>
-        <text>
+      <box minHeight={1}>
+        <text wrapMode="word">
           <span fg={theme.textMuted}>{lead(branch)}</span>
           <span fg={running ? theme.warning : fg}>{running ? spin : "●"} </span>
           <span fg={fg}>Task — {goal || "delegating…"}</span>
@@ -63,8 +63,8 @@ export const Subagent = memo(({ branch = "last", tool }: { branch?: Branch; tool
           ) : null}
         </box>
       ) : sub ? (
-        <box height={1}>
-          <text fg={theme.textMuted}>{stem}{sub}</text>
+        <box minHeight={1}>
+          <text fg={theme.textMuted} wrapMode="word">{stem}{sub}</text>
         </box>
       ) : null}
     </box>

--- a/src/components/chat/tool/index.tsx
+++ b/src/components/chat/tool/index.tsx
@@ -11,6 +11,7 @@ import { spec } from "./preview"
 
 const CHARS = 800
 const LINES = 12
+const TRAIL = 8
 
 function short(s: string | undefined, n = 120): string {
   if (!s) return ""
@@ -71,7 +72,8 @@ export function details(tool: Part, mode: DetailMode): Detail[] {
 
 export function cost(tool: Part, mode: DetailMode): number {
   if (!visible(tool, mode)) return 0
-  if (tool.trail || tool.name === "delegate_task") return 2
+  if (tool.trail) return 2 + Math.min(tool.trail.length, TRAIL)
+  if (tool.name === "delegate_task") return 2
   return 1 + details(tool, mode).reduce((n, d) => n + lines(d.text), 0)
 }
 

--- a/test/subagent.test.tsx
+++ b/test/subagent.test.tsx
@@ -99,6 +99,19 @@ describe("Subagent renderer", () => {
     t.destroy()
   })
 
+  test("wraps long running goals without hiding continuation text", async () => {
+    const goal = "Independently inspect Herm's ThoughtCloud tool rendering path, especially delegate_task/subagent rows. Return concise findings: relevant files/components, how delegate_task is dispatched, and any focused tests that cover it. Do not modify files"
+    const t = await mountNode(
+      <box flexDirection="column" width="100%" height="100%"><Tool tool={part({ status: "running", duration: undefined, goal, preview: goal, trail: [] })} /></box>,
+      { width: 90, height: 20 },
+    )
+    await until(t, () => t.frame().includes("Task — Independently inspect"))
+    const f = t.frame()
+    expect(f).toContain("delegate_task is")
+    expect(f).toContain("dispatched, and any focused tests")
+    t.destroy()
+  })
+
   test("click expands to ├─/└─ trail with per-child glyphs + summary", async () => {
     const t = await setup({})
     await until(t, () => t.frame().includes("● Task — refactor foo"))

--- a/test/tool-detail.test.tsx
+++ b/test/tool-detail.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test, beforeEach } from "bun:test"
 import { act } from "react"
 import { mountNode, until } from "./harness"
 import * as prefs from "../src/context/preferences"
-import { Tool } from "../src/components/chat/tool"
+import { Tool, cost } from "../src/components/chat/tool"
 import type { ToolPart } from "../src/types/message"
 
 describe("preferences > usePref", () => {
@@ -110,5 +110,20 @@ describe("Tool > detail mode", () => {
     await until(t, () => t.frame().includes("Edit src/z.ts"))
     expect(t.frame()).not.toContain("patched result")
     t.destroy()
+  })
+
+  test("cost counts capped trail rows by shape", () => {
+    const trail = Array.from({ length: 20 }, (_, i) => ({ name: "read_file", preview: `src/${i}.ts` }))
+    const tool: ToolPart = {
+      type: "tool", id: "sub", name: "custom_parent", args: "",
+      preview: "parent", status: "running", trail,
+    }
+    const task: ToolPart = {
+      type: "tool", id: "task", name: "delegate_task", args: "",
+      preview: "delegate", status: "running",
+    }
+
+    expect(cost(tool, "expanded")).toBe(10)
+    expect(cost(task, "expanded")).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary

- ThoughtCloud now reserves bounded height for tools with child trails, so nested tool activity can grow the cloud before another top-level row arrives.
- Subagent task and collapsed summary rows now wrap into real layout rows instead of clipping long text inside a one-row container.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH bun test test/subagent.test.tsx test/thoughtcloud.test.tsx test/tool-detail.test.tsx test/messagelist.test.tsx`
- `PATH=/home/kaio/.bun/bin:$PATH bunx tsc --noEmit`
