### PR TITLE
fix(eikon): repair Studio source lifecycle

### DIFF
--- a/src/service/eikon.ts
+++ b/src/service/eikon.ts
@@ -17,8 +17,9 @@
 // live on every open of the rasterizer picker.
 
 import { existsSync, mkdirSync, readdirSync, copyFileSync, readFileSync, writeFileSync, rmSync, statSync, renameSync } from "node:fs"
+import { createHash } from "node:crypto"
 import { join, extname, basename, dirname } from "node:path"
-import { install, resolve, peek, entries as packageEntries, dirty, header as peekHeader, serializeLaunchStream, defaultSignalMappings, decodeRuntimeBytes,
+import { install, resolve, peek, entries as packageEntries, downloadBytes, dirty, header as peekHeader, serializeLaunchStream, defaultSignalMappings, decodeRuntimeBytes,
          type LaunchStreamRecord, type Installed as Got, type Resolved as ResolvedEikon, type Origin as EikonOrigin, type TrustState, type SourceKind, type DownloadOptions, type RuntimeDescriptor } from "eikon"
 import { DEFAULT_PUBLIC_CATALOG } from "eikon/catalog"
 import { hermesPath } from "./hermes-home"
@@ -235,13 +236,6 @@ export function lifecycle(name: string, opts: { dirty?: boolean } = {}): Lifecyc
   }
 }
 
-export function sourceFetchUrl(name: string): string | undefined {
-  const man = manifest(name)
-  const head = header(file(name))
-  const info = sourceInfo(man, head)
-  return info.packageUrl ?? info.origin
-}
-
 /** List folder-form eikons under ~/.hermes/eikons/. Flat legacy
  *  <name>.eikon at the root is still readable by listEikons() in
  *  components/avatar/eikon.ts but doesn't appear here (no studio). */
@@ -253,14 +247,12 @@ export function list(): Installed[] {
     .map(e => {
       const name = e.name
       normalizeStoredSources(name)
-      const src = join(root, e.name, "source")
-      const has = !!findSource(name)
       const man = manifest(name)
-      const head = header(join(root, name, `${name}.eikon`))
+      const path = join(root, name, `${name}.eikon`)
       return {
-        name, file: join(root, name, `${name}.eikon`),
-        source: src, hasSource: has,
-        sourceUrl: origin(man) ?? legacySource(head),
+        name, file: path,
+        source: join(root, name, "source"), hasSource: hasLocalSource(name),
+        sourceUrl: sourceUrl(man, header(path)),
         manifest: man,
         lifecycle: lifecycle(name, { dirty: false }),
       }
@@ -295,7 +287,7 @@ const MEDIA_EXT: Record<string, string> = {
 type SourceFile = { path?: string; mediaType?: string }
 type SourceManifest = { files?: SourceFile[] }
 
-function sourceRole(role: string): role is keyof Sources & string {
+function slot(role: string): role is keyof Sources & string {
   return role === "base" || STATES.includes(role as AvatarState)
 }
 
@@ -314,7 +306,7 @@ function sourceRefs(man: SourceManifest | undefined): Map<string, string> {
   if (!man) return new Map()
   try {
     return new Map(packageEntries(man as never)
-      .filter(([role]) => sourceRole(String(role)))
+      .filter(([role]) => slot(String(role)))
       .map(([role, rel]) => [String(role), rel]))
   } catch {
     return new Map()
@@ -354,17 +346,163 @@ function normalizeStoredSources(name: string): void {
   try { readStudio(name) } catch {}
 }
 
-/** Resolve the effective source path for a state: per-state file →
- *  base.* → idle.* → first image → first video. Returns absolute path. */
-export function findSource(name: string, state?: AvatarState): string | undefined {
+export type Sources = Partial<Record<AvatarState | "base", string | null>>
+export type SourceRole = AvatarState | "base"
+export type SourceStatus = {
+  name: string
+  state: AvatarState
+  kind: "local" | "downloadable" | "baked" | "missing"
+  path?: string
+  file?: string
+  size?: number
+  role?: SourceRole
+  origin?: "draft" | "studio" | "discovered" | "fallback"
+  own: boolean
+  inherited: boolean
+  removed: boolean
+  downloadable: boolean
+  sourceUrl?: string
+}
+
+function fileOk(name: string): boolean {
+  return IMG.test(name) || VID.test(name)
+}
+
+function roleOf(name: string): SourceRole | undefined {
+  const stem = basename(name, extname(name)).toLowerCase()
+  if (stem === "base") return "base"
+  return (STATES as readonly string[]).includes(stem) ? stem as AvatarState : undefined
+}
+
+function sourcePath(name: string, value: string): string {
+  return value.includes("/") ? value : join(sourceDir(name), value)
+}
+
+function storedName(value: string): string {
+  return value.includes("/") ? basename(value) : value
+}
+
+function sourceFiles(name: string) {
   const src = sourceDir(name)
-  if (!existsSync(src)) return undefined
-  const files = readdirSync(src).filter(f => IMG.test(f) || VID.test(f))
-  if (files.length === 0) return undefined
-  const by = (stem: string) => files.find(f => basename(f, extname(f)).toLowerCase() === stem)
-  const pick = (state && by(state)) ?? by("base") ?? by("idle") ?? by(name)
-    ?? files.find(f => IMG.test(f)) ?? files[0]!
-  return join(src, pick)
+  if (!existsSync(src)) return []
+  return readdirSync(src).filter(fileOk)
+}
+
+function byRole(files: string[], role: SourceRole): string | undefined {
+  return files.find(f => roleOf(f) === role)
+}
+
+function roles(state?: AvatarState): SourceRole[] {
+  if (!state) return ["base", "idle"]
+  return state === "idle" ? ["idle", "base"] : [state, "base", "idle"]
+}
+
+function entryRole(value: string | undefined, path: string): SourceRole | undefined {
+  if (value === "source.base") return "base"
+  if (value?.startsWith("source.")) {
+    const role = value.slice("source.".length)
+    if (role === "base") return "base"
+    if ((STATES as readonly string[]).includes(role)) return role as AvatarState
+  }
+  return roleOf(path) ?? "base"
+}
+
+function sourceEntries(man: Record<string, unknown> | undefined, strict = false): Array<[SourceRole, string]> {
+  if (!man) return []
+  try {
+    const xs = packageEntries(man as never).map(([role, path]) => [role as SourceRole, path] as [SourceRole, string])
+    if (xs.length) return xs
+  } catch (err) {
+    if (strict) throw err
+  }
+  const files = Array.isArray(man.files) ? man.files : []
+  return files.flatMap(file => {
+    if (typeof file === "string") return [[entryRole(undefined, file) ?? "base", file] as [SourceRole, string]]
+    if (!OBJ(file) || typeof file.path !== "string" || !String(file.role ?? "").startsWith("source")) return []
+    const role = entryRole(typeof file.role === "string" ? file.role : undefined, file.path)
+    return role ? [[role, file.path] as [SourceRole, string]] : []
+  })
+}
+
+function sourceUrl(man: Record<string, unknown> | undefined, head: Record<string, unknown> | undefined): string | undefined {
+  const src = sourceInfo(man, head)
+  return src.packageUrl ?? src.origin
+}
+
+export function sourceFetchUrl(name: string): string | undefined {
+  return sourceUrl(manifest(name), header(file(name)))
+}
+
+export function sourceStatus(name: string, state?: AvatarState, opts: { sources?: Sources } = {}): SourceStatus {
+  const seed = opts.sources ?? readStudio(name)?.sources
+  const files = sourceFiles(name)
+  const removed = new Set(Object.entries(seed ?? {}).flatMap(([role, value]) => value === null ? [role] : []))
+  const visible = files.filter(f => {
+    const role = roleOf(f)
+    return !role || !removed.has(role)
+  })
+  const hit = (role: SourceRole): Pick<SourceStatus, "path" | "file" | "role" | "origin"> | undefined => {
+    if (removed.has(role)) return undefined
+    const value = seed?.[role]
+    if (typeof value === "string" && value) {
+      const path = sourcePath(name, value)
+      if (existsSync(path) && fileOk(path)) return { path, file: storedName(value), role, origin: opts.sources ? "draft" : "studio" }
+    }
+    const file = byRole(visible, role)
+    return file ? { path: join(sourceDir(name), file), file, role, origin: "discovered" } : undefined
+  }
+  const found = roles(state).map(hit).find(Boolean)
+  const first = removed.size ? undefined : visible.find(f => IMG.test(f)) ?? visible.find(f => VID.test(f))
+  const src = found ?? (first ? { path: join(sourceDir(name), first), file: first, role: roleOf(first), origin: "fallback" as const } : undefined)
+  const st = state ?? "idle"
+  const own = Boolean(src?.role && (src.role === st || (st === "idle" && src.role === "base")))
+  const man = manifest(name)
+  const pack = baked(name)
+  const head = header(file(name)) ?? (pack ? header(pack) : undefined)
+  const url = sourceUrl(man, head)
+  const downloadable = !src && Boolean(url)
+  const size = src?.path ? (() => { try { return statSync(src.path).size } catch { return undefined } })() : undefined
+  return {
+    name,
+    state: st,
+    kind: src ? "local" : downloadable ? "downloadable" : pack ? "baked" : "missing",
+    ...(src?.path ? { path: src.path } : {}),
+    ...(src?.file ? { file: src.file } : {}),
+    ...(size !== undefined ? { size } : {}),
+    ...(src?.role ? { role: src.role } : {}),
+    ...(src?.origin ? { origin: src.origin } : {}),
+    own,
+    inherited: Boolean(src && !own),
+    removed: roles(state).some(role => removed.has(role)),
+    downloadable,
+    ...(url ? { sourceUrl: url } : {}),
+  }
+}
+
+export function localSources(name: string): Array<{ role?: SourceRole; file: string; path: string }> {
+  return sourceFiles(name).map(file => ({ file, path: join(sourceDir(name), file), ...(roleOf(file) ? { role: roleOf(file) } : {}) }))
+}
+
+export function hasLocalSource(name: string): boolean {
+  if (sourceFiles(name).length > 0) return true
+  return Object.values(readStudio(name)?.sources ?? {}).some(value =>
+    typeof value === "string" && fileOk(value) && existsSync(sourcePath(name, value)))
+}
+
+export function sourceStamp(name: string): string {
+  const src = sourceDir(name)
+  const stats = [studioFile(name), existsSync(file(name)) ? file(name) : ""].filter(Boolean).map(path => {
+    try { const st = statSync(path); return `${basename(path)}:${st.mtimeMs}:${st.size}` } catch { return `${basename(path)}:missing` }
+  })
+  const media = sourceFiles(name).sort().map(f => {
+    try { const st = statSync(join(src, f)); return `${f}:${st.mtimeMs}:${st.size}` } catch { return `${f}:missing` }
+  })
+  return [...stats, ...media].join("|")
+}
+
+/** Resolve the effective source path for a state. Returns absolute path. */
+export function findSource(name: string, state?: AvatarState): string | undefined {
+  return sourceStatus(name, state).path
 }
 
 /** Copy an external file into <name>/source/ as <role>.<ext>. No-op if
@@ -486,7 +624,8 @@ export async function save(s: Session): Promise<string> {
   const paths = ensure(s.name)
   // Adopt any external-path sources into source/.
   const sources: Session["sources"] = {}
-  for (const [role, p] of Object.entries(s.sources) as Array<[AvatarState | "base", string]>) {
+  for (const [role, p] of Object.entries(s.sources) as Array<[AvatarState | "base", string | null]>) {
+    if (p === null) { sources[role] = null; continue }
     if (!p) continue
     const abs = p.includes("/") ? p : join(paths.source, p)
     sources[role] = existsSync(abs) ? adopt(s.name, abs, role) : p
@@ -496,7 +635,7 @@ export async function save(s: Session): Promise<string> {
   const clips = new Map<AvatarState, Frame[]>()
   const blank = [Array.from({ length: H }, (_, i) => (i === H >> 1 ? s.glyph.padStart(W >> 1) : "").padEnd(W))]
   for (const st of STATES) {
-    const src = findSource(s.name, st)
+    const src = sourceStatus(s.name, st, { sources }).path
     const k = eff(s, st)
     const key = `${src ?? ""}|${JSON.stringify(k)}`
     let fs = seen.get(key)
@@ -554,7 +693,6 @@ export async function update(name: string, opts: { confirmActive?: boolean } = {
 
 // ── Install / fetch ──────────────────────────────────────────────────
 
-export type Sources = Partial<Record<AvatarState | "base", string>>
 export type Fetched = { name: string; sources: Sources; n: number; bytes: number }
 export type LifecycleState = AvatarState
 export type PackageState = "available" | "invalid" | "installed" | "active" | "update-available" | "incompatible"
@@ -643,6 +781,64 @@ export function attachSources(name: string, sources: Sources) {
   const prev = readStudio(name)
   writeStudio(name, { ...(prev ?? toStudio(fresh(name, pick()))), sources: { ...prev?.sources, ...sources } })
   bump()
+}
+
+function digest(data: Uint8Array) {
+  return `sha256:${createHash("sha256").update(data).digest("hex")}`
+}
+
+function dlOpts(url: string, opts: DownloadOptions = {}): DownloadOptions {
+  return /^http:\/\/localhost[:/]/.test(url) ? { allowPrivate: true, ...opts } : opts
+}
+
+function manUrl(url: string): string {
+  if (url.endsWith("manifest.json")) return url
+  return new URL("manifest.json", url.endsWith("/") ? url : `${url}/`).toString()
+}
+
+function specOf(man: Record<string, unknown>, rel: string): Record<string, unknown> | undefined {
+  const files = Array.isArray(man.files) ? man.files : []
+  return files.find(f => OBJ(f) && f.path === rel) as Record<string, unknown> | undefined
+}
+
+async function readManifest(url: string, opts: DownloadOptions): Promise<Record<string, unknown>> {
+  const raw = await downloadBytes(url, opts)
+  const man = JSON.parse(Buffer.from(raw).toString("utf8")) as unknown
+  if (!OBJ(man)) throw new Error("source manifest: object required")
+  return man
+}
+
+async function readSource(file: Record<string, unknown> | undefined, base: string, rel: string, opts: DownloadOptions) {
+  const raw = await downloadBytes(new URL(rel, base).toString(), opts)
+  const size = file?.size
+  if (typeof size === "number" && raw.length !== size) throw new Error(`source size mismatch: ${rel}`)
+  if (typeof file?.digest === "string" && digest(raw) !== file.digest) throw new Error(`source digest mismatch: ${rel}`)
+  return raw
+}
+
+export async function downloadSource(name: string, opts: { downloader?: DownloadOptions } = {}): Promise<Fetched> {
+  const url = sourceFetchUrl(name)
+  if (!url) throw new Error(`eikon '${name}' has no published source`)
+  const href = manUrl(url)
+  const root = href.slice(0, href.lastIndexOf("/") + 1)
+  const dl = dlOpts(url, opts.downloader)
+  const man = await readManifest(href, dl)
+  const xs = sourceEntries(man, true)
+  if (xs.length === 0) throw new Error(`eikon '${name}' has no published source media`)
+  const dir = ensure(name).source
+  const pairs = await Promise.all(xs.map(async ([role, rel]) => {
+    const file = specOf(man, rel)
+    const fname = sourceName(man as SourceManifest, role, rel)
+    if (!fileOk(fname)) throw new Error(`source media type unsupported: ${rel}`)
+    return [role, fname, await readSource(file, root, rel, dl)] as const
+  }))
+  const sources: Sources = {}
+  await Promise.all(pairs.map(async ([role, fname, data]) => {
+    await Bun.write(join(dir, fname), data)
+    sources[role] = fname
+  }))
+  attachSources(name, sources)
+  return { name, sources, n: pairs.length, bytes: pairs.reduce((sum, [, , data]) => sum + data.length, 0) }
 }
 
 export async function fetchSource(src: string, opts?: { name?: string; media?: boolean;

--- a/src/tabs/EikonStudio.tsx
+++ b/src/tabs/EikonStudio.tsx
@@ -14,7 +14,6 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExterna
 import { extend, useKeyboard, useTerminalDimensions } from "@opentui/react"
 import { SliderRenderable } from "@opentui/core"
 import type { ParsedKey, ScrollBoxRenderable } from "@opentui/core"
-import { statSync } from "node:fs"
 import { basename } from "node:path"
 import type { ReactNode } from "react"
 import { useTheme } from "../theme"
@@ -67,7 +66,7 @@ type RowKind = "select" | "prompt" | "action" | "divider" | "header" | "knob" | 
 type Row = {
   id: string; kind: RowKind; label: string
   knob?: KnobDef
-  show?: (s: Session, live: boolean, url?: string) => boolean
+  show?: (s: Session, status: eikon.SourceStatus) => boolean
 }
 
 const mb = (n: number) => n < 1024 ? `${n} B`
@@ -78,23 +77,23 @@ const HEAD: readonly Row[] = [
   { id: "rasterizer", kind: "select", label: "rasterizer" },
   { id: "source",     kind: "prompt", label: "source" },
   { id: "-1",         kind: "divider", label: "" },
-  { id: "fetch",      kind: "action", label: "fetch source",
-    show: (s, live, url) => !live && !!url },
-  { id: "knobsfor",   kind: "action", label: "tune",        show: (_s, live) => live },
-  { id: "reset",      kind: "action", label: "reset",       show: (_s, live) => live },
+  { id: "fetch",      kind: "action", label: "download source",
+    show: (_s, status) => status.downloadable },
+  { id: "knobsfor",   kind: "action", label: "tune",        show: (_s, status) => !!status.path },
+  { id: "reset",      kind: "action", label: "reset",       show: (_s, status) => !!status.path },
   { id: "revert",     kind: "action", label: "revert",      show: s => s.dirty },
-  { id: "-2",         kind: "divider", label: "", show: (_s, live) => live },
-  { id: "h-input",    kind: "header",  label: "input", show: (_s, live) => live },
-  { id: "contrast",   kind: "tone",    label: "contrast",   show: (_s, live) => live,
+  { id: "-2",         kind: "divider", label: "", show: (_s, status) => !!status.path },
+  { id: "h-input",    kind: "header",  label: "input", show: (_s, status) => !!status.path },
+  { id: "contrast",   kind: "tone",    label: "contrast",   show: (_s, status) => !!status.path,
     knob: { kind: "slider", min: 0.25, max: 4, step: 0.05, default: 1,
             hint: "Spread pixel values around their mean. ×1 = source as-is; higher sharpens, lower flattens. Applied to the image before rasterizing." } },
-  { id: "invert",     kind: "tone",    label: "invert",     show: (_s, live) => live,
+  { id: "invert",     kind: "tone",    label: "invert",     show: (_s, status) => !!status.path,
     knob: { kind: "toggle", default: true,
             hint: "Swap light↔dark in the source pixels. On for a light subject on a dark terminal background — turn off if the subject is darker than its surround." } },
-  { id: "flip",       kind: "tone",    label: "flip",       show: (_s, live) => live,
+  { id: "flip",       kind: "tone",    label: "flip",       show: (_s, status) => !!status.path,
     knob: { kind: "cycle", options: ["none", "h", "v", "hv"], default: "none",
             hint: "Mirror the source horizontally, vertically, or both before rasterizing." } },
-  { id: "-3",         kind: "divider", label: "", show: (_s, live) => live },
+  { id: "-3",         kind: "divider", label: "", show: (_s, status) => !!status.path },
 ]
 
 // One-sentence help per row, shown at the bottom of the Settings
@@ -104,8 +103,8 @@ const HEAD: readonly Row[] = [
 const HELP: Readonly<Record<string, string>> = {
   open:       "Which eikon you're editing. Enter to switch, create a new one, or install from elsewhere.",
   rasterizer: "The engine that turns your source image/video into text art. Each rasterizer exposes its own look-and-feel settings below the divider.",
-  source:     "The image or video file the avatar is rendered from. Enter to pick, generate, or clear.",
-  fetch:      "Download this eikon's published source media so you can re-tune it locally.",
+  source:     "Pick, generate, or clear source.",
+  fetch:      "Download published source for local editing.",
   knobsfor:   "←→ toggles whether the settings below apply to every state or just the one selected in the strip.",
   reset:      "Restore every setting below to this rasterizer's defaults and drop per-state overrides.",
   submit:     "Submit this local eikon after backend preflight.",
@@ -117,8 +116,7 @@ const FLIPS: readonly Flip[] = ["none", "h", "v", "hv"]
 function helpOf(row: Row | undefined): ReactNode {
   if (!row) return ""
   if (row.id === "source") return <>
-    <span>{HELP.source} </span>
-    <strong>Use /eikon-create to generate source files interactively (recommended).</strong>
+    <span>{HELP.source}</span>
   </>
   const head = HELP[row.id]
   if (head) return head
@@ -130,12 +128,12 @@ function helpOf(row: Row | undefined): ReactNode {
   return `←→ or drag adjusts (${row.knob.min}–${row.knob.max}); scroll while selected also works.`
 }
 
-function buildRows(r: Rasterizer, s: Session, live: boolean, url?: string): Row[] {
-  const dyn = live
+function buildRows(r: Rasterizer, s: Session, status: eikon.SourceStatus): Row[] {
+  const dyn = status.path
     ? Object.entries(r.knobs).map<Row>(([id, def]) =>
         ({ id, kind: "knob", label: def.label ?? id, knob: def }))
     : []
-  const head = HEAD.filter(h => h.show ? h.show(s, live, url) : true)
+  const head = HEAD.filter(h => h.show ? h.show(s, status) : true)
   return dyn.length
     ? [...head, { id: "h-r", kind: "header", label: r.name }, ...dyn]
     : head
@@ -294,7 +292,7 @@ function SpatialBar(props: {
 // ── Knob row renderers ───────────────────────────────────────────────
 
 function valueOf(s: Session, r: Rasterizer, row: Row, theme: Theme,
-                 src?: string, peek?: { n: number; bytes: number }, busy?: boolean): string | ReactNode {
+                 status?: eikon.SourceStatus, peek?: { n: number; bytes: number }, busy?: boolean): string | ReactNode {
   if (row.id === "open") return `${s.name} ▸`
   if (row.id === "rasterizer") {
     const a = r.available()
@@ -302,10 +300,14 @@ function valueOf(s: Session, r: Rasterizer, row: Row, theme: Theme,
     return <><span>{`${r.name} ▸`}</span><span fg={theme.warning}>{` ⚠ ${a}`}</span></>
   }
   if (row.id === "source") {
-    if (!src) return "(none — Enter to attach)"
+    if (!status?.path) {
+      if (status?.kind === "downloadable") return "Download source"
+      if (status?.kind === "baked") return "Baked only"
+      return "Missing source"
+    }
     const d = s.dims
-    const sz = (() => { try { return mb(statSync(src).size) } catch { return "?" } })()
-    return d ? `${basename(src)} · ${d.w}×${d.h} · ${sz}` : `${basename(src)} · ${sz}`
+    const sz = status.size === undefined ? "?" : mb(status.size)
+    return d ? `${basename(status.path)} · ${d.w}×${d.h} · ${sz}` : `${basename(status.path)} · ${sz}`
   }
   if (row.id === "knobsfor") {
     const forked = !!s.per[s.state]
@@ -318,8 +320,8 @@ function valueOf(s: Session, r: Rasterizer, row: Row, theme: Theme,
     if (row.id === "invert") return s.tone.invert ? "● on" : "○ off"
     if (row.id === "flip") return `◂ ${s.tone.flip} ▸`
   }
-  if (row.id === "fetch") return busy ? "fetching…"
-    : peek ? `▸ download to edit  (${peek.n} files, ${mb(peek.bytes)})` : "▸ download to edit"
+  if (row.id === "fetch") return busy ? "downloading…"
+    : peek ? `▸ ${peek.n} files · ${mb(peek.bytes)}` : "▸ local editable source"
   if (row.kind === "knob" && row.knob) {
     const k = knobs.eff(s, s.state)[row.id] ?? row.knob.default
     if (row.knob.kind === "cycle") return `◂ ${String(k)} ▸`
@@ -330,7 +332,7 @@ function valueOf(s: Session, r: Rasterizer, row: Row, theme: Theme,
 }
 
 function KnobRow(props: {
-  row: Row; s: Session; r: Rasterizer; src?: string
+  row: Row; s: Session; r: Rasterizer; status: eikon.SourceStatus
   on: boolean; dim: boolean; id: string
   peek?: { n: number; bytes: number }; busy?: boolean
   onHover: () => void; onClick: () => void
@@ -385,9 +387,9 @@ function KnobRow(props: {
       ) : null}
       <box flexGrow={1} minWidth={0} height={1} overflow="hidden">
         {props.busy && row.id === "fetch"
-          ? <Spinner color={theme.accent} label="fetching…" />
+          ? <Spinner color={theme.accent} label="downloading…" />
           : <text fg={dim ? theme.textMuted : theme.text}>
-              {valueOf(props.s, props.r, row, theme, props.src, props.peek, props.busy)}
+              {valueOf(props.s, props.r, row, theme, props.status, props.peek, props.busy)}
             </text>}
       </box>
     </box>
@@ -398,6 +400,7 @@ function KnobRow(props: {
 
 function Strip(props: {
   s: Session; frames: Map<AvatarState, Frame | undefined>
+  stats: Map<AvatarState, eikon.SourceStatus>
   pending: ReadonlySet<AvatarState>
   focused: boolean; onPick: (st: AvatarState) => void
   onEmpty?: (st: AvatarState) => void
@@ -409,7 +412,11 @@ function Strip(props: {
       {STATES.map(st => {
         const on = props.s.state === st
         const own = !!props.s.per[st]
-        const has = !!props.s.sources[st]
+        const status = props.stats.get(st)!
+        const mark = status.kind === "missing" ? "missing"
+          : status.kind === "downloadable" ? "download"
+          : status.role === st ? "own src"
+          : own ? "forked" : ""
         const f = props.frames.get(st)
         const gen = props.pending.has(st)
         const empty = !f && !gen
@@ -427,7 +434,7 @@ function Strip(props: {
                 : <text fg={theme.textMuted}>+</text>}
             </box>
             <box height={1}><text fg={on ? theme.accent : theme.textMuted}>{st}</text></box>
-            <box height={1}><text fg={theme.textMuted}>{has ? "own src" : own ? "forked" : ""}</text></box>
+            <box height={1}><text fg={theme.textMuted}>{mark}</text></box>
           </box>
         )
       })}
@@ -492,6 +499,8 @@ export const EikonStudio = memo((props: {
   const [pending, setPending] = useState<ReadonlySet<AvatarState>>(new Set())
   const [genOk, setGenOk] = useState<{ image: boolean; video: boolean } | null>(null)
   const frame = frames[tick % frames.length] ?? BLANK
+  const stampRef = useRef("")
+  const rev = useSyncExternalStore(eikon.onRevision, eikon.revision)
 
   const r = useMemo(() => eikon.pick(s?.rasterizer ?? prefs.get("eikonRasterizer")), [s?.rasterizer])
   // Spatial is studio-owned now — every rasterizer gets it for free.
@@ -501,6 +510,7 @@ export const EikonStudio = memo((props: {
   // Open by name: read studio.json + probe + seed session.
   const open = useCallback((name: string) => {
     resetCache()
+    stampRef.current = eikon.sourceStamp(name)
     const seed = eikon.readStudio(name)
     const ra = eikon.pick(seed?.rasterizer ?? prefs.get("eikonRasterizer"))
     const next = knobs.fresh(name, ra, seed)
@@ -552,8 +562,13 @@ export const EikonStudio = memo((props: {
     return () => { dead = true }
   }, [])
 
-  const src = useMemo(() => (s ? eikon.findSource(s.name, s.state) : undefined), [s?.name, s?.state, s?.sources])
-  const live = useMemo(() => !!(s && eikon.findSource(s.name)), [s?.name, s?.sources])
+  const stats = useMemo(() => {
+    if (!s) return new Map<AvatarState, eikon.SourceStatus>()
+    return new Map(STATES.map(st => [st, eikon.sourceStatus(s.name, st, { sources: s.sources })] as const))
+  }, [s?.name, s?.sources, rev])
+  const status = s ? stats.get(s.state) : undefined
+  const src = status?.path
+  const live = !!src
   // Sourceless → fall back to the packed .eikon's baked frames so the
   // preview is never blank. One readFileSync per open(); the whole
   // animation is string[] already, so tick stays 0.005ms.
@@ -563,22 +578,29 @@ export const EikonStudio = memo((props: {
     if (!p) return undefined
     try { return eikon.parseEikonFile(p) } catch { return undefined }
   }, [live, s?.name])
-  const url = useMemo(() => {
-    if (!s) return undefined
-    const src = eikon.sourceFetchUrl(s.name)
-    if (src) return src
-    const p = eikon.baked(s.name)
-    return p ? eikon.header(p)?.source_url as string | undefined : undefined
-  }, [s?.name])
+  const url = status?.sourceUrl
   useEffect(() => {
     setPeek(undefined)
-    if (!url || live) return
+    if (!url || !status?.downloadable) return
     let dead = false
     void eikon.peekSource(url).then(x => { if (!dead) setPeek(x) })
     return () => { dead = true }
-  }, [url, live])
+  }, [url, status?.downloadable])
 
-  const rows = useMemo(() => (s ? buildRows(r, s, live, url) : []), [r, s, live, url])
+  useEffect(() => {
+    if (!s) return
+    const stamp = eikon.sourceStamp(s.name)
+    if (!stampRef.current) { stampRef.current = stamp; return }
+    if (stamp === stampRef.current) return
+    stampRef.current = stamp
+    if (s.dirty) {
+      toast.show({ variant: "info", message: "Source changed on disk", duration: 3000 })
+      return
+    }
+    open(s.name)
+  }, [rev, s?.name, s?.dirty, open, toast])
+
+  const rows = useMemo(() => (s && status ? buildRows(r, s, status) : []), [r, s, status])
   const navRows = useMemo(() => rows.map((x, i) => ({ ...x, i }))
     .filter(x => x.kind !== "divider" && x.kind !== "header"), [rows])
   // Keep selection anchored to its row identity when navRows mutates
@@ -656,7 +678,7 @@ export const EikonStudio = memo((props: {
     const t = setTimeout(() => {
       if (dead) return
       const jobs = STATES.map(st => {
-        const sp = eikon.findSource(s.name, st)
+        const sp = stats.get(st)?.path
         if (!sp) {
           const f = baked?.states.get(st)?.frames[0]
           return Promise.resolve([st, f ? thumb(f) : undefined] as const)
@@ -671,7 +693,7 @@ export const EikonStudio = memo((props: {
     }, 400)
     return () => { dead = true; clearTimeout(t) }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [frames, s?.per, s?.sources, s?.name, s?.fps, r, baked])
+  }, [frames, s?.per, s?.sources, s?.name, s?.fps, r, baked, stats])
 
   const mutate = (fn: (prev: Session) => Session) => setS(p => (p ? fn(p) : p))
 
@@ -698,7 +720,7 @@ export const EikonStudio = memo((props: {
       return true
     }
     if (!live) {
-      toast.show({ variant: "warning", message: "No source — fetch or attach before saving" })
+      toast.show({ variant: "warning", message: "No source — download or attach before saving" })
       return false
     }
     setSaving(true)
@@ -745,7 +767,7 @@ export const EikonStudio = memo((props: {
 
   const runGenerate = async (st: AvatarState, kind: GenerateKind) => {
     if (!s) return
-    const seed = s.sources.base ? eikon.findSource(s.name) : undefined
+    const seed = stats.get("idle")?.path
     setPending(prev => { const n = new Set(prev); n.add(st); return n })
     const out = await openGenerate(dialog, gen.current(), {
       state: st, kind, seed, lastPrompt: s.prompts?.[st],
@@ -770,18 +792,49 @@ export const EikonStudio = memo((props: {
     }
   }
 
+  const download = async () => {
+    if (!s || fetching) return
+    setFetching(true)
+    await eikon.downloadSource(s.name)
+      .then(out => {
+        toast.show({ variant: "success", message: `Downloaded ${out.n} file(s) · ${mb(out.bytes)}` })
+        if (sRef.current?.dirty) mutate(prev => ({ ...prev, sources: { ...out.sources, ...prev.sources } }))
+        else open(s.name)
+      })
+      .catch(e => toast.error(e instanceof Error ? e : new Error(String(e))))
+      .finally(() => setFetching(false))
+  }
+
   const doSource = (forSt?: AvatarState) => {
     if (!s) return
     const st = forSt ?? s.state
-    const has = !!s.sources[st]
-    const opts: Array<{ title: string; value: string }> = [{ title: "Local file…", value: "local" }]
-    if (genOk?.image) opts.push({ title: "Generate image…", value: "gen-image" })
-    if (genOk?.video) opts.push({ title: "Generate video…", value: "gen-video" })
-    if (has && st !== "idle") opts.push({ title: "Same as base", value: "same" })
-    if (has) opts.push({ title: "Remove", value: "remove" })
+    const info = stats.get(st) ?? eikon.sourceStatus(s.name, st, { sources: s.sources })
+    const own = info.role === st || (st === "idle" && info.role === "base") || s.sources[st] !== undefined
+    const loc = eikon.localSources(s.name)
+    const opts: Array<{ title: string; value: string; hint?: string }> = [
+      ...(info.downloadable ? [{ title: "Download source", value: "download" }] : []),
+      ...loc.map(x => ({ title: x.file, value: `pick:${x.file}`, hint: x.role ?? "source" })),
+      ...(genOk?.image ? [{ title: "Generate image…", value: "gen-image" }] : []),
+      ...(genOk?.video ? [{ title: "Generate video…", value: "gen-video" }] : []),
+      { title: "Local file…", value: "local" },
+      ...(st !== "idle" && own ? [{ title: "Same as base", value: "same" }] : []),
+      ...(own ? [{ title: "Remove", value: "remove" }] : []),
+    ]
     dialog.replace(
       <DialogSelect title={`Source for '${st}'`} filterable={false} options={opts}
         onSelect={async o => {
+          if (o.value === "download") {
+            dialog.clear()
+            await download()
+            return
+          }
+          if (o.value.startsWith("pick:")) {
+            dialog.clear()
+            const file = o.value.slice("pick:".length)
+            const role = st === "idle" && loc.find(x => x.file === file)?.role === "base" ? "base" : st
+            mutate(prev => ({ ...prev, sources: { ...prev.sources, [role]: file }, dirty: true }))
+            return
+          }
           if (o.value === "local") {
             const p = await openPathPrompt(dialog, gw, {
               title: `Source for '${st}'`,
@@ -797,11 +850,11 @@ export const EikonStudio = memo((props: {
           if (o.value === "gen-image") return void runGenerate(st, "image")
           if (o.value === "gen-video") return void runGenerate(st, "video")
           dialog.clear()
-          mutate(prev => {
-            const next = { ...prev.sources }
-            delete next[st]
-            return { ...prev, sources: next, dirty: true }
-          })
+          mutate(prev => ({
+            ...prev,
+            sources: { ...prev.sources, [st === "idle" ? "base" : st]: null },
+            dirty: true,
+          }))
         }} />,
       () => {},
     )
@@ -952,15 +1005,8 @@ export const EikonStudio = memo((props: {
       return
     }
     if (id === "fetch") {
-      if (!url || fetching) return
-      setFetching(true)
-      await eikon.fetchSource(url, { name: s.name })
-        .then(out => {
-          toast.show({ variant: "success", message: `Fetched ${out.n} file(s) · ${mb(out.bytes)}` })
-          open(s.name)
-        })
-        .catch(e => toast.error(e instanceof Error ? e : new Error(String(e))))
-        .finally(() => setFetching(false))
+      if (!status?.downloadable || fetching) return
+      await download()
     }
   }
 
@@ -1052,6 +1098,18 @@ export const EikonStudio = memo((props: {
     return true
   }
 
+  const refresh = useCallback(() => {
+    const cur = sRef.current
+    if (!cur) return
+    stampRef.current = eikon.sourceStamp(cur.name)
+    if (cur.dirty) {
+      toast.show({ variant: "info", message: "Reload skipped: unsaved edits", duration: 3000 })
+      return
+    }
+    open(cur.name)
+    toast.show({ variant: "info", message: "Reloaded", duration: 1000 })
+  }, [open, toast])
+
   useKeyboard((key: ParsedKey) => {
     if (!props.focused || dialog.open()) return
     if (key.name === "u" && key.ctrl && sRef.current) return void doSaveUse()
@@ -1077,6 +1135,7 @@ export const EikonStudio = memo((props: {
         onActivate: activate,
         onToggle: toggle,
         onNew: () => void doNew(),
+        onRefresh: refresh,
       })) return
       if (key.name === "left") return adjust(-1)
       if (key.name === "right") return adjust(1)
@@ -1130,12 +1189,12 @@ export const EikonStudio = memo((props: {
       + (live ? "" : baked ? "  ·  (baked)" : "")
     : "Preview"
   const previewErr = err ?? (!s || src || baked ? null
-    : url ? "no source — Enter on 'fetch source' to download"
-    :       "no source — Enter on 'source' to attach")
+    : url ? "no source — Enter on 'download source'"
+    :       "no source — Enter on 'source'")
 
   const hint: Array<readonly [string, string]> =
     !s                   ? [["Enter", "new eikon"], ["Shift+→", "gallery"]]
-  : pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "edit"], [keys.print("list.new"), "new"], ["u", "submit"], [keys.print("eikon.save"), "save"], ["Ctrl+U", "save & use"], ["Tab", "pane"]]
+  : pane === "knobs"   ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.activate"), "edit"], [keys.print("list.refresh"), "reload"], [keys.print("list.new"), "new"], ["u", "submit"], [keys.print("eikon.save"), "save"], ["Ctrl+U", "save & use"], ["Tab", "pane"]]
   : pane === "preview" ? [["↑↓", "row"], ["←→", "adjust"], [keys.print("list.toggle"), "play/pause"], ["wheel", "pan"], ["Ctrl+wheel", "zoom"], [keys.print("eikon.save"), "save"], ["Ctrl+U", "save & use"], ["Tab", "pane"]]
   :                      [["←→", "state"], [keys.print("list.activate"), "actions"], [keys.print("eikon.save"), "save"], ["Ctrl+U", "save & use"], ["Tab", "pane"]]
 
@@ -1164,7 +1223,7 @@ export const EikonStudio = memo((props: {
               error={previewErr} focus={pane === "preview"}>
       {!live && baked
         ? <box height={1} overflow="hidden">
-            <text fg={theme.textMuted} wrapMode="none">Baked — fetch or attach a source to edit.</text>
+            <text fg={theme.textMuted} wrapMode="none">Baked — download or attach source to edit.</text>
           </box>
         : null}
       {spatialOk && live && s
@@ -1197,7 +1256,7 @@ export const EikonStudio = memo((props: {
                 const on = pane === "knobs" && ni === sel
                 const dim = row.kind === "knob" && !src
                 return (
-                  <KnobRow key={`${row.kind}:${r.name}:${row.id}`} id={`knob-${row.kind}-${row.id}`} row={row} s={s} r={r} src={src}
+                  <KnobRow key={`${row.kind}:${r.name}:${row.id}`} id={`knob-${row.kind}-${row.id}`} row={row} s={s} r={r} status={status!}
                            on={on} dim={dim} peek={peek} busy={row.id === "fetch" && fetching}
                            onHover={() => { if (ni >= 0) { setPane("knobs"); setSelBy(ni) } }}
                            onClick={() => { if (ni >= 0) { setSelBy(ni); setPane("knobs"); act(row, "click") } }}
@@ -1223,7 +1282,7 @@ export const EikonStudio = memo((props: {
   const strip = s ? (
     <box id="studio-strip" flexShrink={0} height={STRIP_H}>
       <TabShell title="States" focus={pane === "strip"}>
-        <Strip s={s} frames={thumbs} pending={pending} focused={pane === "strip"}
+        <Strip s={s} frames={thumbs} stats={stats} pending={pending} focused={pane === "strip"}
                onPick={st => { setPane("strip"); mutate(p => knobs.setState(p, st)) }}
                onEmpty={st => doSource(st)} />
       </TabShell>

--- a/src/utils/eikon-knobs.ts
+++ b/src/utils/eikon-knobs.ts
@@ -25,7 +25,7 @@ export type Studio = {
   base: KnobValues
   per: Partial<Record<AvatarState, KnobValues>>
   glyph: string
-  sources: Partial<Record<AvatarState | "base", string>>
+  sources: Partial<Record<AvatarState | "base", string | null>>
   /** Per-state last generation prompt — pre-fills the generate dialog
    *  on a state's next open so users can iterate without retyping. */
   prompts?: Partial<Record<AvatarState, string>>

--- a/test/eikon-baked.test.tsx
+++ b/test/eikon-baked.test.tsx
@@ -8,7 +8,7 @@ import * as prefs from "../src/context/preferences"
 
 // A minimal 2-frame 4×2 .eikon with source_url in the header. Studio
 // has no source/ for it, so it must open in baked mode: playing the
-// packed frames, PanBars/SpatialBar hidden, fetch row visible.
+// packed frames, PanBars/SpatialBar hidden, download row visible.
 const make = (name: string, url?: string) => {
   const head = { eikon: 1, name, width: 4, height: 2, ...(url ? { source_url: url } : {}) }
   const st = { state: "idle", fps: 12, frame_count: 2, loop_from: 0 }
@@ -16,7 +16,7 @@ const make = (name: string, url?: string) => {
   return [head, st, f0, f1].map(x => JSON.stringify(x)).join("\n") + "\n"
 }
 
-test("baked mode: plays packed frames, hides spatial, shows fetch row", async () => {
+test("baked mode: plays packed frames, hides spatial, shows download row", async () => {
   // Served manifest so peekSource resolves → size hint on the row.
   const srv = Bun.serve({
     port: 0,
@@ -35,10 +35,10 @@ test("baked mode: plays packed frames, hides spatial, shows fetch row", async ()
   // Baked frame content is on screen; spatial rows are not.
   expect(f).toContain("AB@@")
   expect(f).not.toContain("zoom")
-  // Knob panel collapsed: fetch row present, rasterizer-declared
+  // Knob panel collapsed: download row present, rasterizer-declared
   // knobs absent, fork/reset hidden.
-  expect(f).toContain("fetch source")
-  expect(f).toContain("download to edit")
+  expect(f).toContain("Download source")
+  expect(f).toContain("1 files")
   // Live-only action rows absent in baked mode.
   expect(f).not.toMatch(/▸?\s+tune\s+◂/)
   expect(f).not.toMatch(/▸?\s+reset\s+▸ defaults/)
@@ -51,14 +51,14 @@ test("baked mode: plays packed frames, hides spatial, shows fetch row", async ()
   srv.stop()
 })
 
-test("baked mode: no url → 'attach' hint, no fetch row", async () => {
+test("baked mode: no url → 'attach' hint, no download row", async () => {
   eikon.ensure("noburl")
   writeFileSync(eikon.file("noburl"), make("noburl"))
   prefs.set("eikon", "noburl")
   await using t = await mountNode(<EikonGroup focused sub={1} setSub={() => {}} />, { width: 180, height: 50 })
   await until(t, () => t.frame().includes("(baked)"))
   const f = t.frame()
-  expect(f).not.toContain("fetch source")
+  expect(f).not.toContain("download source")
   expect(f).toContain("AB@@")
 })
 

--- a/test/eikon-service.test.ts
+++ b/test/eikon-service.test.ts
@@ -32,6 +32,40 @@ describe("service/eikon: layout", () => {
     expect(eikon.findSource("foo", "idle")).toMatch(/base\.png$/)
   })
 
+  test("sourceStatus discovers media and honors draft tombstones", () => {
+    eikon.ensure("status")
+    writeFileSync(eikon.file("status"), JSON.stringify({ eikon: 1, name: "status", source_url: "http://x/status/" }) + "\n")
+    writeFileSync(join(eikon.sourceDir("status"), "base.png"), "b")
+    writeFileSync(join(eikon.sourceDir("status"), "thinking.png"), "t")
+
+    const own = eikon.sourceStatus("status", "thinking")
+    expect(own.kind).toBe("local")
+    expect(own.role).toBe("thinking")
+    expect(own.origin).toBe("discovered")
+    const inherited = eikon.sourceStatus("status", "thinking", { sources: { thinking: null, base: "base.png" } })
+    expect(inherited.kind).toBe("local")
+    expect(inherited.role).toBe("base")
+    expect(inherited.inherited).toBe(true)
+    expect(inherited.removed).toBe(true)
+    const removed = eikon.sourceStatus("status", "thinking", { sources: { thinking: null, base: null } })
+    expect(removed.kind).toBe("downloadable")
+    expect(removed.path).toBeUndefined()
+  })
+
+  test("sourceStatus advertises packageUrl-only downloads", () => {
+    eikon.ensure("pkgstatus")
+    writeFileSync(eikon.file("pkgstatus"), '{"eikon":1,"name":"pkgstatus"}\n')
+    writeFileSync(join(eikon.dir("pkgstatus"), "manifest.json"), JSON.stringify({
+      name: "pkgstatus",
+      origin: { packageUrl: "http://x/pkgstatus/manifest.json", kind: "catalog-package" },
+    }))
+
+    const status = eikon.sourceStatus("pkgstatus")
+    expect(status.kind).toBe("downloadable")
+    expect(status.sourceUrl).toBe("http://x/pkgstatus/manifest.json")
+    expect(eikon.list().find(x => x.name === "pkgstatus")!.sourceUrl).toBe("http://x/pkgstatus/manifest.json")
+  })
+
   test("studio.json round-trip", () => {
     const s = knobs.fresh("foo", native)
     eikon.writeStudio("foo", knobs.toStudio(s))
@@ -168,6 +202,27 @@ describe("service/eikon: fetchSource", () => {
     expect(man.provenance).toBeUndefined()
     // peekSource memoized — second call same Promise.
     expect(eikon.peekSource(url)).toBe(eikon.peekSource(url))
+    srv.stop()
+  })
+
+  test("downloadSource writes source without replacing runtime or manifest", async () => {
+    const srv = Bun.serve({ port: 0, fetch: r => body(new URL(r.url).pathname.split("/").pop()!) })
+    const url = `http://localhost:${srv.port}/source-only/manifest.json`
+    eikon.ensure("sourceonly")
+    writeFileSync(eikon.file("sourceonly"), "OLD-RUNTIME\n")
+    const mf = join(eikon.dir("sourceonly"), "manifest.json")
+    writeFileSync(mf, JSON.stringify({ name: "sourceonly", origin: { packageUrl: url, kind: "catalog-package" } }, null, 2))
+    const before = readFileSync(mf, "utf8")
+
+    const out = await eikon.downloadSource("sourceonly")
+
+    expect(out.name).toBe("sourceonly")
+    expect(out.sources.base).toBe("base.png")
+    expect(readFileSync(eikon.file("sourceonly"), "utf8")).toBe("OLD-RUNTIME\n")
+    expect(readFileSync(mf, "utf8")).toBe(before)
+    expect(existsSync(join(eikon.sourceDir("sourceonly"), "base.png"))).toBe(true)
+    expect(eikon.readStudio("sourceonly")!.sources.base).toBe("base.png")
+    expect(eikon.sourceStatus("sourceonly").kind).toBe("local")
     srv.stop()
   })
 

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -89,8 +89,8 @@ describe("EikonStudio tab", () => {
 
     await using t = await mountNode(<EikonStudio focused />, { width: 160, height: 48 })
 
-    await until(t, () => t.frame().includes("fetch source"))
-    expect(t.frame()).toContain("download to edit")
+    await until(t, () => t.frame().includes("Download source"))
+    expect(t.frame()).toContain("1 files")
     srv.stop()
   })
 
@@ -365,6 +365,51 @@ describe("EikonStudio tab", () => {
     un()
   })
 
+  run("reload refreshes clean source metadata and preserves dirty drafts", async () => {
+    const un = eikon.register(stub)
+    seed("refresh")
+    prefs.set("eikon", "refresh")
+    await using t = await mountNode(<EikonGroup focused sub={1} setSub={() => {}} />, { width: 160, height: 48 })
+    await until(t, () => t.frame().includes("base.png · 1×1 · 67 B"))
+
+    writeFileSync(join(eikon.sourceDir("refresh"), "base.png"), new Uint8Array([...PX, 0]))
+    act(() => t.keys.pressKey("r"))
+    await until(t, () => t.frame().includes("base.png · 1×1 · 68 B"))
+
+    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    act(() => t.keys.pressArrow("right"))
+    await until(t, () => t.frame().includes("● unsaved"))
+    writeFileSync(join(eikon.sourceDir("refresh"), "base.png"), new Uint8Array([...PX, 0, 0]))
+    act(() => t.keys.pressKey("r"))
+    await until(t, () => t.frame().includes("● unsaved") && t.frame().includes("Reload skipped"))
+    un()
+  })
+
+  run("download source action fetches published media without local path entry", async () => {
+    const srv = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new URL(req.url).pathname.endsWith("manifest.json")
+          ? Response.json({ files: ["base.png"] })
+          : new Response(PX)
+      },
+    })
+    const un = eikon.register(stub)
+    eikon.ensure("remote")
+    writeFileSync(eikon.file("remote"), JSON.stringify({ eikon: 1, name: "remote", width: 48, height: 24, source_url: `http://localhost:${srv.port}/remote/` }) + "\n")
+    eikon.writeStudio("remote", { rasterizer: "stub", spatial: { zoom: 1, ox: 0.5, oy: 0.5 }, tone: { contrast: 1, invert: true, flip: "none" }, fps: 16, base: {}, per: {}, glyph: "◆", sources: {} })
+    prefs.set("eikon", "remote")
+    await using t = await mountNode(<EikonGroup focused sub={1} setSub={() => {}} />, { width: 160, height: 48 })
+    await until(t, () => t.frame().includes("Download source"))
+
+    for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    act(() => t.keys.pressEnter())
+    await until(t, () => Bun.file(join(eikon.sourceDir("remote"), "base.png")).size > 0)
+    expect(eikon.readStudio("remote")!.sources.base).toBe("base.png")
+    srv.stop()
+    un()
+  })
+
   run("Enter on source row → menu with Local file…; pick + path + Enter adopts source", async () => {
     const un = eikon.register(stub)
     seed("fox")
@@ -372,6 +417,8 @@ describe("EikonStudio tab", () => {
     // Pre-create a file we can adopt.
     const extPath = join(HH, "extra.png")
     writeFileSync(extPath, PX)
+    resetToolsetsCache()
+    gen.setProbe(async () => ({ image: false, video: false }))
     let sub = 1
     await using t = await mountNode(
       <EikonGroup focused sub={sub} setSub={i => { sub = i }} />,
@@ -389,7 +436,9 @@ describe("EikonStudio tab", () => {
     await until(t, () => t.frame().includes("Local file"))
     expect(t.frame()).toContain("Source for 'idle'")
 
-    // Pick "Local file…" (first/only-when-empty option).
+    // Pick fallback "Local file…" after the detected base source.
+    act(() => t.keys.pressArrow("down"))
+    await t.settle()
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Tab complete"))
 
@@ -402,6 +451,7 @@ describe("EikonStudio tab", () => {
     const adoptedDir = eikon.ensure("fox").source
     const f = Bun.file(join(adoptedDir, "idle.png"))
     expect(await f.exists()).toBe(true)
+    gen.setProbe(null)
     un()
   })
 
@@ -503,10 +553,7 @@ describe("EikonStudio tab", () => {
     expect(t.frame()).toContain("engine that turns your source")
     // ↓ to source.
     act(() => t.keys.pressArrow("down")); await t.settle()
-    expect(t.frame()).toContain("image or video file the avatar is rendered from")
-    // Bold /eikon-create recommendation may hyphen-wrap; match a run
-    // that's guaranteed contiguous.
-    expect(t.frame()).toContain("interactively (recommended)")
+    expect(t.frame()).toContain("Pick, generate, or clear source")
     // ↓↓↓ → contrast (studio-owned tone row, has a KnobDef.hint).
     for (let i = 0; i < 3; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
     expect(t.frame()).toContain("Spread pixel values around their mean")


### PR DESCRIPTION
## Summary

Eikon Studio now treats installed or downloaded source as the editable source of truth instead of leaving package installs stuck in baked-only mode.

- Source resolution uses one service contract that distinguishes local, downloadable, baked, and missing source, including packageUrl-only installs and draft source removals.
- Package and marketplace source downloads keep editable media filenames derived from package descriptors, so content-addressed source blobs remain usable in Studio.
- The source picker leads with detected local source files and published-source download; manual path entry remains as a fallback.
- Published source downloads copy only source media into the installed eikon and preserve the existing runtime and manifest.
- Refresh reloads clean source changes from disk while keeping dirty Studio drafts intact.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit --pretty false`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test test/eikon-service.test.ts test/eikon-baked.test.tsx test/eikon-studio.test.tsx test/eikon-marketplace.test.ts test/eikon-swap.test.tsx` (83 pass, 0 fail)
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test` (1279 pass, 0 fail)
