### PR TITLE
fix: resume sessions with default model

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -387,7 +387,6 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setReady(true)
       sessionStart.current = Date.now()
       if (res.messages.length) dispatch({ kind: "load", messages: res.messages })
-      if (res.note) dispatch({ kind: "system", text: res.note })
       // Close only after resume succeeds — a failed resume leaves the
       // user in the outgoing session, which must stay live. Skip when
       // resuming self (prev === res.id), e.g. the boot path reusing an

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -2,7 +2,7 @@
 
 import { useMemo, useCallback } from "react"
 import * as preferences from "../context/preferences"
-import { sdb, byId } from "../service/sessions-db"
+import { sdb } from "../service/sessions-db"
 import { useGateway } from "../context/gateway"
 import { transcriptToMessages } from "./turnReducer"
 import type { Launch } from "./launch"
@@ -15,14 +15,6 @@ import type {
   TranscriptMessage,
 } from "../context/wire"
 import type { Message, Usage } from "../types/message"
-
-const spec = (row: ReturnType<typeof byId>) => {
-  if (!row?.model) return null
-  if (!row.billing_provider) return row.model
-  return `${row.model} --provider ${row.billing_provider}`
-}
-
-const msg = (e: unknown) => e instanceof Error ? e.message : String(e)
 
 /** session.compress response shape. `messages` is compacted server context;
  *  the live chat transcript intentionally stays visually unchanged. */
@@ -45,7 +37,7 @@ export type CompressResult = {
 }
 
 type Booted = { id: string; messages: Message[]; note?: string; info?: SessionInfo }
-type Resumed = { id: string; messages: Message[]; note?: string; info?: SessionInfo }
+type Resumed = { id: string; messages: Message[]; info?: SessionInfo }
 type Activated = { id: string; messages: Message[]; info?: SessionInfo; running: boolean; status?: string; startedAt?: number }
 type Agents = { processes?: Array<{ status?: string }> }
 type Close = { preserveBackground?: boolean }
@@ -84,18 +76,12 @@ export function useSession(): SessionOps {
     // No tip-chasing here: Sessions-tab lineage walk and `/resume <id>`
     // pass exact ids on purpose; boot() resolves tips itself.
     const target = normalize(sid)
-    const row = byId(target)
-    const model = spec(row)
-    const note = model ? await gw.request("config.set", {
-      session_id: undefined, key: "model", value: model,
-    }).then(() => undefined).catch(e =>
-      `Stored session model unavailable: ${msg(e)}; resumed with current model.`) : undefined
     const res = await gw.request<SessionResumeResponse>("session.resume", { session_id: target })
     const id = res.session_id
     gw.setSession(id)
     preferences.set("lastSessionId", res.resumed ?? target)
     const messages = res.messages?.length ? transcriptToMessages(res.messages) : []
-    return { id, messages, note, info: res.info }
+    return { id, messages, info: res.info }
   }, [gw])
 
   // No `cols` param and no `terminal.resize` RPC on SIGWINCH: herm renders

--- a/test/eikon-studio.test.tsx
+++ b/test/eikon-studio.test.tsx
@@ -89,8 +89,7 @@ describe("EikonStudio tab", () => {
 
     await using t = await mountNode(<EikonStudio focused />, { width: 160, height: 48 })
 
-    await until(t, () => t.frame().includes("Download source"))
-    expect(t.frame()).toContain("1 files")
+    await until(t, () => t.frame().includes("Download source") && t.frame().includes("1 files"))
     srv.stop()
   })
 

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -168,29 +168,7 @@ describe("useSession.boot", () => {
     expect(gw.last("session.resume")?.params.session_id).toBe("tip")
   })
 
-  test("mode:resume switches live model to the stored provider/model", async () => {
-    const db = seed()
-    sess(db, "past", "tui", 1005, 5, { model: "gpt-5.5", billing_provider: "openai-codex" })
-    db.close()
-    resetDb()
-
-    const sets: Array<Record<string, unknown>> = []
-    const gw = new MockGateway({
-      "session.resume": p => ({ session_id: "live-past", resumed: p.session_id, messages: [] }),
-      "config.set": p => { sets.push(p); return { value: p.value } },
-    })
-    gw.setSession("old")
-    await boot(gw, { mode: "resume", sid: "past" })
-
-    expect(gw.last("session.resume")?.params.session_id).toBe("past")
-    expect(sets).toEqual([{ session_id: undefined, key: "model", value: "gpt-5.5 --provider openai-codex" }])
-    const ci = gw.calls.findIndex(c => c.method === "config.set")
-    const ri = gw.calls.findIndex(c => c.method === "session.resume")
-    expect(ci).toBeGreaterThan(-1)
-    expect(ci).toBeLessThan(ri)
-  })
-
-  test("mode:resume keeps going when stored model switch fails", async () => {
+  test("mode:resume ignores stored provider/model", async () => {
     const db = seed()
     sess(db, "past", "tui", 1005, 5, { model: "gpt-5.5-free", billing_provider: "openai-codex" })
     db.close()
@@ -198,13 +176,15 @@ describe("useSession.boot", () => {
 
     const gw = new MockGateway({
       "session.resume": p => ({ session_id: "live-past", resumed: p.session_id, messages: [] }),
-      "config.set": () => { throw new Error("missing model") },
+      "config.set": () => { throw new Error("unexpected model switch") },
     })
+    gw.setSession("old")
     const r = await boot(gw, { mode: "resume", sid: "past" })
 
     expect(gw.last("session.resume")?.params.session_id).toBe("past")
     expect(r.id).toBe("live-past")
-    expect(r.note).toBe("Stored session model unavailable: missing model; resumed with current model.")
+    expect(r.note).toBeUndefined()
+    expect(gw.calls.some(c => c.method === "config.set")).toBe(false)
   })
 
   test("mode:resume normalizes session_*.json filenames", async () => {

--- a/test/session-close.test.tsx
+++ b/test/session-close.test.tsx
@@ -145,16 +145,12 @@ describe("session.close", () => {
     t.destroy()
   })
 
-  test("switchSession preconfigures stored model before resume", async () => {
+  test("switchSession resumes without stored model preconfigure", async () => {
     seed()
-    let prepped = false
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
       "session.create": () => ({ session_id: "old" }),
-      "config.set": p => {
-        prepped = p.value === "gpt-5.5 --provider openai-codex" && p.session_id === undefined
-        return { key: p.key, value: p.value, warning: "" }
-      },
+      "config.set": () => { throw new Error("unexpected model switch") },
       "session.resume": p => ({
         session_id: "live-past",
         resumed: p.session_id,
@@ -169,7 +165,7 @@ describe("session.close", () => {
             output: 0,
             total: 0,
             context_used: 110_000,
-            context_max: prepped ? 1_000_000 : 256_000,
+            context_max: 256_000,
           },
         },
       }),
@@ -181,27 +177,21 @@ describe("session.close", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Ready") && t.frame().includes("hello"))
 
-    const ri = gw.calls.findIndex(c => c.method === "session.resume" && c.params.session_id === "past")
-    const ci = gw.calls.findIndex(c => c.method === "config.set" && c.params.value === "gpt-5.5 --provider openai-codex")
-    expect(ci).toBeGreaterThan(-1)
-    expect(ci).toBeLessThan(ri)
-    expect(t.frame()).toContain("110K / 1M")
+    expect(gw.calls.some(c => c.method === "config.set")).toBe(false)
+    expect(gw.last("session.resume")?.params.session_id).toBe("past")
+    expect(t.frame()).toContain("110K / 256K")
 
     t.destroy()
   })
 
-  test("Sessions tab preconfigures stored model on first resume", async () => {
+  test("Sessions tab resumes without stored model preconfigure", async () => {
     seed()
-    let prepped = false
     const row = { id: "past", title: "Past", preview: "hello", message_count: 2, started_at: 1000, source: "tui" }
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/sessions", "sessions"]] }),
       "session.create": () => ({ session_id: "old" }),
       "session.list": () => ({ sessions: [row] }),
-      "config.set": p => {
-        prepped = p.value === "gpt-5.5 --provider openai-codex" && p.session_id === undefined
-        return { key: p.key, value: p.value, warning: "" }
-      },
+      "config.set": () => { throw new Error("unexpected model switch") },
       "session.resume": p => ({
         session_id: "live-past",
         resumed: p.session_id,
@@ -216,7 +206,7 @@ describe("session.close", () => {
             output: 0,
             total: 0,
             context_used: 110_000,
-            context_max: prepped ? 1_000_000 : 256_000,
+            context_max: 256_000,
           },
         },
       }),
@@ -232,22 +222,20 @@ describe("session.close", () => {
     await act(async () => { await t.keys.typeText("y") })
     await until(t, () => t.frame().includes("Ready") && t.frame().includes("hello"))
 
-    const ci = gw.calls.findIndex(c => c.method === "config.set" && c.params.value === "gpt-5.5 --provider openai-codex")
-    const ri = gw.calls.findIndex(c => c.method === "session.resume" && c.params.session_id === "past")
-    expect(ci).toBeGreaterThan(-1)
-    expect(ci).toBeLessThan(ri)
-    expect(t.frame()).toContain("110K / 1M")
+    expect(gw.calls.some(c => c.method === "config.set")).toBe(false)
+    expect(gw.last("session.resume")?.params.session_id).toBe("past")
+    expect(t.frame()).toContain("110K / 256K")
     expect(t.frame()).not.toContain("Connecting")
 
     t.destroy()
   })
 
-  test("switchSession resumes when stored model preconfigure fails", async () => {
+  test("switchSession ignores stale stored model", async () => {
     seed()
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
       "session.create": () => ({ session_id: "old" }),
-      "config.set": () => { throw new Error("model switch failed") },
+      "config.set": () => { throw new Error("unexpected model switch") },
       "session.resume": p => ({
         session_id: "live-past",
         resumed: p.session_id,
@@ -261,7 +249,8 @@ describe("session.close", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Ready") && t.frame().includes("hello"))
 
-    expect(t.frame()).toContain("Stored session model unavailable: model switch failed; resumed with current model.")
+    expect(gw.calls.some(c => c.method === "config.set")).toBe(false)
+    expect(t.frame()).not.toContain("Stored session model unavailable")
     expect(t.frame()).not.toContain("Failed to resume")
     expect(t.frame()).not.toContain("Connecting")
     expect(gw.last("session.close")?.params.session_id).toBe("old")


### PR DESCRIPTION
## Summary
- Resumes sessions with the configured runtime model instead of switching to the model stored on the session row.
- Removes the stale-model fallback path because missing provider listings should not block session resume.
- Updates resume coverage for startup, slash-driven switching, and Sessions tab switching to assert no model reconfiguration occurs.
- Stabilizes the Eikon source-preview assertion by waiting for the async file-count preview before checking it.

## Test Plan
- `bunx tsc --noEmit`
- `bun test`
- `timeout 3 bun run src/index.tsx --help`
