### PR TITLE
chore: pin eikon to merged main commit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@opentui/core": "0.2.2",
         "@opentui/react": "0.2.2",
-        "eikon": "github:liftaris/eikon#ee169892b5c5de1f86d29d35a18a7fde3ae531de",
+        "eikon": "github:liftaris/eikon#c924b3cb4fb57ce100eb602ac5cf83ea9c99acff",
         "gpt-tokenizer": "^3.4.0",
         "open": "^11.0.0",
         "react": "^19.2.5",
@@ -295,7 +295,7 @@
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
-    "eikon": ["eikon@github:liftaris/eikon#ee16989", { "dependencies": { "@opentui/core": "^0.1.99", "@opentui/react": "^0.1.99", "react": "19.2.7", "react-dom": "19.2.7", "ssh2": "^1.16.0" }, "bin": { "eikon": "./src/cli.tsx" } }, "liftaris-eikon-ee16989", "sha512-iflWDM6EDQ/PUiFCxBCEBM8D1l7tNp59SYNYCFjs8+C5CL1AYewvZNXfS+T0mkOy/0jGrQGPDNJWSVwhqckZoQ=="],
+    "eikon": ["eikon@github:liftaris/eikon#c924b3c", { "dependencies": { "@opentui/core": "^0.1.99", "@opentui/react": "^0.1.99", "react": "19.2.7", "react-dom": "19.2.7", "ssh2": "^1.16.0" }, "bin": { "eikon": "./src/cli.tsx" } }, "liftaris-eikon-c924b3c", "sha512-s2dOYEE5MUjviCiVGJhZVmT9bBKPK2ZUMlrbpMByWBePmjrsZdBdUFScd6ynbqgcZ78TyH4iVZxpMH+z+4llwA=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@opentui/core": "0.2.2",
     "@opentui/react": "0.2.2",
-    "eikon": "github:liftaris/eikon#ee169892b5c5de1f86d29d35a18a7fde3ae531de",
+    "eikon": "github:liftaris/eikon#c924b3cb4fb57ce100eb602ac5cf83ea9c99acff",
     "gpt-tokenizer": "^3.4.0",
     "open": "^11.0.0",
     "react": "^19.2.5",


### PR DESCRIPTION
## Summary

Herm now pins Eikon to the merge commit that landed on Eikon `main`, rather than the pre-merge PR head. This keeps the dependency pointed at the durable upstream history while preserving the same simplified Eikon contract behavior already verified in Herm.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH bun install`
- `PATH=/home/kaio/.bun/bin:$PATH bunx tsc --noEmit`
- `PATH=/home/kaio/.bun/bin:$PATH bun test` → 1280 pass
