### PR TITLE
feat(media): add PDF attach slash support

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -40,7 +40,7 @@ import { TAB_SLASH } from "./tabs"
 import { transcriptToMessages, type Action, type TurnState } from "./turnReducer"
 import type { SlashCommand } from "./slashCommands"
 import type { ComposerHandle } from "../components/chat/Composer"
-import type { SessionInfo, TranscriptMessage, ImageAttachResponse } from "../context/wire"
+import type { SessionInfo, TranscriptMessage, ImageAttachResponse, PdfAttachResponse } from "../context/wire"
 import type { Message, Usage } from "../types/message"
 import { text as msgText } from "../types/message"
 import type { useSession } from "./useSession"
@@ -372,6 +372,34 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             .then(r => r.attached
               ? x.setAttachments(a => [...a, r])
               : toast.show({ variant: "warning", message: r.message ?? "attach failed" }))
+            .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
+          return
+        case "pdf":
+          if (!arg.trim()) { toast.show({ variant: "info", message: "usage: /pdf <path>" }); return }
+          gw.request<PdfAttachResponse>("pdf.attach", { path: arg.trim() })
+            .then(r => {
+              if (!r.attached) {
+                toast.show({ variant: "warning", message: r.message ?? "attach failed" })
+                return
+              }
+              const pages = r.pages ?? []
+              if (pages.length === 0) {
+                toast.show({ variant: "warning", message: r.message ?? "no PDF pages attached" })
+                return
+              }
+              const file = r.filename ?? arg.trim().split(/[\\/]/).pop() ?? "PDF"
+              x.setAttachments(a => [...a, ...pages.map(p => ({
+                attached: true,
+                path: p.path,
+                count: r.count,
+                name: p.name ?? `${file} p.${p.page}`,
+                width: p.width,
+                height: p.height,
+                token_estimate: p.token_estimate,
+              }))])
+              const n = r.pages_attached ?? pages.length
+              toast.show({ variant: "success", message: `attached ${file} · ${n} ${n === 1 ? "page" : "pages"}` })
+            })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "background":

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -38,7 +38,7 @@ export const LOCAL_NAMES = new Set([
   "reload", "reload-mcp", "reload-skills", "chafa", "splash", "skin",
   // parity: session-mutating commands the slash-worker can't service
   "resume", "branch", "compress", "undo", "redo", "retry", "model", "yolo", "quit",
-  "copy", "paste", "image", "background", "voice", "mouse", "redraw", "queue",
+  "copy", "paste", "image", "pdf", "background", "voice", "mouse", "redraw", "queue",
   "stash",
   // Ink-only UI toggles — local no-op with a note
   "compact", "setup",
@@ -73,6 +73,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "goal",   description: "Set/control the session goal",        category: "Session", aliases: [], argsHint: "[text|done|pause|resume|clear|status]", subcommands: ["done", "pause", "resume", "clear", "status"], source: "command", target: "gateway" },
   { name: "skin",   description: "Switch Hermes skin (+ theme + eikon)", category: "Client",  aliases: [], argsHint: "[name]", subcommands: [...SKINS], source: "local", target: "local" },
   { name: "voice",  description: "Toggle voice recording",               category: "Client",  aliases: [], argsHint: "[on|off|status|tts]", subcommands: ["on", "off", "status", "tts"], source: "local", target: "local" },
+  { name: "pdf",    description: "Attach PDF pages",                     category: "Client",  aliases: [], argsHint: "<path>", subcommands: [], source: "local", target: "local" },
   { name: "queue",  description: "Queue a prompt for the next idle turn", category: "Session", aliases: ["q"], argsHint: "[text]", subcommands: [], source: "local", target: "local" },
   { name: "yolo",   description: "Toggle approval bypass",                 category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "quit",   description: "Exit herm",                             category: "Exit",    aliases: ["exit"], argsHint: "", subcommands: [], source: "local", target: "local" },

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -369,6 +369,52 @@ export type ImageAttachResponse = {
   message?: string
 }
 
+export type ImageAttachBytesRequest = {
+  session_id: string
+  content_base64?: string
+  data?: string
+  filename?: string
+  ext?: string
+}
+
+export type ImageAttachBytesResponse = ImageAttachResponse & {
+  attached: true
+  path: string
+  count: number
+  remainder: string
+  text: string
+  bytes: number
+}
+
+export type PdfAttachRequest = {
+  session_id: string
+  path?: string
+  content_base64?: string
+  data?: string
+  filename?: string
+  first_page?: number
+  last_page?: number
+}
+
+export type PdfAttachPage = {
+  path: string
+  page: number
+  name?: string
+  width?: number
+  height?: number
+  token_estimate?: number
+}
+
+export type PdfAttachResponse = {
+  attached: boolean
+  filename?: string
+  pages_attached?: number
+  pages?: PdfAttachPage[]
+  count?: number
+  text?: string
+  message?: string
+}
+
 export type DropDetectResponse =
   | { matched: false }
   | ({ matched: true; is_image: true; text: string } & Omit<ImageAttachResponse, "attached" | "message">)

--- a/test/pdf-attach.test.tsx
+++ b/test/pdf-attach.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until } from "./harness"
+
+describe("PDF attach slash command", () => {
+  test("/pdf calls pdf.attach and renders returned page chips", async () => {
+    const t = await mount({
+      handlers: {
+        "pdf.attach": params => ({
+          attached: true,
+          filename: "paper.pdf",
+          pages_attached: 2,
+          pages: [
+            { path: "/tmp/paper-page-1.png", page: 1, name: "paper.pdf p.1", width: 900, height: 1200, token_estimate: 1500 },
+            { path: "/tmp/paper-page-2.png", page: 2, width: 900, height: 1200, token_estimate: 1510 },
+          ],
+          count: 2,
+          text: "[User attached PDF: paper.pdf (2 pages)]",
+        }),
+      },
+    })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/pdf /tmp/paper.pdf") })
+    act(() => t.keys.pressEnter())
+
+    await until(t, () => t.gw.last("pdf.attach") !== undefined)
+    expect(t.gw.last("pdf.attach")?.params).toMatchObject({ path: "/tmp/paper.pdf" })
+    await until(t, () => t.frame().includes("paper.pdf p.1"))
+    expect(t.frame()).toContain("paper.pdf p.2")
+    expect(t.frame()).toContain("attached paper.pdf · 2 pages")
+    t.destroy()
+  })
+
+  test("/pdf surfaces gateway failures without adding a chip", async () => {
+    const t = await mount({
+      handlers: {
+        "pdf.attach": () => { throw new Error("pdftoppm not installed (poppler-utils package required)") },
+      },
+    })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/pdf /tmp/paper.pdf") })
+    act(() => t.keys.pressEnter())
+
+    await until(t, () => t.gw.last("pdf.attach") !== undefined)
+    await until(t, () => t.frame().includes("pdftoppm not installed"))
+    expect(t.frame()).not.toContain("⌫ to detach")
+    t.destroy()
+  })
+})

--- a/test/slash.test.ts
+++ b/test/slash.test.ts
@@ -57,7 +57,7 @@ describe("slash", () => {
 
   test("LOCAL_NAMES covers session-mutating commands", () => {
     for (const n of ["resume", "branch", "compress", "undo", "retry", "model",
-                     "quit", "copy", "paste", "image", "background", "voice",
+                     "quit", "copy", "paste", "image", "pdf", "background", "voice",
                      "mouse", "redraw", "save", "browser"])
       expect(LOCAL_NAMES.has(n)).toBe(true)
   })


### PR DESCRIPTION
## What changed

- Adds a local `/pdf <path>` slash command in Herm.
- Calls the gateway `pdf.attach` RPC with the provided path and leaves PDF rasterization/conversion on the gateway side.
- Converts returned PDF page records into composer attachment chips, preserving page name, dimensions, and token estimate when provided.
- Handles empty-page and failed attach responses with warning/error toasts instead of adding broken chips.
- Adds typed wire contracts for `pdf.attach` and `image.attach_bytes` responses.
- Registers `/pdf` in the local slash catalog and keeps slash parity tests covering the new command.

## Review notes

- Herm does not parse PDF bytes locally in this PR. It only bridges the slash command to the gateway RPC and renders the returned page attachments.
- The success path supports multiple page chips from one command.

## Verification

- `bun test test/pdf-attach.test.tsx test/slash.test.ts` (12 pass, 0 fail)
- `bunx tsc --noEmit`
