### PR TITLE
feat(approval): add YOLO status toggle

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,7 +3,7 @@ import { Profiler, useState, useEffect, useRef, useCallback, useMemo, useReducer
 import * as perf from "./utils/perf"
 import { hasInterp, interpolate } from "./utils/interpolate"
 import { GatewayProvider, useGateway, useGatewayRestart, type Gateway } from "./context/gateway"
-import type { SessionInfo, TranscriptMessage, ImageAttachResponse } from "./context/wire"
+import type { ConfigSetResponse, SessionInfo, TranscriptMessage, ImageAttachResponse } from "./context/wire"
 import type { Message, Usage } from "./types/message"
 import { text as msgText } from "./types/message"
 import { CLOUD_MIN } from "./components/chat/ThoughtCloud"
@@ -320,6 +320,22 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     setQueue(q => [...q, t])
   }, [busy, gw, toast])
   const onAttach = useCallback((r: ImageAttachResponse) => setAttachments(a => [...a, r]), [])
+  const toggleYolo = useCallback((scope: "session" | "global") => {
+    gw.request<ConfigSetResponse>("config.set", scope === "global"
+      ? { key: "yolo", scope: "global" }
+      : { key: "yolo" })
+      .then(r => {
+        if (r.info) {
+          setInfo(r.info)
+          setUsage(r.info.usage)
+        } else {
+          setInfo(prev => prev ? { ...prev, yolo: !prev.yolo } : prev)
+        }
+        toast.show({ variant: "success", message: `yolo ${r.value ?? "toggled"}${scope === "global" ? " (global)" : ""}` })
+        if (r.warning) toast.show({ variant: "warning", message: r.warning })
+      })
+      .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
+  }, [gw, toast])
 
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
@@ -739,6 +755,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     onNotice: (text) => dispatch({ kind: "system", text }),
     onToggleSidebar: () => setHideSidebar(v => !v),
     onSteer: openSteer,
+    onYoloGlobal: () => toggleYolo("global"),
     onStash: () => {
       const c = composer.current
       const v = c?.value().trim() ?? ""
@@ -849,6 +866,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming}
                 status={status}
                 model={info?.model}
+                yolo={info?.yolo}
                 escHint={escHint}
                 queue={queue}
                 attachments={attachments}
@@ -859,6 +877,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 onEnqueue={onEnqueue}
                 onDequeue={dequeue}
                 onSteer={openSteer}
+                onYolo={toggleYolo}
                 onDirty={setComposing}
                 onEmptyEnter={onEmptyEnter}
               />

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -40,7 +40,7 @@ import { TAB_SLASH } from "./tabs"
 import { transcriptToMessages, type Action, type TurnState } from "./turnReducer"
 import type { SlashCommand } from "./slashCommands"
 import type { ComposerHandle } from "../components/chat/Composer"
-import type { SessionInfo, TranscriptMessage, ImageAttachResponse } from "../context/wire"
+import type { ConfigSetResponse, SessionInfo, TranscriptMessage, ImageAttachResponse } from "../context/wire"
 import type { Message, Usage } from "../types/message"
 import { text as msgText } from "../types/message"
 import type { useSession } from "./useSession"
@@ -69,7 +69,7 @@ export type SlashCtx = {
   setFocusRegion: (r: "input" | "content") => void
   setSplash: (v: boolean) => void
   setAttachments: React.Dispatch<React.SetStateAction<ImageAttachResponse[]>>
-  setInfo: (i: SessionInfo) => void
+  setInfo: React.Dispatch<React.SetStateAction<SessionInfo | null>>
   setUsage: React.Dispatch<React.SetStateAction<Usage | undefined>>
   setTitle: (t: string) => void
 
@@ -188,6 +188,20 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
     const x = ctx.current
     if (c.target === "local") {
       switch (c.name) {
+        case "__yolo_global":
+          gw.request<ConfigSetResponse>("config.set", { key: "yolo", scope: "global" })
+            .then(r => {
+              if (r.info) {
+                x.setInfo(r.info)
+                x.setUsage(r.info.usage)
+              } else {
+                x.setInfo(prev => prev ? { ...prev, yolo: !prev.yolo } : prev)
+              }
+              toast.show({ variant: "success", message: `yolo ${r.value ?? "toggled"} (global)` })
+              if (r.warning) toast.show({ variant: "warning", message: r.warning })
+            })
+            .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
+          return
         case "clear":
           destructive(arg,
             { title: "Clear session?", body: "Discards the in-memory transcript. Your session on disk is unchanged; reload to restore.", yes: "clear" },
@@ -538,6 +552,8 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
       onSelect: () => openThemePicker(dialog, themeCtx) },
     { title: "Switch Model", value: "model", action: "model.pick", category: "General",
       onSelect: () => openModelPicker(dialog, gw) },
+    { title: "Toggle Global YOLO", value: "yolo-global", description: "Persistent approval bypass", category: "Session",
+      onSelect: () => run({ name: "__yolo_global", target: "local" } as SlashCommand) },
     { title: "Pick Avatar", value: "eikon", description: "Choose sidebar .eikon avatar", category: "General",
       onSelect: () => pickEikon() },
     { title: "Rollback", value: "rollback", description: "Browse & restore checkpoints", category: "Session",

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -63,6 +63,7 @@ type Opts = {
   onNotice: (text: string) => void
   onToggleSidebar: () => void
   onSteer: () => void
+  onYoloGlobal: () => void
   onStash: () => void
   /** Voice recording key binding + handler from useVoice hook. */
   voiceRecordKey?: VoiceKey
@@ -197,6 +198,12 @@ export function useAppKeys(o: Opts) {
 
     if (keys.match("session.steer", key)) {
       o.onSteer()
+      key.stopPropagation()
+      return
+    }
+
+    if (keys.match("session.yoloGlobal", key)) {
+      o.onYoloGlobal()
       key.stopPropagation()
       return
     }

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -3,7 +3,7 @@
 // the imperative handle so there is exactly one global useKeyboard.
 
 import { forwardRef, memo, useImperativeHandle, useRef, useState, useCallback, useMemo, useEffect } from "react"
-import type { TextareaRenderable, PasteEvent } from "@opentui/core"
+import type { TextareaRenderable, PasteEvent, MouseEvent } from "@opentui/core"
 import { decodePasteBytes } from "@opentui/core"
 import { useTheme } from "../../theme"
 import { useKeys, toBindings } from "../../keys"
@@ -55,6 +55,7 @@ type Props = {
   streaming: boolean
   status?: string
   model?: string
+  yolo?: boolean
   /** Set for ~5s after the first Esc of the interrupt double-tap. */
   escHint?: boolean
   queue?: ReadonlyArray<string>
@@ -71,6 +72,7 @@ type Props = {
   onEnqueue?: (text: string) => void
   onDequeue?: (i: number) => void
   onSteer?: () => void
+  onYolo?: (scope: "session" | "global") => void
   /** Enter pressed with an empty buffer. Return true to consume. */
   onEmptyEnter?: () => boolean
   /** Fires on the empty↔non-empty edge of the input buffer. */
@@ -78,6 +80,9 @@ type Props = {
 }
 
 const MAX_ROWS = 6
+
+export const yoloScopeFromMouse = (e: Pick<MouseEvent, "modifiers">): "session" | "global" =>
+  e.modifiers.shift ? "global" : "session"
 
 function fmt(n: number): string {
   if (n < 1000) return String(n)
@@ -527,7 +532,20 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         <box
           height={1}
           flexDirection="row"
-          onMouseDown={() => props.onSteer?.()}
+          onMouseDown={(e: MouseEvent) => { e.stopPropagation(); props.onYolo?.(yoloScopeFromMouse(e)) }}
+        >
+          <text onMouseDown={(e: MouseEvent) => { e.stopPropagation(); props.onYolo?.(yoloScopeFromMouse(e)) }}>
+            <span fg={props.yolo ? theme.warning : theme.borderSubtle}>⚡ </span>
+            <span fg={props.yolo ? theme.warning : theme.textMuted}>yolo</span>
+            <span fg={theme.textMuted}> </span>
+            <span fg={theme.accent}>{keys.print("session.yoloGlobal")}</span>
+          </text>
+        </box>
+        <text fg={theme.textMuted}>  </text>
+        <box
+          height={1}
+          flexDirection="row"
+          onMouseDown={(e: MouseEvent) => { e.stopPropagation(); props.onSteer?.() }}
         >
           <text>
             <span fg={theme.borderSubtle}>◇ </span>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -30,7 +30,7 @@ const SELECTS: Record<string, string[]> = {
   "display.details_mode": ["hidden", "collapsed", "expanded"],
   "display.thinking_mode": ["collapsed", "truncated", "full"],
   "display.tool_progress": ["off", "new", "all", "verbose"],
-  "approvals.mode": ["manual", "ask", "yolo", "deny"],
+  "approvals.mode": ["manual", "smart", "off"],
 }
 
 const get = (obj: Record<string, unknown>, path: string): unknown => {

--- a/src/config/rules.ts
+++ b/src/config/rules.ts
@@ -71,7 +71,7 @@ export const RULES: Record<string, Rule> = {
   "display.tool_progress": oneOf("off", "new", "all", "verbose"),
   "display.final_response_markdown": oneOf("render", "strip", "raw"),
   "logging.level": oneOf("DEBUG", "INFO", "WARNING", "ERROR"),
-  "approvals.mode": oneOf("manual", "ask", "yolo", "deny"),
+  "approvals.mode": oneOf("manual", "smart", "off"),
   "code_execution.mode": oneOf("project", "strict"),
 }
 

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -164,6 +164,7 @@ export type SessionInfo = {
   model?: string
   cwd?: string
   session_id?: string
+  yolo?: boolean
   /**
    * Live tool catalog from gateway session.info. state.db is canonical for
    * historical sessions, while legacy sessions/session_*.json snapshots are
@@ -319,6 +320,7 @@ export type CommandsCatalogResponse = {
 export type ConfigSetResponse = {
   value?: string
   info?: SessionInfo
+  scope?: "session" | "global"
   warning?: string
   history_reset?: boolean
 }

--- a/src/keys/catalog.ts
+++ b/src/keys/catalog.ts
@@ -45,6 +45,7 @@ export const DEFAULTS = {
   "session.redo":      def("<leader>r",            "Redo last undo",                     "global"),
   "session.compress":  def("<leader>c",            "Compress context",                   "global"),
   "session.steer":     def("<leader>s",            "Steer active turn",                   "global"),
+  "session.yoloGlobal": def("<leader>z",            "Toggle global YOLO",                  "global"),
   "input.stash":       def("<leader>p",            "Stash prompt draft",                 "global"),
   "session.timeline":  def("<leader>g",            "Session timeline",                   "global"),
   "theme.pick":        def("<leader>t",            "Switch theme",                       "global"),

--- a/test/yolo-status.test.tsx
+++ b/test/yolo-status.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount as mountApp, until, MockGateway } from "./harness"
+import { yoloScopeFromMouse } from "../src/components/chat/Composer"
+import { check } from "../src/config/rules"
+import { buildFields } from "../src/config"
+import type { ConfigSetResponse, SessionInfo } from "../src/context/wire"
+
+describe("yolo status control", () => {
+  test("Composer yolo chip toggles session scope and refreshes from config.set info", async () => {
+    const gw = new MockGateway({
+      "config.set": p => ({
+        value: "on",
+        scope: "session",
+        info: { model: "test-model", session_id: p.session_id, tools: {}, skills: {}, yolo: true },
+      }),
+    })
+    const t = await mountApp({ gw })
+    await until(t, () => t.frame().includes("yolo") && t.frame().includes("Ready"))
+
+    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("z") })
+    await until(t, () => t.gw.last("config.set")?.params.key === "yolo")
+
+    expect(t.gw.last("config.set")?.params).toMatchObject({ key: "yolo", scope: "global", session_id: "test-sid" })
+    expect(t.frame()).toContain("yolo on")
+
+    t.destroy()
+  })
+
+  test("Composer yolo mouse helper maps plain and shifted activation to scopes", () => {
+    const evt = (shift: boolean) => ({ modifiers: { shift, alt: false, ctrl: false } })
+    expect(yoloScopeFromMouse(evt(false))).toBe("session")
+    expect(yoloScopeFromMouse(evt(true))).toBe("global")
+  })
+
+  test("wire/config typing accepts yolo status, response scope, and upstream approval modes", () => {
+    const info: SessionInfo = { yolo: true }
+    const res: ConfigSetResponse = { scope: "global", info }
+    expect(res.info?.yolo).toBe(true)
+
+    const mode = buildFields({ approvals: { mode: "smart" } }).find(f => f.key === "approvals.mode")
+    expect(mode?.options).toEqual(["manual", "smart", "off"])
+    expect(check("approvals.mode", "manual")).toBe(null)
+    expect(check("approvals.mode", "smart")).toBe(null)
+    expect(check("approvals.mode", "off")).toBe(null)
+    expect(check("approvals.mode", "yolo")).toContain("manual | smart | off")
+  })
+})


### PR DESCRIPTION
## What changed

- Adds a compact `yolo` control in the composer footer, next to the steering affordance.
- Shows the control in the active YOLO color when `session.info` reports `yolo: true`.
- Clicking the control toggles YOLO for the current session; Shift-click toggles global YOLO.
- Adds a global keybind, `<leader>z`, for the global toggle.
- Adds a command-palette action, `Toggle Global YOLO`, that uses the same config write path.
- Routes toggles through `config.set` with `key: "yolo"`, then refreshes session info and usage from the response when available.
- Updates Herm's local `approvals.mode` enum to the current values: `manual | smart | off`.
- Extends wire types for `SessionInfo.yolo` and `ConfigSetResponse.scope`.

## Review notes

- The UI does not directly write `approvals.mode`. It uses the dedicated `yolo` config-set lane and lets the gateway decide the resulting value.
- The session/global split is available both by mouse and keyboard.

## Verification

- `bun test test/yolo-status.test.tsx test/config-index.test.ts test/approval-memory.test.tsx` (19 pass, 0 fail)
- `bunx tsc --noEmit`
