### PR TITLE
feat(config): add Agent Plugins tab

### DIFF
--- a/src/agentPlugins.ts
+++ b/src/agentPlugins.ts
@@ -1,0 +1,68 @@
+import type { Gateway } from "./context/gateway"
+
+export type AgentPluginStatus = "enabled" | "disabled" | "not enabled" | string
+
+export type AgentPlugin = {
+  name: string
+  version: string
+  description: string
+  source: string
+  status: AgentPluginStatus
+}
+
+type LegacyPlugin = {
+  name?: string
+  version?: string
+  description?: string
+  source?: string
+  status?: string
+  enabled?: boolean
+}
+
+export type PluginsListResponse = {
+  plugins: LegacyPlugin[]
+  user_count?: number
+  bundled_count?: number
+}
+
+export type PluginsToggleRequest = { action: "toggle"; name: string; enable: boolean }
+
+export type ShellResult = { stdout: string; stderr: string; code: number }
+
+const shq = (s: string) => `'${s.replace(/'/g, `'"'"'`)}'`
+
+const status = (p: LegacyPlugin): AgentPluginStatus => {
+  if (typeof p.status === "string" && p.status) return p.status
+  if (p.enabled === true) return "enabled"
+  if (p.enabled === false) return "disabled"
+  return "not enabled"
+}
+
+export const normalizeAgentPlugin = (p: LegacyPlugin): AgentPlugin => ({
+  name: p.name ?? "",
+  version: p.version ?? "",
+  description: p.description ?? "",
+  source: p.source ?? "unknown",
+  status: status(p),
+})
+
+export const listAgentPlugins = async (gw: Pick<Gateway, "request">) => {
+  const r = await gw.request<PluginsListResponse>("plugins.list", { action: "list" })
+  const plugins = (r.plugins ?? []).map(normalizeAgentPlugin)
+  return {
+    plugins,
+    user_count: r.user_count ?? plugins.filter(p => p.source !== "bundled").length,
+    bundled_count: r.bundled_count ?? plugins.filter(p => p.source === "bundled").length,
+  }
+}
+
+export const toggleAgentPlugin = async (gw: Pick<Gateway, "request">, req: PluginsToggleRequest) => {
+  const verb = req.enable ? "enable" : "disable"
+  const cmd = `hermes plugins ${verb} ${shq(req.name)}`
+  const r = await gw.request<ShellResult>("shell.exec", { command: cmd })
+  if (r.code !== 0) throw new Error((r.stderr || r.stdout || `exit ${r.code}`).trim())
+  return normalizeAgentPlugin({
+    name: req.name,
+    status: req.enable ? "enabled" : "disabled",
+  })
+}

--- a/src/app/tabs.ts
+++ b/src/app/tabs.ts
@@ -11,7 +11,7 @@ export const TABS = [
   { name: "Chat",                 description: "Main chat interface" },
   { name: "Sessions",             description: "Sessions, context, analytics" },
   { name: "Profiles & Automation",description: "Profiles, cron jobs, kanban boards" },
-  { name: "Config",               description: "Config, env, skills, toolsets, memory" },
+  { name: "Config",               description: "Config, env, skills, toolsets, plugins, memory" },
   { name: "Eikon",                description: "Avatar studio & gallery" },
 ] as const
 
@@ -25,7 +25,7 @@ export const EIKON_TAB = 4
 export const SUB_TABS: Record<number, readonly string[]> = {
   [SESSIONS_TAB]:   ["List", "Context", "Analytics"],
   [AUTOMATION_TAB]: ["Kanban", "Profiles", "Cron"],
-  [CONFIG_TAB]:     ["Config", "Skills", "Toolsets", "Env", "Memory"],
+  [CONFIG_TAB]:     ["Config", "Skills", "Toolsets", "Env", "Memory", "Plugins"],
   [EIKON_TAB]:      ["Gallery", "Studio", "Marketplace"],
 }
 
@@ -47,6 +47,7 @@ export const TAB_SLASH: Record<string, { tab: number; sub: number }> = {
   toolsets:   { tab: CONFIG_TAB,     sub: 2 },
   env:        { tab: CONFIG_TAB,     sub: 3 },
   memory:     { tab: CONFIG_TAB,     sub: 4 },
+  plugins:    { tab: CONFIG_TAB,     sub: 5 },
   studio:     { tab: EIKON_TAB,      sub: 1 },
   gallery:    { tab: EIKON_TAB,      sub: 0 },
   marketplace:{ tab: EIKON_TAB,      sub: 2 },

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -323,6 +323,29 @@ export type ConfigSetResponse = {
   history_reset?: boolean
 }
 
+export type AgentPluginStatus = "enabled" | "disabled" | "not-enabled" | string
+
+export type AgentPlugin = {
+  name: string
+  version: string
+  description: string
+  source: string
+  status: AgentPluginStatus
+}
+
+export type PluginsManageListRequest = { action: "list" }
+
+export type PluginsManageToggleRequest = { action: "toggle"; name: string; enable: boolean }
+export type PluginsManageRequest = PluginsManageListRequest | PluginsManageToggleRequest
+
+export type PluginsManageListResponse = {
+  plugins: AgentPlugin[]
+  user_count: number
+  bundled_count: number
+}
+
+export type PluginsManageToggleResponse = AgentPlugin
+
 export type ModelPricing = {
   input: string
   output: string

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -323,28 +323,7 @@ export type ConfigSetResponse = {
   history_reset?: boolean
 }
 
-export type AgentPluginStatus = "enabled" | "disabled" | "not-enabled" | string
-
-export type AgentPlugin = {
-  name: string
-  version: string
-  description: string
-  source: string
-  status: AgentPluginStatus
-}
-
-export type PluginsManageListRequest = { action: "list" }
-
-export type PluginsManageToggleRequest = { action: "toggle"; name: string; enable: boolean }
-export type PluginsManageRequest = PluginsManageListRequest | PluginsManageToggleRequest
-
-export type PluginsManageListResponse = {
-  plugins: AgentPlugin[]
-  user_count: number
-  bundled_count: number
-}
-
-export type PluginsManageToggleResponse = AgentPlugin
+export type { AgentPlugin, AgentPluginStatus, PluginsListResponse, PluginsToggleRequest } from "../agentPlugins"
 
 export type ModelPricing = {
   input: string

--- a/src/tabs/AgentPlugins.tsx
+++ b/src/tabs/AgentPlugins.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import { useGateway } from "../context/gateway"
-import { type AgentPlugin, type PluginsManageListRequest, type PluginsManageListResponse, type PluginsManageToggleRequest, type PluginsManageToggleResponse } from "../context/wire"
+import { type AgentPlugin, listAgentPlugins, toggleAgentPlugin } from "../agentPlugins"
 import { useListKeys, useFollow } from "../keys"
 import { useTheme } from "../theme"
 import { useDialog } from "../ui/dialog"
@@ -13,7 +13,7 @@ import { Col, Hdr, VBAR } from "../ui/table"
 type Section = { source: string; items: AgentPlugin[] }
 
 const enabled = (p: AgentPlugin) => p.status === "enabled"
-const canToggle = (p: AgentPlugin) => p.status === "enabled" || p.status === "disabled" || p.status === "not-enabled"
+const canToggle = (p: AgentPlugin) => p.status === "enabled" || p.status === "disabled" || p.status === "not enabled"
 const statusLabel = (p: AgentPlugin) => p.status || "unknown"
 
 const group = (list: AgentPlugin[]): Section[] => {
@@ -34,7 +34,7 @@ const rank = (source: string) =>
 
 const statusFg = (theme: ReturnType<typeof useTheme>["theme"], p: AgentPlugin) =>
   enabled(p) ? theme.success
-  : p.status === "disabled" || p.status === "not-enabled" ? theme.textMuted
+  : p.status === "disabled" || p.status === "not enabled" ? theme.textMuted
   : theme.warning
 
 const Row = memo((props: {
@@ -112,11 +112,11 @@ export const AgentPlugins = memo((props: { focused?: boolean }) => {
 
   const load = useCallback(() => {
     setLoading(true)
-    gw.request<PluginsManageListResponse>("plugins.manage", { action: "list" } satisfies PluginsManageListRequest)
+    listAgentPlugins(gw)
       .then(r => {
-        setPlugins(r.plugins ?? [])
-        setCounts({ user: r.user_count ?? 0, bundled: r.bundled_count ?? 0 })
-        setSel(s => Math.max(0, Math.min(s, Math.max(0, (r.plugins?.length ?? 1) - 1))))
+        setPlugins(r.plugins)
+        setCounts({ user: r.user_count, bundled: r.bundled_count })
+        setSel(s => Math.max(0, Math.min(s, Math.max(0, r.plugins.length - 1))))
         setErr(null)
       })
       .catch(e => setErr(e instanceof Error ? e.message : String(e)))
@@ -134,10 +134,10 @@ export const AgentPlugins = memo((props: { focused?: boolean }) => {
     }
     const enable = !enabled(p)
     setBusy(p.name)
-    const req = { action: "toggle", name: p.name, enable } satisfies PluginsManageToggleRequest
-    gw.request<PluginsManageToggleResponse>("plugins.manage", req)
+    const req = { action: "toggle", name: p.name, enable } as const
+    toggleAgentPlugin(gw, req)
       .then(plugin => {
-        setPlugins(prev => prev.map(x => x.name === p.name ? plugin : x))
+        setPlugins(prev => prev.map(x => x.name === p.name ? { ...x, ...plugin } : x))
         setErr(null)
         toast.show({
           variant: "success",

--- a/src/tabs/AgentPlugins.tsx
+++ b/src/tabs/AgentPlugins.tsx
@@ -1,0 +1,224 @@
+import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react"
+import { useGateway } from "../context/gateway"
+import { type AgentPlugin, type PluginsManageListRequest, type PluginsManageListResponse, type PluginsManageToggleRequest, type PluginsManageToggleResponse } from "../context/wire"
+import { useListKeys, useFollow } from "../keys"
+import { useTheme } from "../theme"
+import { useDialog } from "../ui/dialog"
+import { HintBar } from "../ui/hint"
+import { KVBlock } from "../ui/kv"
+import { TabShell } from "../ui/shell"
+import { useToast } from "../ui/toast"
+import { Col, Hdr, VBAR } from "../ui/table"
+
+type Section = { source: string; items: AgentPlugin[] }
+
+const enabled = (p: AgentPlugin) => p.status === "enabled"
+const canToggle = (p: AgentPlugin) => p.status === "enabled" || p.status === "disabled" || p.status === "not-enabled"
+const statusLabel = (p: AgentPlugin) => p.status || "unknown"
+
+const group = (list: AgentPlugin[]): Section[] => {
+  const by = new Map<string, AgentPlugin[]>()
+  for (const p of list) {
+    const key = p.source || "unknown"
+    by.set(key, [...(by.get(key) ?? []), p])
+  }
+  return [...by.entries()]
+    .sort(([a], [b]) => rank(a) - rank(b) || a.localeCompare(b))
+    .map(([source, items]) => ({ source, items }))
+}
+
+const rank = (source: string) =>
+  source === "user" ? 0
+  : source === "bundled" ? 1
+  : 2
+
+const statusFg = (theme: ReturnType<typeof useTheme>["theme"], p: AgentPlugin) =>
+  enabled(p) ? theme.success
+  : p.status === "disabled" || p.status === "not-enabled" ? theme.textMuted
+  : theme.warning
+
+const Row = memo((props: {
+  id: string
+  plugin: AgentPlugin
+  selected: boolean
+  busy: boolean
+  onSelect: () => void
+  onHover: () => void
+}) => {
+  const theme = useTheme().theme
+  const p = props.plugin
+  const glyph = props.busy ? "◒" : enabled(p) ? "●" : "○"
+  return (
+    <box id={props.id} flexDirection="row" height={1}
+         backgroundColor={props.selected ? theme.backgroundElement : undefined}
+         onMouseDown={props.onSelect} onMouseMove={props.onHover}>
+      <Col w={2} fg={props.selected ? theme.primary : theme.text}>{props.selected ? "▸ " : "  "}</Col>
+      <Col w={2} fg={statusFg(theme, p)}>{`${glyph} `}</Col>
+      <Col grow min={10} fg={props.selected ? theme.accent : theme.text}>{p.name}</Col>
+      <Col w={10} fg={theme.info}>{p.version || "—"}</Col>
+      <Col w={13} fg={theme.textMuted}>{statusLabel(p)}</Col>
+      <Col w={10} fg={theme.textMuted}>{p.source || "unknown"}</Col>
+    </box>
+  )
+})
+
+const DetailPanel = memo((props: { plugin: AgentPlugin; busy: boolean }) => {
+  const theme = useTheme().theme
+  const p = props.plugin
+  const action = enabled(p) ? "Disable" : "Enable"
+  return (
+    <box flexDirection="column" padding={1} border borderColor={theme.border}
+         backgroundColor={theme.backgroundPanel} width="42%">
+      <box height={1}><text fg={theme.accent}><strong>{p.name}</strong></text></box>
+      <box height={1}><text fg={theme.textMuted}>Upstream Hermes Agent plugin</text></box>
+      <box height={1} />
+      <KVBlock rows={[
+        ["Status", statusLabel(p), statusFg(theme, p)],
+        ["Version", p.version || undefined, theme.info],
+        ["Source", p.source || undefined, theme.text],
+      ]} />
+      <box height={1} />
+      <box minHeight={1}>
+        <text wrapMode="word" fg={theme.text}>{p.description || "No description"}</text>
+      </box>
+      <box height={1} />
+      <box minHeight={2}>
+        <text wrapMode="word" fg={theme.textMuted}>These are upstream Python/agent plugins, not Herm UI-extension plugins. A restart or reload may be required for changes to take effect.</text>
+      </box>
+      <box height={1} />
+      <box height={1}>
+        <text fg={canToggle(p) ? theme.text : theme.textMuted}>{props.busy ? "Applying…" : canToggle(p) ? `${action}: Space/Enter` : "Toggle unavailable"}</text>
+      </box>
+    </box>
+  )
+})
+
+export const AgentPlugins = memo((props: { focused?: boolean }) => {
+  const theme = useTheme().theme
+  const gw = useGateway()
+  const dialog = useDialog()
+  const toast = useToast()
+  const [plugins, setPlugins] = useState<AgentPlugin[]>([])
+  const [counts, setCounts] = useState({ user: 0, bundled: 0 })
+  const [sel, setSel] = useState(0)
+  const [err, setErr] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const secs = group(plugins)
+  const flat = secs.flatMap(s => s.items)
+  const live = useRef({ flat, sel })
+  live.current = { flat, sel }
+
+  const load = useCallback(() => {
+    setLoading(true)
+    gw.request<PluginsManageListResponse>("plugins.manage", { action: "list" } satisfies PluginsManageListRequest)
+      .then(r => {
+        setPlugins(r.plugins ?? [])
+        setCounts({ user: r.user_count ?? 0, bundled: r.bundled_count ?? 0 })
+        setSel(s => Math.max(0, Math.min(s, Math.max(0, (r.plugins?.length ?? 1) - 1))))
+        setErr(null)
+      })
+      .catch(e => setErr(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false))
+  }, [gw])
+
+  useEffect(() => { load() }, [load])
+
+  const toggle = useCallback(() => {
+    const p = live.current.flat[live.current.sel]
+    if (!p || busy) return
+    if (!canToggle(p)) {
+      toast.show({ variant: "warning", message: `${p.name} cannot be toggled` })
+      return
+    }
+    const enable = !enabled(p)
+    setBusy(p.name)
+    const req = { action: "toggle", name: p.name, enable } satisfies PluginsManageToggleRequest
+    gw.request<PluginsManageToggleResponse>("plugins.manage", req)
+      .then(plugin => {
+        setPlugins(prev => prev.map(x => x.name === p.name ? plugin : x))
+        setErr(null)
+        toast.show({
+          variant: "success",
+          message: `${plugin.name} ${enabled(plugin) ? "enabled" : "disabled"}. Restart or reload may be required.`,
+        })
+      })
+      .catch(e => {
+        const msg = e instanceof Error ? e.message : String(e)
+        setErr(msg)
+        toast.show({ variant: "error", message: msg })
+      })
+      .finally(() => setBusy(null))
+  }, [gw, toast, busy])
+
+  const follow = useFollow("agent-plugin")
+  const keys = useListKeys({
+    active: () => !!props.focused && !dialog.open(),
+    count: flat.length,
+    setSel,
+    ...follow.opts,
+    onToggle: toggle,
+    onActivate: toggle,
+    onRefresh: () => { load(); toast.show({ variant: "info", message: "Reloading agent plugins", duration: 1000 }) },
+  })
+  const selected = flat[sel] ?? null
+
+  return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <box flexDirection="row" flexGrow={1} minWidth={0}>
+        <TabShell title={`Agent Plugins (${flat.length})`} error={err}>
+          <box minHeight={2} flexShrink={0}>
+            <text wrapMode="word" fg={theme.textMuted}>Upstream Hermes Agent plugins · user {String(counts.user)} · bundled {String(counts.bundled)} · not Herm UI extensions</text>
+          </box>
+          <box height={1} flexShrink={0}>
+            <text fg={theme.textMuted}>A restart or reload may be required for changes to take effect.</text>
+          </box>
+          <box height={1} />
+          <Hdr>
+            <Col w={4} fg={theme.textMuted}>{""}</Col>
+            <Col grow min={10} fg={theme.textMuted} bold>Name</Col>
+            <Col w={10} fg={theme.textMuted} bold>Version</Col>
+            <Col w={13} fg={theme.textMuted} bold>Status</Col>
+            <Col w={10} fg={theme.textMuted} bold>Source</Col>
+          </Hdr>
+          {loading ? (
+            <box key="loading" flexGrow={1} padding={2}>
+              <text fg={theme.textMuted}>Loading agent plugins…</text>
+            </box>
+          ) : flat.length === 0 ? (
+            <box key="empty" flexGrow={1} padding={2}>
+              <text fg={theme.textMuted}>No upstream agent plugins found</text>
+            </box>
+          ) : (
+            <scrollbox key="list" ref={follow.ref} scrollY flexGrow={1} verticalScrollbarOptions={VBAR}>
+              {secs.reduce<{ base: number; out: ReactNode[] }>((acc, s) => {
+                acc.out.push(
+                  <box key={`§${s.source}`} height={1} marginTop={acc.base > 0 ? 1 : 0}>
+                    <text fg={theme.textMuted}>─ {s.source || "unknown"} ({s.items.length}) </text>
+                  </box>
+                )
+                s.items.forEach((p, j) => {
+                  const i = acc.base + j
+                  acc.out.push(
+                    <Row key={`${p.source}:${p.name}`} id={follow.id(i)} plugin={p}
+                         selected={i === sel} busy={busy === p.name}
+                         onSelect={() => setSel(i)} onHover={() => setSel(i)} />
+                  )
+                })
+                acc.base += s.items.length
+                return acc
+              }, { base: 0, out: [] }).out}
+            </scrollbox>
+          )}
+        </TabShell>
+        {selected ? <DetailPanel plugin={selected} busy={busy === selected.name} /> : null}
+      </box>
+      <HintBar pairs={[
+        ["↑↓", "nav"],
+        [keys.print("list.toggle"), "toggle"],
+        [keys.print("list.refresh"), "refresh"],
+      ]} />
+    </box>
+  )
+})

--- a/src/tabs/ConfigGroup.tsx
+++ b/src/tabs/ConfigGroup.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, type ReactNode } from "react"
 import { Config } from "./Config"
 import { Skills } from "./Skills"
 import { Toolsets } from "./Toolsets"
+import { AgentPlugins } from "./AgentPlugins"
 import { Env } from "./Env"
 import { Memory } from "./Memory"
 import { SubTabBar } from "../components/tabs/SubTabBar"
@@ -13,7 +14,7 @@ type Props = {
   setSub: (i: number) => void
 }
 
-// Consolidates Config / Skills / Toolsets / Env / Memory. Order is
+// Consolidates Config / Skills / Toolsets / Env / Memory / Plugins. Order is
 // Config first so a bare click on the top-level tab lands on the most
 // common target; the rest are alphabetical-ish by frequency of use.
 export const ConfigGroup = memo((props: Props) => {
@@ -40,6 +41,9 @@ export const ConfigGroup = memo((props: Props) => {
         </Pane>
         <Pane visible={props.sub === 4}>
           <Memory focused={!!props.focused && props.sub === 4} />
+        </Pane>
+        <Pane visible={props.sub === 5}>
+          <AgentPlugins focused={!!props.focused && props.sub === 5} />
         </Pane>
       </box>
     </box>

--- a/test/agent-plugins.test.tsx
+++ b/test/agent-plugins.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { CONFIG_TAB, SUB_TABS, TAB_SLASH } from "../src/app/tabs"
+import { AgentPlugins } from "../src/tabs/AgentPlugins"
+import { mountNode, until, MockGateway } from "./harness"
+
+describe("Agent Plugins tab", () => {
+  test("renders upstream plugin rows and toggles through plugins.manage", async () => {
+    const gw = new MockGateway({
+      "plugins.manage": p => {
+        if (p.action === "toggle") return {
+          name: p.name as string,
+          version: "1.2.3",
+          description: "captures traces",
+          source: "user",
+          status: p.enable ? "enabled" : "disabled",
+        }
+        return {
+          user_count: 1,
+          bundled_count: 1,
+          plugins: [
+            { name: "langfuse", version: "1.2.3", description: "captures traces", source: "user", status: "disabled" },
+            { name: "memory", version: "0.4.0", description: "memory provider", source: "bundled", status: "enabled" },
+          ],
+        }
+      },
+    })
+
+    const t = await mountNode(<AgentPlugins focused />, { gw, width: 170, height: 34 })
+    await until(t, () => t.frame().includes("langfuse") && t.frame().includes("memory"))
+
+    expect(t.frame()).toContain("Upstream Hermes Agent plugins")
+    expect(t.frame()).toContain("user 1")
+    expect(t.frame()).toContain("bundled 1")
+    expect(t.frame()).toContain("not Herm UI extensions")
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.calls.some(c => c.method === "plugins.manage" && c.params.action === "toggle"))
+    expect(gw.last("plugins.manage")?.params).toEqual({ action: "toggle", name: "langfuse", enable: true })
+    await until(t, () => t.frame().includes("enabled"))
+    t.destroy()
+  })
+
+  test("/plugins routes to Config Plugins without moving plugin subcommands", () => {
+    expect(SUB_TABS[CONFIG_TAB][TAB_SLASH.plugins.sub]).toBe("Plugins")
+    expect(TAB_SLASH.plugins).toEqual({ tab: CONFIG_TAB, sub: 5 })
+    expect(TAB_SLASH.env).toEqual({ tab: CONFIG_TAB, sub: 3 })
+    expect(TAB_SLASH.memory).toEqual({ tab: CONFIG_TAB, sub: 4 })
+  })
+})

--- a/test/agent-plugins.test.tsx
+++ b/test/agent-plugins.test.tsx
@@ -5,25 +5,18 @@ import { AgentPlugins } from "../src/tabs/AgentPlugins"
 import { mountNode, until, MockGateway } from "./harness"
 
 describe("Agent Plugins tab", () => {
-  test("renders upstream plugin rows and toggles through plugins.manage", async () => {
+  test("renders upstream plugin rows and toggles through shell bridge", async () => {
     const gw = new MockGateway({
-      "plugins.manage": p => {
-        if (p.action === "toggle") return {
-          name: p.name as string,
-          version: "1.2.3",
-          description: "captures traces",
-          source: "user",
-          status: p.enable ? "enabled" : "disabled",
-        }
-        return {
-          user_count: 1,
-          bundled_count: 1,
-          plugins: [
-            { name: "langfuse", version: "1.2.3", description: "captures traces", source: "user", status: "disabled" },
-            { name: "memory", version: "0.4.0", description: "memory provider", source: "bundled", status: "enabled" },
-          ],
-        }
-      },
+      "plugins.list": () => ({
+        user_count: 1,
+        bundled_count: 1,
+        plugins: [
+          { name: "langfuse", version: "1.2.3", description: "captures traces", source: "user", status: "disabled" },
+          { name: "memory", version: "0.4.0", description: "memory provider", source: "bundled", status: "enabled" },
+          { name: "fresh", version: "", description: "", source: "user", status: "not enabled" },
+        ],
+      }),
+      "shell.exec": p => ({ code: 0, stdout: `ran ${p.command}`, stderr: "" }),
     })
 
     const t = await mountNode(<AgentPlugins focused />, { gw, width: 170, height: 34 })
@@ -34,9 +27,13 @@ describe("Agent Plugins tab", () => {
     expect(t.frame()).toContain("bundled 1")
     expect(t.frame()).toContain("not Herm UI extensions")
 
+    expect(gw.last("plugins.list")?.params).toEqual({ action: "list" })
+    expect(gw.calls.map(c => c.method)).not.toContain("plugins.manage")
+
     act(() => t.keys.pressEnter())
-    await until(t, () => gw.calls.some(c => c.method === "plugins.manage" && c.params.action === "toggle"))
-    expect(gw.last("plugins.manage")?.params).toEqual({ action: "toggle", name: "langfuse", enable: true })
+    await until(t, () => gw.calls.some(c => c.method === "shell.exec"))
+    expect(gw.last("shell.exec")?.params).toEqual({ command: "hermes plugins enable 'langfuse'" })
+    expect(gw.calls.map(c => c.method)).not.toContain("plugins.manage")
     await until(t, () => t.frame().includes("enabled"))
     t.destroy()
   })


### PR DESCRIPTION
## What changed

- Adds a Config > Plugins subtab and `/plugins` route.
- Adds `src/agentPlugins.ts`, a small bridge for listing and toggling Hermes Agent plugins.
- Reads plugin rows through `plugins.list` and normalizes status, version, description, source, and fallback counts.
- Toggles plugins through the existing shell bridge with `hermes plugins enable <name>` / `hermes plugins disable <name>`.
- Renders plugins grouped by source, with enabled/disabled glyphs, version/status/source columns, and a detail pane.
- Supports Space/Enter toggling for toggleable plugin statuses and surfaces command failures as toasts.
- Labels the detail pane clearly as Hermes Agent plugins, not Herm UI-extension plugins.

## Review notes

- The toggle path intentionally uses the CLI bridge. There is no `plugins.manage` RPC dependency in this PR.
- A restart or reload may still be required after enabling/disabling a plugin; the UI states that in the detail pane and success toast.

## Verification

- `bun test test/agent-plugins.test.tsx test/app.test.tsx` (49 pass, 0 fail)
- `bunx tsc --noEmit`
