### PR TITLE
fix(approval): route local /yolo through session config

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -858,7 +858,6 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 onAttachClipboard={attachClipboard}
                 onEnqueue={onEnqueue}
                 onDequeue={dequeue}
-                onSteer={openSteer}
                 onDirty={setComposing}
                 onEmptyEnter={onEmptyEnter}
               />

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -299,6 +299,20 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
+        case "yolo":
+          gw.request<{ value?: string; warning?: string; info?: SessionInfo }>("config.set", { key: "yolo" })
+            .then(r => {
+              if (r.info) {
+                x.setInfo(r.info)
+                x.setUsage(r.info.usage)
+              } else {
+                x.setInfo({ ...(x.info ?? {}), yolo: !x.info?.yolo })
+              }
+              toast.show({ variant: "success", message: `yolo ${r.value ?? "toggled"}` })
+              if (r.warning) toast.show({ variant: "warning", message: r.warning })
+            })
+            .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
+          return
         case "quit": quit(renderer, x.sid, x.title, gw); return
         case "queue":
           if (!arg) { x.dispatch({ kind: "system", text: `${x.queueRef.current.length} queued` }); return }

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -37,7 +37,7 @@ export const LOCAL_NAMES = new Set([
   "rollback", "save", "history", "status", "usage", "profile", "steer",
   "reload", "reload-mcp", "reload-skills", "chafa", "splash", "skin",
   // parity: session-mutating commands the slash-worker can't service
-  "resume", "branch", "compress", "undo", "redo", "retry", "model", "quit",
+  "resume", "branch", "compress", "undo", "redo", "retry", "model", "yolo", "quit",
   "copy", "paste", "image", "background", "voice", "mouse", "redraw", "queue",
   "stash",
   // Ink-only UI toggles — local no-op with a note
@@ -74,6 +74,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "skin",   description: "Switch Hermes skin (+ theme + eikon)", category: "Client",  aliases: [], argsHint: "[name]", subcommands: [...SKINS], source: "local", target: "local" },
   { name: "voice",  description: "Toggle voice recording",               category: "Client",  aliases: [], argsHint: "[on|off|status|tts]", subcommands: ["on", "off", "status", "tts"], source: "local", target: "local" },
   { name: "queue",  description: "Queue a prompt for the next idle turn", category: "Session", aliases: ["q"], argsHint: "[text]", subcommands: [], source: "local", target: "local" },
+  { name: "yolo",   description: "Toggle approval bypass",                 category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "quit",   description: "Exit herm",                             category: "Exit",    aliases: ["exit"], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -70,7 +70,6 @@ type Props = {
   onAttachClipboard?: () => void
   onEnqueue?: (text: string) => void
   onDequeue?: (i: number) => void
-  onSteer?: () => void
   /** Enter pressed with an empty buffer. Return true to consume. */
   onEmptyEnter?: () => boolean
   /** Fires on the empty↔non-empty edge of the input buffer. */
@@ -524,18 +523,6 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         {props.streaming && (props.queue?.length ?? 0) > 0 ? (
           <text fg={theme.textMuted}>{keys.print("queue.flush")} to send queued now  </text>
         ) : null}
-        <box
-          height={1}
-          flexDirection="row"
-          onMouseDown={() => props.onSteer?.()}
-        >
-          <text>
-            <span fg={theme.borderSubtle}>◇ </span>
-            <span fg={theme.textMuted}>steer </span>
-            <span fg={theme.accent}>{keys.print("session.steer")}</span>
-          </text>
-        </box>
-        <text fg={theme.textMuted}>  </text>
         {bg.count > 0 ? <text fg={theme.text}>▶ {bg.count}  </text> : null}
         {props.model ? <text fg={theme.textMuted}>{props.model}</text> : null}
       </box>

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -199,6 +199,7 @@ export type SessionInfo = {
   context_max?: number
   context_used?: number
   credential_warning?: string
+  yolo?: boolean
   mcp_servers?: McpServer[]
   /** hermes-agent version string (e.g. "1.14.2-dev+abc123") */
   release_date?: string

--- a/test/session-steer.test.tsx
+++ b/test/session-steer.test.tsx
@@ -51,14 +51,22 @@ describe("session steer", () => {
     t.destroy()
   })
 
-  test("composer steer chip advertises the leader chord", async () => {
+  test("/steer opens a text prompt and submits guidance through session.steer", async () => {
     const gw = new MockGateway({
       "session.steer": p => ({ status: "queued", text: p.text }),
     })
     const t = await mount({ gw })
-    await until(t, () => t.frame().includes("steer Ctrl+X S"))
+    await until(t, () => t.frame().includes("Ready"))
 
-    expect(t.frame()).toContain("◇ steer Ctrl+X S")
+    await act(async () => { await t.keys.typeText("/steer") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Steer"))
+    await act(async () => { await t.keys.typeText("use the cache") })
+    act(() => { t.keys.pressEnter() })
+    await until(t, () => gw.last("session.steer")?.params.text === "use the cache")
+
+    expect(t.gw.last("prompt.submit")).toBeUndefined()
+    expect(t.frame()).toContain("Queued")
     t.destroy()
   })
 

--- a/test/yolo-status.test.tsx
+++ b/test/yolo-status.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+import type { SessionInfo } from "../src/context/wire"
+
+describe("yolo slash command", () => {
+  test("/yolo toggles session approval bypass through config.set and updates session info", async () => {
+    const info: SessionInfo = { model: "test-model", session_id: "test-sid", tools: {}, skills: {}, yolo: true }
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/yolo", "Toggle YOLO mode"]] }),
+      "config.set": p => ({ key: p.key, value: "on", info }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/yolo") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("config.set")?.params.key === "yolo")
+
+    expect(t.gw.last("config.set")?.params).toMatchObject({ key: "yolo", session_id: "test-sid" })
+    expect(t.gw.last("slash.exec")).toBeUndefined()
+    expect(t.gw.last("prompt.submit")).toBeUndefined()
+    await until(t, () => t.frame().includes("yolo on"))
+    t.destroy()
+  })
+
+  test("/yolo falls back to local info toggle when gateway returns only a value", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/yolo", "Toggle YOLO mode"]] }),
+      "config.set": p => ({ key: p.key, value: "on" }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/yolo") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("config.set")?.params.key === "yolo")
+
+    expect(t.gw.last("config.set")?.params).toMatchObject({ key: "yolo", session_id: "test-sid" })
+    await until(t, () => t.frame().includes("yolo on"))
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## What changed

- Adds `/yolo` as a Herm-local slash command so it is intercepted before prompt submission or `slash.exec` fallback.
- Routes `/yolo` through the live gateway `config.set` path with `key: "yolo"`, which toggles approval bypass for the active session.
- Refreshes local `session.info.yolo` from the gateway response when available, and falls back to toggling the local info bit when older gateways return only a value.
- Adds `SessionInfo.yolo` to Herm's wire type so the active session can carry and render the backend YOLO state.
- Removes the composer footer steer hint/control. Steering remains available through `/steer [text]` and the existing keyboard shortcut.
- Adds `/steer` no-argument coverage to make sure it opens the same text prompt and submits through `session.steer`.

## Review notes

- This PR intentionally does not add a composer YOLO chip, global YOLO keybind, or command-palette global toggle.
- It does not change persistent `approvals.mode`; it only fixes the near-term active-session `/yolo` behavior.
- `/yolo` uses the gateway-backed session toggle instead of trying to emulate approval state in Herm.

## Verification

- `bun test test/yolo-status.test.tsx test/session-steer.test.tsx test/slash.test.ts test/app.test.tsx` (64 pass, 0 fail)
- `bunx tsc --noEmit`
- `bun test` (1287 pass, 0 fail)
