### PR TITLE
fix(chat): refine transcript message chrome

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo, useRef, useState, type RefObject } from "react"
-import type { RGBA, MouseEvent } from "@opentui/core"
+import { RGBA, type MouseEvent } from "@opentui/core"
 import type { Message, Part, TextPart, ToolPart, PromptPart } from "../../types/message"
 import { ErrorBlock } from "./ErrorBlock"
 import { MediaChip, classify, splitContent } from "./MediaChip"
@@ -35,6 +35,27 @@ function extract(msg: Message): string {
 }
 
 const trunc = (s: string, max: number) => s.length <= max ? s : s.slice(0, max - 1) + "…"
+
+function mix(a: RGBA, b: RGBA, n = 0.5): RGBA {
+  return RGBA.fromValues(
+    a.r + (b.r - a.r) * n,
+    a.g + (b.g - a.g) * n,
+    a.b + (b.b - a.b) * n,
+    a.a + (b.a - a.a) * n,
+  )
+}
+
+const TOP_RULE = {
+  topLeft: "▔", topRight: "▔", horizontal: "▔",
+  bottomLeft: "", bottomRight: "", vertical: "",
+  topT: "", bottomT: "", leftT: "", rightT: "", cross: "",
+}
+
+const BOTTOM_RULE = {
+  bottomLeft: "▁", bottomRight: "▁", horizontal: "▁",
+  topLeft: "", topRight: "", vertical: "",
+  topT: "", bottomT: "", leftT: "", rightT: "", cross: "",
+}
 
 // OpenTUI has no onClick; synthesize one from down→up at the same cell
 // so text-selection drags don't fire it.
@@ -116,6 +137,10 @@ const UserMessage = memo(({ message, onRewind }: { message: Message; onRewind?: 
   const theme = useTheme().theme
   const [hover, setHover] = useState(false)
   const click = useClick(onRewind && (() => onRewind(message)))
+  const rule = useMemo(
+    () => mix(theme.background, theme.backgroundElement),
+    [theme.background, theme.backgroundElement],
+  )
   const segs = useMemo(
     () => message.parts.map(p => p.type === "text" && p.content ? splitContent(p.content) : null),
     [message.parts],
@@ -124,34 +149,36 @@ const UserMessage = memo(({ message, onRewind }: { message: Message; onRewind?: 
     <box
       flexDirection="column"
       marginBottom={1}
-      backgroundColor={hover ? theme.backgroundElement : undefined}
-      onMouseOver={() => setHover(true)}
-      onMouseOut={() => setHover(false)}
-      {...click}
     >
-      <Gutter color={theme.primary} side="left">
-        <box minHeight={1} flexDirection="column">
-          {message.parts.map((p, i) => {
-            const seg = segs[i]
-            if (!seg) return null
-            const k = (p as TextPart).key ?? i
-            return seg.map((s, j) => {
-              if ("media" in s) {
-                const kind = classify(s.media)
-                return kind === "img" ? (
-                  <box key={`${k}-m${j}`}><ChafaImage path={s.media} /></box>
-                ) : (
-                  <box key={`${k}-m${j}`} marginTop={1}><MediaChip path={s.media} /></box>
-                )
-              }
-              if ("code" in s) return (
-                <CodeBlock key={`${k}-c${j}`} code={s.code} lang={s.lang} />
+      <box height={1} border={["bottom"]} customBorderChars={BOTTOM_RULE}
+           borderColor={rule} />
+      <box backgroundColor={hover ? rule : theme.backgroundElement}
+           paddingLeft={1} paddingRight={1} paddingY={1} flexDirection="column" minHeight={1}
+           onMouseOver={() => setHover(true)}
+           onMouseOut={() => setHover(false)}
+           {...click}>
+        {message.parts.map((p, i) => {
+          const seg = segs[i]
+          if (!seg) return null
+          const k = (p as TextPart).key ?? i
+          return seg.map((s, j) => {
+            if ("media" in s) {
+              const kind = classify(s.media)
+              return kind === "img" ? (
+                <box key={`${k}-m${j}`}><ChafaImage path={s.media} /></box>
+              ) : (
+                <box key={`${k}-m${j}`} marginTop={1}><MediaChip path={s.media} /></box>
               )
-              return <text key={`${k}-${j}`} fg={theme.text} wrapMode="word">{s.md}</text>
-            })
-          })}
-        </box>
-      </Gutter>
+            }
+            if ("code" in s) return (
+              <CodeBlock key={`${k}-c${j}`} code={s.code} lang={s.lang} />
+            )
+            return <text key={`${k}-${j}`} fg={theme.text} wrapMode="word">{s.md}</text>
+          })
+        })}
+      </box>
+      <box height={1} border={["top"]} customBorderChars={TOP_RULE}
+           borderColor={rule} />
     </box>
   )
 })
@@ -230,12 +257,12 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
   }
 
   return (
-    <box flexDirection="column" marginBottom={1}
-         backgroundColor={hover ? theme.backgroundElement : undefined}
+    <box flexDirection="row" marginBottom={1}
          onMouseOver={() => setHover(true)}
          onMouseOut={() => setHover(false)}
          {...click}>
-      <Gutter color={err ? theme.error : theme.accent} side="right">
+      <box width={3} flexShrink={0} backgroundColor={hover ? theme.backgroundElement : undefined} />
+      <box flexDirection="column" flexGrow={1} flexShrink={1}>
         <box height={1} flexDirection="row">
           <box flexGrow={1}><text fg={theme.textMuted}>{header}</text></box>
           {trail.length ? (
@@ -247,7 +274,7 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
         {message.parts.map(part)}
         {diffs.length ? <DiffTabs tools={diffs} /> : null}
         {err ? <ErrorBlock text={message.error!} /> : null}
-      </Gutter>
+      </box>
     </box>
   )
 })

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -448,8 +448,7 @@ describe("app", () => {
 
     const call = t.gw.last("prompt.submit")
     expect(call?.params.text).toBe("hello gateway")
-    // User messages render inside a left-side gutter.
-    expect(t.frame()).toMatch(/│ hello gateway/)
+    expect(t.frame()).toContain("hello gateway")
 
     t.destroy()
   })
@@ -1261,9 +1260,8 @@ describe("app", () => {
     expect(f).not.toContain("STALE-THINK")
     expect(f).not.toContain("zz_stale_tool")   // tool part never created
     expect(f).toContain("alpha")
-    // `*[interrupted]*` → markdown strips `*` and `[]`; bare word under
-    // the assistant right-side gutter (content on the left, bar on the right).
-    expect(f).toMatch(/interrupted\s+│/)
+    // `*[interrupted]*` → markdown strips `*` and `[]`.
+    expect(f).toMatch(/^\s+interrupted\s*$/m)
 
     // Latch survives completion: the worker thread's stream-retry except
     // handler emits lifecycle "Reconnecting…" after message.complete; a

--- a/test/messagelist.test.tsx
+++ b/test/messagelist.test.tsx
@@ -70,7 +70,7 @@ describe("MessageList", () => {
     expect(msg.parts[0]).toMatchObject({ type: "text", content: "Keep, regenerate, or adjust?", streaming: false })
   })
 
-  test("renders gutter + header + trail badge; body is text-only", async () => {
+  test("renders message chrome + header + trail badge; body is text-only", async () => {
     const t: Harness = await mountNode(
       <box flexDirection="column" width="100%" height="100%">
         <MessageList messages={turn} streaming={false} />
@@ -81,7 +81,8 @@ describe("MessageList", () => {
     const f = t.frame()
 
     expect(f).toContain("run the build")
-    expect(f).toContain("│")
+    expect(f).toContain("▁")
+    expect(f).toContain("▔")
     // Agent header: "Hermes · <tokens> · <duration>" (model is shown
     // in the sidebar/status bar, not in message headers).
     expect(f).toContain("Hermes · 12→34 tok · 250ms")
@@ -112,9 +113,9 @@ describe("MessageList", () => {
     const y3 = lines.findIndex(l => l.includes("third question"))
     // First user turn: the line directly above must NOT be a separator.
     expect(lines[y1 - 1] ?? "").not.toContain("───")
-    // Second + third user turns: separator sits directly above.
-    expect(lines[y2 - 1]).toContain("───")
-    expect(lines[y3 - 1]).toContain("───")
+    // Second + third user turns: separator sits before user chrome.
+    expect(lines.slice(Math.max(0, y2 - 4), y2).some(l => l.includes("───"))).toBe(true)
+    expect(lines.slice(Math.max(0, y3 - 4), y3).some(l => l.includes("───"))).toBe(true)
     t.destroy()
   })
 })


### PR DESCRIPTION
## Summary

- User messages now render as a muted highlighted band framed by custom top and bottom rule glyphs instead of the previous one-sided gutter or full border box.
- User message rules and hover fill are derived between the chat background and message background, so dark themes lighten toward the message and light themes darken toward it.
- User message hover applies only to the message body, keeping the rule rows as static separators.
- Assistant messages no longer carry persistent borders and use a left hover rail so the message body stays readable when the pointer rests over the transcript.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun install --frozen-lockfile`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test`
