### PR TITLE
feat: launch with a one-off profile

### DIFF
--- a/src/app/launch.ts
+++ b/src/app/launch.ts
@@ -19,25 +19,34 @@ const pkgVersion = (d: string, up = 4): string => {
 export const VERSION = pkgVersion(import.meta.dirname)
 
 export type Launch =
-  | { mode: "new"; splash?: boolean }
-  | { mode: "resume"; sid?: string; splash?: boolean }
+  | { mode: "new"; profile?: string; splash?: boolean }
+  | { mode: "resume"; profile?: string; sid?: string; splash?: boolean }
 
 /** Parse process argv (everything after the script path). No deps. */
 export function parseLaunch(argv: readonly string[]): Launch {
   let splash = true
+  let mode: "new" | "resume" = "new"
+  let profile: string | undefined
+  let sid: string | undefined
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === "--no-splash") { splash = false; continue }
-    if (a === "-c" || a === "--continue") return { mode: "resume", splash }
+    if (a === "--profile") {
+      const next = argv[i + 1]
+      if (!next || next.startsWith("-")) throw new Error("--profile requires a name")
+      profile = next
+      i++
+      continue
+    }
+    if (a === "-c" || a === "--continue") { mode = "resume"; continue }
     if (a === "--resume") {
       const next = argv[i + 1]
-      // Treat a following non-flag token as the session id.
-      return next && !next.startsWith("-")
-        ? { mode: "resume", sid: next, splash }
-        : { mode: "resume", splash }
+      mode = "resume"
+      if (next && !next.startsWith("-")) { sid = next; i++ }
     }
   }
-  return { mode: "new", splash }
+  if (mode === "resume") return { mode, ...(profile ? { profile } : {}), ...(sid ? { sid } : {}), splash }
+  return { mode, ...(profile ? { profile } : {}), splash }
 }
 
 export const HELP = `\
@@ -47,6 +56,7 @@ Usage:
   herm                    start a fresh session
   herm -c, --continue     resume the last real TUI session
   herm --resume [id]      resume last (or the given) session
+  herm --profile <name>   start once with a profile; do not change the default
   herm --no-splash        skip the launch splash
   herm -v, --version      print version
   herm -h, --help         show this help

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,8 @@ import { resetTerminalModes, installExitResetHooks } from "./utils/terminal-rese
 import { clampStdoutDimensions } from "./utils/terminal-size";
 import { warmup as warmTokens } from "./utils/tokens";
 import { prime as primeTheme, DEFAULT_THEME } from "./theme";
+import { resolveProfileHome } from "./service/hermes-profiles";
+import { rehome } from "./home/rehome";
 
 // Static ESM imports hoist above module-level code, so the only
 // honest import-graph measurement is process-uptime at the point
@@ -39,6 +41,11 @@ if (argv.includes("--version") || argv.includes("-v")) {
   process.exit(0)
 }
 const launch = parseLaunch(argv)
+if (launch.profile) {
+  const home = resolveProfileHome(launch.profile)
+  if (!home) throw new Error(`profile not found: ${launch.profile}`)
+  rehome(home)
+}
 
 // Initialize and render
 const main = async () => {

--- a/src/service/hermes-profiles.ts
+++ b/src/service/hermes-profiles.ts
@@ -107,6 +107,13 @@ export function stickyDefault(): string | null {
 
 const ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 
+export function resolveProfileHome(name: string): string | null {
+  if (name === "default") return root()
+  if (!ID_RE.test(name)) return null
+  const dir = join(root(), "profiles", name)
+  return existsSync(dir) ? dir : null
+}
+
 function readModel(dir: string): [string | null, string | null] {
   try {
     const raw = readFileSync(join(dir, "config.yaml"), "utf-8")

--- a/test/agents.test.tsx
+++ b/test/agents.test.tsx
@@ -7,7 +7,7 @@ import { mountNode, until, MockGateway } from "./harness"
 import { Agents } from "../src/tabs/Agents"
 import {
   listProfiles, validateName, activeProfileName, profileNameFrom, stickyDefault, profileStats,
-  readDistributionManifest,
+  readDistributionManifest, resolveProfileHome,
 } from "../src/service/hermes-profiles"
 import type { DelegationRecord, DelegationStatus } from "../src/context/wire"
 
@@ -96,6 +96,13 @@ describe("hermes-profiles", () => {
     expect(validateName("Bad", [])).toMatch(/must match/)
     expect(validateName("coder", ["coder"])).toBe("already exists")
     expect(validateName("default", [])).toBe("reserved name")
+  })
+
+  test("resolveProfileHome validates one-off launch profiles", () => {
+    expect(resolveProfileHome("default")).toBe(ROOT)
+    expect(resolveProfileHome("coder")).toBe(join(ROOT, "profiles", "coder"))
+    expect(resolveProfileHome("missing")).toBeNull()
+    expect(resolveProfileHome("Bad")).toBeNull()
   })
 
   test("profileStats reads state.db + cron/jobs.json + herm/tui.json; nulls when absent", async () => {

--- a/test/launch.test.tsx
+++ b/test/launch.test.tsx
@@ -19,10 +19,18 @@ describe("parseLaunch", () => {
     [["--foo", "-c"], { mode: "resume", splash: true }],
     [["--no-splash"], { mode: "new", splash: false }],
     [["--no-splash", "-c"], { mode: "resume", splash: false }],
+    [["-c", "--no-splash"], { mode: "resume", splash: false }],
+    [["--profile", "coder"], { mode: "new", profile: "coder", splash: true }],
+    [["--resume", "abc123", "--profile", "coder"], { mode: "resume", profile: "coder", sid: "abc123", splash: true }],
   ]
   for (const [argv, want] of cases) {
     test(JSON.stringify(argv), () => expect(parseLaunch(argv)).toEqual(want))
   }
+
+  test("requires a profile name", () => {
+    expect(() => parseLaunch(["--profile"])).toThrow("--profile requires a name")
+    expect(() => parseLaunch(["--profile", "--resume"])).toThrow("--profile requires a name")
+  })
 })
 
 describe("normalize", () => {


### PR DESCRIPTION
## What changed

- Adds `herm --profile <name>` for one-off profile launches.
- Resolves the requested profile and rebinds Herm's filesystem, SQLite, cache, watcher, preference, and home-store readers before renderer and gateway startup.
- Leaves the sticky default profile unchanged.
- Composes `--profile` with `--resume`, `--continue`, and `--no-splash` regardless of argument order.
- Rejects missing, invalid, and unknown named profiles instead of silently launching the default profile.

## Verification

- `bun test ./test/launch.test.tsx ./test/agents.test.tsx ./test/rehome.test.ts`: 62 pass, 0 fail
- `bun test ./test/eikon-service.test.ts`: 26 pass, 0 fail
- `bunx tsc --noEmit`
- `bun run build`
- The full suite reproduces existing cross-file Eikon state leakage and an intermittent Eikon layout timeout; the affected files are unchanged by this PR.
