### PR TITLE
fix: route composer slash tokens

### DIFF
--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -354,8 +354,16 @@ export function useAppKeys(o: Opts) {
         key.stopPropagation()
         return
       }
-      if (key.name === "up") return void c?.historyUp()
-      if (key.name === "down") return void c?.historyDown()
+      if (key.name === "up") {
+        const before = c?.value()
+        const ok = c?.historyUp()
+        return void (ok && c?.value() !== before && key.stopPropagation())
+      }
+      if (key.name === "down") {
+        const before = c?.value()
+        const ok = c?.historyDown()
+        return void (ok && c?.value() !== before && key.stopPropagation())
+      }
       // Backspace on an empty buffer with attachments → detach the last.
       // Swallow before the textarea sees it so a subsequent backspace on
       // a still-empty buffer keeps peeling attachments off, not chars.

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -279,14 +279,14 @@ export function useAppKeys(o: Opts) {
       }
     }
 
-    // Popover owns up/down/tab/escape while open; stopPropagation keeps the
-    // textarea renderable from also moving the cursor on the same keypress.
+    // Popover owns up/down/tab/enter/escape while open; stopPropagation keeps
+    // the textarea renderable from also moving the cursor or submitting.
     // Structural — popover nav is composer-state, not a catalog action.
     if (c?.popOpen()) {
-      if (key.name === "escape") return c.popCancel()
+      if (key.name === "escape") { c.popCancel(); key.stopPropagation(); return }
       if (key.name === "up") { c.popNav(-1); key.stopPropagation(); return }
       if (key.name === "down") { c.popNav(1); key.stopPropagation(); return }
-      if (key.name === "tab") return c.popAccept()
+      if (key.name === "tab" || key.name === "return") { c.popAccept(); key.stopPropagation(); return }
       return
     }
 

--- a/src/app/useCompletion.ts
+++ b/src/app/useCompletion.ts
@@ -9,64 +9,62 @@ export type CompletionItem = {
 }
 
 export type CompletionRequest =
-  | { method: "complete.path"; params: { word: string }; replaceFrom: number }
-  | { method: "complete.slash"; params: { text: string }; replaceFrom: number }
+  | { method: "complete.path"; params: { word: string }; replaceFrom: number; replaceTo: number }
+  | { method: "complete.slash"; params: { text: string }; replaceFrom: number; replaceTo: number }
 
 const TAB_PATH_RE = /((?:["']?(?:[A-Za-z]:[\\/]|\.{1,2}\/|~\/|\/|@|[^"'`\s]+\/))[^\s]*)$/
 
-function looksLikeSlashCommand(text: string) {
-  return /^\/[^\s/]*(?:\s|$)/.test(text)
-}
-
-function clear(setItems: (items: CompletionItem[]) => void, setCursor: (idx: number) => void, setReplace: (idx: number) => void) {
+function clear(setItems: (items: CompletionItem[]) => void, setCursor: (idx: number) => void, setReplace: (idx: number) => void, setEnd: (idx: number) => void) {
   setItems([])
   setCursor(0)
   setReplace(0)
+  setEnd(0)
 }
 
 export function completionRequest(input: string): CompletionRequest | null {
-  const slash = looksLikeSlashCommand(input)
-  const word = slash ? null : (input.match(TAB_PATH_RE)?.[1] ?? null)
-  if (!slash && !word) return null
-  if (slash && /^\/model(?:\s|$)/.test(input)) return null
-  if (slash) return { method: "complete.slash", params: { text: input }, replaceFrom: 1 }
-  return { method: "complete.path", params: { word: word! }, replaceFrom: input.length - word!.length }
+  if (/^\/[A-Za-z0-9_-]+$/.test(input)) return null
+  const word = input.match(TAB_PATH_RE)?.[1] ?? null
+  if (!word) return null
+  return { method: "complete.path", params: { word }, replaceFrom: input.length - word.length, replaceTo: input.length }
 }
 
-export function acceptCompletion(input: string, item: CompletionItem, replaceFrom: number) {
+export function acceptCompletion(input: string, item: CompletionItem, replaceFrom: number, replaceTo = input.length) {
   const replace = item.text.startsWith("/") && input.startsWith("/") ? 0 : replaceFrom
   const left = input.slice(0, replace)
+  const right = input.slice(replaceTo)
   if (item.text.includes(":")) frecency.bump(item.text)
-  const space = item.text.endsWith("/") || /\s$/.test(item.text) ? "" : " "
-  return left + item.text + space
+  const space = item.text.endsWith("/") || /\s$/.test(item.text) || /^\s/.test(right) ? "" : " "
+  return left + item.text + space + right
 }
 
-export function useCompletion(input: string, blocked: boolean, gw: Gateway) {
+export function useCompletion(input: string, blocked: boolean, gw: Gateway, req?: CompletionRequest | null) {
   const [items, setItems] = useState<CompletionItem[]>([])
   const [cursor, setCursor] = useState(0)
   const [replaceFrom, setReplace] = useState(0)
+  const [replaceTo, setEnd] = useState(0)
   const seq = useRef(0)
   const dismissed = useRef<string | null>(null)
+  const reqKey = req ? JSON.stringify(req) : ""
 
   useEffect(() => {
     if (blocked) {
       seq.current++
       dismissed.current = null
-      clear(setItems, setCursor, setReplace)
+      clear(setItems, setCursor, setReplace, setEnd)
       return
     }
-    const req = completionRequest(input)
-    if (!req) {
+    const next = req ?? completionRequest(input)
+    if (!next) {
       seq.current++
       dismissed.current = null
-      clear(setItems, setCursor, setReplace)
+      clear(setItems, setCursor, setReplace, setEnd)
       return
     }
     if (dismissed.current === input) return
     dismissed.current = null
     const me = ++seq.current
     const t = setTimeout(() => {
-      gw.request<{ items?: CompletionItem[]; replace_from?: number }>(req.method, req.params)
+      gw.request<{ items?: CompletionItem[]; replace_from?: number }>(next.method, next.params)
         .then(r => {
           if (seq.current !== me) return
           const ranked = (r.items ?? [])
@@ -75,24 +73,26 @@ export function useCompletion(input: string, blocked: boolean, gw: Gateway) {
             .map(x => x.i)
           setItems(ranked)
           setCursor(0)
-          setReplace(req.method === "complete.slash" ? (r.replace_from ?? req.replaceFrom) : req.replaceFrom)
+          setReplace(next.method === "complete.slash" ? next.replaceFrom + ((r.replace_from ?? 1) - 1) : next.replaceFrom)
+          setEnd(next.replaceTo)
         })
         .catch(e => {
           if (seq.current !== me) return
           setItems([{ text: "", display: "completion unavailable", meta: e instanceof Error && e.message ? e.message : "unavailable" }])
           setCursor(0)
-          setReplace(req.replaceFrom)
+          setReplace(next.replaceFrom)
+          setEnd(next.replaceTo)
         })
     }, 60)
     return () => clearTimeout(t)
-  }, [blocked, gw, input])
+  }, [blocked, gw, input, reqKey])
 
   const open = items.length > 0
   const dismiss = () => {
     seq.current++
     dismissed.current = input
-    clear(setItems, setCursor, setReplace)
+    clear(setItems, setCursor, setReplace, setEnd)
   }
 
-  return { open, items, cursor, setCursor, replaceFrom, dismiss }
+  return { open, items, cursor, setCursor, replaceFrom, replaceTo, dismiss }
 }

--- a/src/app/useCompletion.ts
+++ b/src/app/useCompletion.ts
@@ -29,7 +29,9 @@ export function completionRequest(input: string): CompletionRequest | null {
 }
 
 export function acceptCompletion(input: string, item: CompletionItem, replaceFrom: number, replaceTo = input.length) {
-  const replace = item.text.startsWith("/") && input.startsWith("/") ? 0 : replaceFrom
+  const replace = item.text.startsWith("/") && input[replaceFrom - 1] === "/"
+    ? replaceFrom - 1
+    : item.text.startsWith("/") && input.startsWith("/") ? 0 : replaceFrom
   const left = input.slice(0, replace)
   const right = input.slice(replaceTo)
   if (item.text.includes(":")) frecency.bump(item.text)

--- a/src/app/useSlashPopover.ts
+++ b/src/app/useSlashPopover.ts
@@ -4,6 +4,14 @@ import { useMemo, useEffect, useState } from "react"
 import { matchSub, type SlashCommand } from "./slashCommands"
 import { score } from "../utils/fuzzy"
 
+export type SlashToken = {
+  text: string
+  query: string
+  start: number
+  end: number
+  whole: boolean
+}
+
 function best(q: string, cmd: SlashCommand) {
   return cmd.aliases.reduce((m, a) => Math.max(m, score(q, a)), score(q, cmd.name))
 }
@@ -17,34 +25,71 @@ export function rank(list: ReadonlyArray<SlashCommand>, q: string): SlashCommand
     .map(r => r.cmd)
 }
 
-export function useSlashPopover(input: string, cmds: ReadonlyArray<SlashCommand>) {
+function boundary(ch: string | undefined) {
+  return ch === undefined || /\s/.test(ch) || "({\"'`".includes(ch)
+}
+
+export function slashTokenAt(input: string, caret = input.length): SlashToken | null {
+  const off = Math.max(0, Math.min(caret, input.length))
+  if (/^\/[A-Za-z0-9_-]*$/.test(input)) {
+    return { text: input, query: input.slice(1), start: 0, end: input.length, whole: true }
+  }
+
+  const line = input.lastIndexOf("\n", Math.max(0, off - 1)) + 1
+  const slash = input.lastIndexOf("/", off)
+  if (slash < line) return null
+  if (!boundary(input[slash - 1])) return null
+  if (input[slash - 1] === "(" && input[slash - 2] === "]") return null
+  if (input[slash - 1] === "[") return null
+
+  const tail = input.slice(slash + 1)
+  const m = tail.match(/^[A-Za-z0-9_-]*/)
+  const query = m?.[0] ?? ""
+  const end = slash + 1 + query.length
+  if (off > end || off < slash) return null
+  if (input[end] === "/") return null
+  if (!query && input[slash + 1] === "/") return null
+  return { text: input.slice(slash, end), query, start: slash, end, whole: false }
+}
+
+export function replaceSlashToken(input: string, spot: SlashToken, cmd: SlashCommand) {
+  const text = `/${cmd.name}${cmd.name.includes(" ") ? " " : ""}`
+  return input.slice(0, spot.start) + text + input.slice(spot.end)
+}
+
+export function useSlashPopover(input: string, cmds: ReadonlyArray<SlashCommand>, caret = input.length) {
   const [cursor, setCursor] = useState(0)
+  const [dismissed, setDismissed] = useState<string | null>(null)
+  const spot = useMemo(() => slashTokenAt(input, caret), [input, caret])
+  const key = spot ? `${spot.start}:${spot.end}:${spot.text}` : ""
 
   const popover = useMemo(() => {
-    const subs = matchSub(cmds, input)
+    if (!spot || dismissed === key) return null
+    const subs = matchSub(cmds, spot.text)
     if (subs) return subs
-    const m = input.match(/^\/(\S*)$/)
-    return m ? rank(cmds, m[1]) : null
-  }, [input, cmds])
+    return rank(cmds, spot.query)
+  }, [spot, cmds, dismissed, key])
 
   const active = popover ? Math.max(0, Math.min(cursor, popover.length - 1)) : 0
 
   // Reset cursor when input changes
-  useEffect(() => { setCursor(c => c === 0 ? c : 0) }, [input])
+  useEffect(() => {
+    setCursor(c => c === 0 ? c : 0)
+    setDismissed(d => d && d !== key ? null : d)
+  }, [key])
 
   const ghost = useMemo(() => {
     if (!popover || popover.length === 0) return ""
-    const best = popover[active]
-    if (!best || best.name.includes(" ")) return ""
-    const m = input.match(/^\/(\S*)$/)
-    if (!m) return ""
-    const typed = m[1]
+    const hit = popover[active]
+    if (!hit || hit.name.includes(" ")) return ""
+    if (!spot || !/^\/\S*$/.test(spot.text)) return ""
+    const typed = spot.query
     if (typed.length < 2) return ""
-    if (!best.name.toLowerCase().startsWith(typed.toLowerCase())) return ""
-    return best.name.slice(typed.length)
-  }, [input, popover, active])
+    if (!hit.name.toLowerCase().startsWith(typed.toLowerCase())) return ""
+    return hit.name.slice(typed.length)
+  }, [spot, popover, active])
 
   const open = popover !== null && popover.length > 0
 
-  return { popover, cursor: active, setCursor, ghost, open }
+  return { popover, cursor: active, setCursor, ghost, open, spot, dismiss: () => setDismissed(key) }
 }

--- a/src/app/useSlashPopover.ts
+++ b/src/app/useSlashPopover.ts
@@ -29,6 +29,17 @@ function boundary(ch: string | undefined) {
   return ch === undefined || /\s/.test(ch) || "({\"'`".includes(ch)
 }
 
+function tag(s: SlashToken | null) {
+  return s ? `${s.start}:${s.end}:${s.text}` : ""
+}
+
+function exact(spot: SlashToken, cmds: ReadonlyArray<SlashCommand>) {
+  const m = spot.query.match(/^(\S+)(?:\s+(\S.*))?$/)
+  if (!m) return false
+  return cmds.some(c => c.name === m[1] || c.aliases.includes(m[1]))
+    && (m[2] !== undefined || spot.query === m[1])
+}
+
 export function slashTokenAt(input: string, caret = input.length): SlashToken | null {
   const off = Math.max(0, Math.min(caret, input.length))
   if (/^\/[A-Za-z0-9_-]*$/.test(input)) {
@@ -46,8 +57,11 @@ export function slashTokenAt(input: string, caret = input.length): SlashToken | 
   const m = tail.match(/^[A-Za-z0-9_-]*/)
   const query = m?.[0] ?? ""
   const end = slash + 1 + query.length
-  if (off > end || off < slash) return null
   if (input[end] === "/") return null
+  if (slash === line && off > end && /^\s+[^\n]*$/.test(input.slice(end, off))) {
+    return { text: input.slice(slash, off), query: input.slice(slash + 1, off), start: slash, end: off, whole: true }
+  }
+  if (off > end || off < slash) return null
   if (!query && input[slash + 1] === "/") return null
   return { text: input.slice(slash, end), query, start: slash, end, whole: false }
 }
@@ -61,10 +75,11 @@ export function useSlashPopover(input: string, cmds: ReadonlyArray<SlashCommand>
   const [cursor, setCursor] = useState(0)
   const [dismissed, setDismissed] = useState<string | null>(null)
   const spot = useMemo(() => slashTokenAt(input, caret), [input, caret])
-  const key = spot ? `${spot.start}:${spot.end}:${spot.text}` : ""
+  const key = tag(spot)
 
   const popover = useMemo(() => {
     if (!spot || dismissed === key) return null
+    if (spot.whole && exact(spot, cmds)) return null
     const subs = matchSub(cmds, spot.text)
     if (subs) return subs
     return rank(cmds, spot.query)
@@ -91,5 +106,9 @@ export function useSlashPopover(input: string, cmds: ReadonlyArray<SlashCommand>
 
   const open = popover !== null && popover.length > 0
 
-  return { popover, cursor: active, setCursor, ghost, open, spot, dismiss: () => setDismissed(key) }
+  return {
+    popover, cursor: active, setCursor, ghost, open, spot,
+    dismiss: (next?: string, off = next?.length ?? caret) =>
+      setDismissed(tag(next === undefined ? spot : slashTokenAt(next, off))),
+  }
 }

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -166,6 +166,14 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     live.current.props.onSlash(c)
   }
 
+  const fill = (c: SlashCommand) => {
+    const p = live.current.pop
+    if (!p.spot) return
+    const next = replaceSlashToken(live.current.input, p.spot, c)
+    p.dismiss(next)
+    write(next)
+  }
+
   // Complete @-refs land as styled chips; prefix keywords that keep the
   // popover open have nothing to anchor a mark to and stay plain text.
   const atAccept = (idx?: number) => {
@@ -266,7 +274,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     const p = live.current.pop
     if (p.open) {
       const c = p.popover?.[p.cursor]
-      if (c) select(c)
+      if (c) fill(c)
       return
     }
     const exp = buf.current?.expand() ?? { text: live.current.input, parts: [] }
@@ -330,14 +338,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       }
       const p = live.current.pop
       const c = p.popover?.[p.cursor]
-      if (c && p.spot) {
-        if (p.spot.whole && p.spot.text === `/${c.name}` && !c.name.includes(" ")) {
-          write("")
-          live.current.props.onSlash(c)
-          return
-        }
-        write(replaceSlashToken(live.current.input, p.spot, c))
-      }
+      if (c) fill(c)
     },
     popCancel: () => {
       const a = live.current.at

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -11,7 +11,7 @@ import { useGateway } from "../../context/gateway"
 import type { ImageAttachResponse, DropDetectResponse } from "../../context/wire"
 import { looksLikePath } from "../../utils/drop"
 import type { SlashCommand } from "../../app/slashCommands"
-import { useSlashPopover } from "../../app/useSlashPopover"
+import { replaceSlashToken, useSlashPopover } from "../../app/useSlashPopover"
 import { useAtRefPopover, atWordAt } from "../../app/useAtRefPopover"
 import { acceptCompletion, useCompletion } from "../../app/useCompletion"
 import { frecency } from "../../app/frecency"
@@ -103,19 +103,16 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   const [mode, setMode] = useState<"normal" | "shell">("normal")
   const modeRef = useRef(mode); modeRef.current = mode
 
-  // Slash popover keys off the first line only — the grammar is a
-  // single-line prefix and a newline is a hard boundary. @-ref is
-  // cursor-relative over the full buffer so mid-prompt file mentions
-  // work on any line.
-  const head = useMemo(() => {
-    const i = input.indexOf("\n")
-    return i < 0 ? input : input.slice(0, i)
-  }, [input])
-
-  const pop = useSlashPopover(mode === "normal" ? head : "", props.cmds)
+  // Slash and @-ref popovers are cursor-relative over the current buffer.
+  // Slash command execution stays whole-buffer only; mixed prose accepts
+  // replace the token under the cursor without invoking local commands.
+  const pop = useSlashPopover(mode === "normal" ? input : "", props.cmds, caret)
   const atSpot = mode === "normal" ? atWordAt(input, caret) : null
   const at = useAtRefPopover(mode === "normal" ? input : "", caret)
-  const comp = useCompletion(mode === "normal" && !atSpot ? head : "", mode !== "normal" || pop.open, gw)
+  const slashReq = pop.spot && !pop.open && pop.spot.query
+    ? { method: "complete.slash" as const, params: { text: pop.spot.text }, replaceFrom: pop.spot.start + 1, replaceTo: pop.spot.end }
+    : null
+  const comp = useCompletion(mode === "normal" && !atSpot ? input : "", mode !== "normal" || pop.open, gw, slashReq)
 
   const write = useCallback((v: string) => {
     // clear() wipes text + extmarks via setText(""); replay v after.
@@ -159,6 +156,11 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   // Selecting a popover entry: subcommand synthetics (name contains a
   // space) complete the input for further typing; real commands dispatch.
   const select = (c: SlashCommand) => {
+    const spot = live.current.pop.spot
+    if (spot && !spot.whole) {
+      write(replaceSlashToken(live.current.input, spot, c))
+      return
+    }
     if (c.name.includes(" ")) { write(`/${c.name} `); return }
     write("")
     live.current.props.onSlash(c)
@@ -258,7 +260,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     if (cc.open) {
       const it = cc.items[cc.cursor]
       if (!it || !it.text) return
-      write(acceptCompletion(live.current.input, it, cc.replaceFrom))
+      write(acceptCompletion(live.current.input, it, cc.replaceFrom, cc.replaceTo))
       return
     }
     const p = live.current.pop
@@ -323,18 +325,27 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       const cc = live.current.comp
       if (cc.open) {
         const it = cc.items[cc.cursor]
-        if (it?.text) write(acceptCompletion(live.current.input, it, cc.replaceFrom))
+        if (it?.text) write(acceptCompletion(live.current.input, it, cc.replaceFrom, cc.replaceTo))
         return
       }
       const p = live.current.pop
       const c = p.popover?.[p.cursor]
-      if (c) write(`/${c.name}${c.name.includes(" ") ? " " : ""}`)
+      if (c && p.spot) {
+        if (p.spot.whole && p.spot.text === `/${c.name}` && !c.name.includes(" ")) {
+          write("")
+          live.current.props.onSlash(c)
+          return
+        }
+        write(replaceSlashToken(live.current.input, p.spot, c))
+      }
     },
     popCancel: () => {
       const a = live.current.at
       if (a.open) return a.dismiss()
       const cc = live.current.comp
       if (cc.open) return cc.dismiss()
+      const p = live.current.pop
+      if (p.open && p.spot && !p.spot.whole) return p.dismiss()
       write("")
     },
     // History nav is cursor-aware: ↑ fires when the caret is on the
@@ -412,7 +423,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
             onCursor={comp.setCursor}
             onSelect={idx => {
               const it = comp.items[idx]
-              if (it?.text) write(acceptCompletion(input, it, comp.replaceFrom))
+              if (it?.text) write(acceptCompletion(input, it, comp.replaceFrom, comp.replaceTo))
             }}
           />
         </box>
@@ -480,7 +491,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
             // Only worth a re-render when @-completion might retarget;
             // otherwise ←/→ in a long prompt would reconcile Composer
             // on every keystroke for no observable effect.
-            if (!live.current.input.includes("@")) return
+            if (!live.current.input.includes("@") && !live.current.input.includes("/")) return
             const off = ta.current?.cursorOffset ?? 0
             setCaret(c => c === off ? c : off)
           }}
@@ -500,7 +511,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
           focusedBackgroundColor="transparent"
           flexGrow={1}
         />
-        {pop.ghost && props.focused && rows === 1 ? (
+        {pop.ghost && props.focused && rows === 1 && pop.spot?.whole ? (
           <box position="absolute" top={0} left={2 + input.length} height={1}>
             <text fg={theme.textMuted}>{pop.ghost}</text>
           </box>

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -578,7 +578,7 @@ describe("app", () => {
     t.destroy()
   })
 
-  test("slash popover opens on '/' and Enter dispatches local command", async () => {
+  test("slash popover Enter completes command before local dispatch", async () => {
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/model", "Switch model"]] }),
     })
@@ -592,11 +592,19 @@ describe("app", () => {
     await act(async () => { await t.keys.typeText("cle") })
     await t.settle()
     act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("> /clear"))
+
+    expect(t.gw.last("slash.exec")).toBeUndefined()
+    expect(t.gw.last("prompt.submit")).toBeUndefined()
+    expect(t.frame().split("\n").filter(l => l.includes("/clear")).length).toBe(1)
+
+    act(() => t.keys.pressEnter())
     await t.settle()
 
-    // /clear is local — no gateway call, transcript cleared, popover closed
+    // /clear is local — no gateway call, transcript cleared, input cleared.
     expect(t.gw.last("slash.exec")).toBeUndefined()
-    expect(t.frame()).not.toContain("/clear")
+    expect(t.gw.last("prompt.submit")).toBeUndefined()
+    expect(t.frame()).not.toContain("> /clear")
 
     t.destroy()
   })

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -601,6 +601,22 @@ describe("app", () => {
     t.destroy()
   })
 
+  test("mixed prose slash command submits through prompt.submit, not local slash", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("please /clear now") })
+    await until(t, () => t.frame().includes("/clear"))
+    act(() => t.keys.pressEscape())
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("prompt.submit") !== undefined)
+
+    expect(t.gw.last("prompt.submit")?.params.text).toBe("please /clear now")
+    expect(t.gw.last("slash.exec")).toBeUndefined()
+    t.destroy()
+  })
+
   test("/title <arg> sets via session.title RPC", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -2,12 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { acceptCompletion, completionRequest } from "../src/app/useCompletion"
 
 describe("composer completion request", () => {
-  test("routes slash-like input through complete.slash", () => {
-    expect(completionRequest("/help")).toEqual({
-      method: "complete.slash",
-      params: { text: "/help" },
-      replaceFrom: 1,
-    })
+  test("whole-buffer slash popover owns slash-like input", () => {
+    expect(completionRequest("/help")).toBeNull()
   })
 
   test("does not treat absolute paths as slash commands", () => {
@@ -15,6 +11,7 @@ describe("composer completion request", () => {
       method: "complete.path",
       params: { word: "/home/kaio/Dev/herm/src/app.tsx" },
       replaceFrom: 0,
+      replaceTo: 31,
     })
   })
 
@@ -23,6 +20,7 @@ describe("composer completion request", () => {
       method: "complete.path",
       params: { word: "src/app" },
       replaceFrom: 5,
+      replaceTo: 12,
     })
   })
 
@@ -33,6 +31,11 @@ describe("composer completion request", () => {
   test("acceptance replaces only the completion token", () => {
     expect(acceptCompletion("read src/app", { text: "src/app.tsx", display: "app.tsx", meta: "file" }, 5))
       .toBe("read src/app.tsx ")
+  })
+
+  test("acceptance preserves suffix", () => {
+    expect(acceptCompletion("read src/app now", { text: "src/app.tsx", display: "app.tsx", meta: "file" }, 5, 12))
+      .toBe("read src/app.tsx now")
   })
 
   test("acceptance avoids duplicating slash command prefixes", () => {

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -41,6 +41,8 @@ describe("composer completion request", () => {
   test("acceptance avoids duplicating slash command prefixes", () => {
     expect(acceptCompletion("/det", { text: "/details", display: "/details", meta: "command" }, 1))
       .toBe("/details ")
+    expect(acceptCompletion("please /det now", { text: "/details", display: "/details", meta: "command" }, 8, 11))
+      .toBe("please /details now")
   })
 
   test("acceptance preserves prompt toolkit slash command items", () => {

--- a/test/composer.test.tsx
+++ b/test/composer.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { act, createRef, useState } from "react"
 import { mountNode, until, MockGateway, type Harness } from "./harness"
 import { Composer, type ComposerHandle } from "../src/components/chat/Composer"
+import { acceptCompletion } from "../src/app/useCompletion"
 import * as prefs from "../src/context/preferences"
 import type { SlashCommand } from "../src/app/slashCommands"
 import { LOCAL_COMMANDS } from "../src/app/slashCommands"
@@ -181,7 +182,7 @@ describe("composer", () => {
     t.destroy()
   })
 
-  test("history: multi-line buffer → up/down no-op (returned false)", async () => {
+  test("history: Up from a later logical line lets the textarea own movement", async () => {
     const { t, ref } = await setup()
     await act(async () => { await t.keys.typeText("seed") })
     act(() => t.keys.pressEnter())
@@ -191,6 +192,20 @@ describe("composer", () => {
     await t.settle()
     expect(ref.current?.historyUp()).toBe(false)
     expect(ref.current?.value()).toBe("a\nb")
+    t.destroy()
+  })
+
+  test("history: Up at first logical line loads previous prompt", async () => {
+    const { t, ref } = await setup()
+    await act(async () => { await t.keys.typeText("seed") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    act(() => ref.current?.set("draft"))
+    await t.settle()
+    expect(ref.current?.historyUp()).toBe(true)
+    await t.settle()
+    expect(ref.current?.value()).toBe("seed")
     t.destroy()
   })
 
@@ -254,6 +269,75 @@ describe("composer", () => {
     expect(cats.length).toBe(1)
     expect(items.length).toBeLessThanOrEqual(10)
     expect(t.frame()).toContain("/skill-31")
+    t.destroy()
+  })
+
+  test("slash token in mixed prose opens popover and accept replaces only token", async () => {
+    const { t, ref, slashed } = await setup()
+    await act(async () => { await t.keys.typeText("please /cl") })
+    await until(t, () => t.frame().includes("/clear"))
+    expect(ref.current?.popOpen()).toBe(true)
+
+    act(() => ref.current?.popAccept())
+    await t.settle()
+    expect(ref.current?.value()).toBe("please /clear")
+    expect(slashed).toEqual([])
+    t.destroy()
+  })
+
+  test("slash tokens in paths, URLs, and markdown links do not open popover", async () => {
+    for (const text of ["/tmp/file", "https://host/path", "see [label](/clear)"]) {
+      const { t, ref } = await setup()
+      await act(async () => { await t.keys.typeText(text) })
+      await t.settle()
+      expect(ref.current?.popOpen()).toBe(false)
+      t.destroy()
+    }
+  })
+
+  test("mixed prose slash command submits as prompt text, not local slash", async () => {
+    const { t, sent, slashed } = await setup()
+    await act(async () => { await t.keys.typeText("please /clear now") })
+    await until(t, () => t.frame().includes("/clear"))
+    act(() => t.keys.pressEscape())
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toEqual(["please /clear now"])
+    expect(slashed).toEqual([])
+    t.destroy()
+  })
+
+  test("slash RPC completion in mixed prose preserves suffix", async () => {
+    const gw = new MockGateway({
+      "complete.slash": p => p.text === "/zz" ? {
+        replace_from: 1,
+        items: [{ text: "zeta", display: "/zeta", meta: "remote" }],
+      } : { items: [] },
+    })
+    const { t, ref } = await setup(gw)
+
+    await act(async () => { await t.keys.typeText("please /zz") })
+    await until(t, () => t.frame().includes("/zeta"))
+    expect(t.gw.last("complete.slash")?.params.text).toBe("/zz")
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(ref.current?.value()).toBe("please /zeta ")
+    t.destroy()
+  })
+
+  test("popover arrows own navigation before composer history", async () => {
+    const { t, ref } = await setup()
+    await act(async () => { await t.keys.typeText("seed") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    await act(async () => { await t.keys.typeText("please /") })
+    await until(t, () => t.frame().includes("/clear"))
+    act(() => ref.current?.popNav(1))
+    await t.settle()
+    expect(ref.current?.value()).toBe("please /")
     t.destroy()
   })
 
@@ -338,6 +422,15 @@ describe("composer", () => {
     expect(sent).toEqual([])
     expect(ref.current?.value()).toBe("see ./bad")
     t.destroy()
+  })
+
+  test("acceptCompletion preserves suffix for mid-buffer replacement", () => {
+    expect(acceptCompletion(
+      "please /zz now",
+      { text: "zeta", display: "/zeta", meta: "remote" },
+      8,
+      10,
+    )).toBe("please /zeta now")
   })
 
   test("@ opens atref popover; Tab inserts; Esc dismisses without clearing", async () => {

--- a/test/composer.test.tsx
+++ b/test/composer.test.tsx
@@ -223,21 +223,28 @@ describe("composer", () => {
     t.destroy()
   })
 
-  test("popover Enter dispatches onSlash and clears input", async () => {
-    const { t, ref, slashed } = await setup()
-    await act(async () => { await t.keys.typeText("/help") })
+  test("popover Enter completes command text and closes before submit", async () => {
+    const { t, ref, sent, slashed } = await setup()
+    await act(async () => { await t.keys.typeText("/he") })
     await t.settle()
     expect(ref.current?.popOpen()).toBe(true)
 
     act(() => t.keys.pressEnter())
     await t.settle()
-    expect(slashed.map(c => c.name)).toEqual(["help"])
+    expect(slashed).toEqual([])
+    expect(sent).toEqual([])
+    expect(ref.current?.value()).toBe("/help")
+    expect(ref.current?.popOpen()).toBe(false)
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    expect(sent).toEqual(["/help"])
     expect(ref.current?.value()).toBe("")
     t.destroy()
   })
 
-  test("slash popover selection accepts the top rendered candidate", async () => {
-    const { t, slashed } = await withCommands([
+  test("slash popover Enter accepts the top rendered candidate", async () => {
+    const { t, ref, slashed } = await withCommands([
       cmd("zulu", "Zed"),
       cmd("alpha", "Client"),
     ])
@@ -250,7 +257,9 @@ describe("composer", () => {
     act(() => t.keys.pressEnter())
     await t.settle()
 
-    expect(slashed.map(c => c.name)).toEqual([top!])
+    expect(ref.current?.value()).toBe(`/${top!}`)
+    expect(ref.current?.popOpen()).toBe(false)
+    expect(slashed).toEqual([])
     t.destroy()
   })
 
@@ -281,6 +290,7 @@ describe("composer", () => {
     act(() => ref.current?.popAccept())
     await t.settle()
     expect(ref.current?.value()).toBe("please /clear")
+    expect(ref.current?.popOpen()).toBe(false)
     expect(slashed).toEqual([])
     t.destroy()
   })
@@ -534,16 +544,17 @@ describe("composer", () => {
     t.destroy()
   })
 
-  test("slash popover live while streaming; Enter fires onSlash, not onEnqueue", async () => {
+  test("slash popover live while streaming; Enter accepts without enqueueing", async () => {
     const ref = createRef<ComposerHandle>()
     const slashed: SlashCommand[] = []
     const queued: string[] = []
+    const sent: string[] = []
     const t: Harness = await mountNode(
       <box flexDirection="column" flexGrow={1} width="100%" height="100%">
         <box flexGrow={1} />
         <Composer
           ref={ref} focused canSubmitPrompt={true} ready streaming queue={[]} cmds={LOCAL_COMMANDS}
-          onSend={() => {}} onSlash={c => slashed.push(c)}
+          onSend={m => sent.push(m)} onSlash={c => slashed.push(c)}
           onEnqueue={m => queued.push(m)}
         />
       </box>,
@@ -551,7 +562,7 @@ describe("composer", () => {
     )
     await until(t, () => t.frame().includes("Type to queue"))
 
-    await act(async () => { await t.keys.typeText("/steer") })
+    await act(async () => { await t.keys.typeText("/ste") })
     await t.settle()
     expect(ref.current?.popOpen()).toBe(true)
     // Popover renders its matched entry above the input.
@@ -559,9 +570,11 @@ describe("composer", () => {
 
     act(() => t.keys.pressEnter())
     await t.settle()
-    expect(slashed.map(c => c.name)).toEqual(["steer"])
+    expect(slashed).toEqual([])
+    expect(sent).toEqual([])
     expect(queued).toEqual([])
-    expect(ref.current?.value()).toBe("")
+    expect(ref.current?.value()).toBe("/steer")
+    expect(ref.current?.popOpen()).toBe(false)
     t.destroy()
   })
 

--- a/test/slash.test.ts
+++ b/test/slash.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { readFileSync } from "fs"
 import { filter, matchSub, resolve, sort, LOCAL_COMMANDS, LOCAL_NAMES, type SlashCommand } from "../src/app/slashCommands"
+import { replaceSlashToken, slashTokenAt } from "../src/app/useSlashPopover"
 
 const cmd = (over: Partial<SlashCommand>): SlashCommand => ({
   name: "x", description: "", category: "Session", aliases: [], argsHint: "",
@@ -60,6 +61,21 @@ describe("slash", () => {
                      "quit", "copy", "paste", "image", "background", "voice",
                      "mouse", "redraw", "save", "browser"])
       expect(LOCAL_NAMES.has(n)).toBe(true)
+  })
+
+  test("slashTokenAt finds command tokens under cursor and rejects paths", () => {
+    expect(slashTokenAt("please /cl now", 9)).toEqual({ text: "/cl", query: "cl", start: 7, end: 10, whole: false })
+    expect(slashTokenAt("line one\ntry /new later", 16)).toEqual({ text: "/new", query: "new", start: 13, end: 17, whole: false })
+    expect(slashTokenAt("/clear")).toEqual({ text: "/clear", query: "clear", start: 0, end: 6, whole: true })
+    expect(slashTokenAt("/tmp/file")).toBeNull()
+    expect(slashTokenAt("https://host/path")).toBeNull()
+    expect(slashTokenAt("see [label](/clear)")).toBeNull()
+    expect(slashTokenAt("see [/clear]")).toBeNull()
+  })
+
+  test("replaceSlashToken preserves prefix and suffix", () => {
+    const spot = slashTokenAt("please /cl now", 9)!
+    expect(replaceSlashToken("please /cl now", spot, cmd({ name: "clear" }))).toBe("please /clear now")
   })
 
   describe("resolve", () => {

--- a/test/slash.test.ts
+++ b/test/slash.test.ts
@@ -67,6 +67,7 @@ describe("slash", () => {
     expect(slashTokenAt("please /cl now", 9)).toEqual({ text: "/cl", query: "cl", start: 7, end: 10, whole: false })
     expect(slashTokenAt("line one\ntry /new later", 16)).toEqual({ text: "/new", query: "new", start: 13, end: 17, whole: false })
     expect(slashTokenAt("/clear")).toEqual({ text: "/clear", query: "clear", start: 0, end: 6, whole: true })
+    expect(slashTokenAt("/voice o")).toEqual({ text: "/voice o", query: "voice o", start: 0, end: 8, whole: true })
     expect(slashTokenAt("/tmp/file")).toBeNull()
     expect(slashTokenAt("https://host/path")).toBeNull()
     expect(slashTokenAt("see [label](/clear)")).toBeNull()


### PR DESCRIPTION
## What changed
- Makes slash popover parsing cursor-relative so `/command` tokens inside mixed prose can be completed without treating the whole buffer as a command.
  ![Screenshot of slash completion opened inside mixed prose](https://files.catbox.moe/vwl8ak.png)
- Keeps local slash command execution limited to whole-buffer slash commands.
- Preserves mixed-prose slash text as prompt text when submitted, preventing accidental `/clear`, `/new`, or similar local execution from prose.
- Extends completion replacement ranges so mid-message slash completions preserve prefix and suffix text, including slash-prefixed remote completion items.
- Restores slash subcommand parsing such as `/voice o` while still rejecting paths, URLs, markdown links, and path-like slash tokens.
- Lets textarea movement own multiline Up/Down before prompt history is consulted.

## Review notes
- Key ownership stays ordered as dialog/prompt/popover before composer history.
- The completion path handles both prompt-toolkit-style slash items and command items that already include `/`.
- Path-like strings such as `/tmp/file` continue to route as paths, not command popovers.

## Verification
- `bun test test/slash.test.ts test/completion.test.ts test/composer.test.tsx test/app.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- GitHub `test` check is passing.

## Out of scope
- This does not redesign the command catalog UI or add new slash commands.
