### PR TITLE
feat: add media preview fallback strategy

### DIFF
--- a/.ignore/ce/2026-06-11-001-u3-media-fallback-chain-plan.md
+++ b/.ignore/ce/2026-06-11-001-u3-media-fallback-chain-plan.md
@@ -11,9 +11,8 @@ date: 2026-06-11
 
 Implement the transcript/composer image preview decision chain for Herm only:
 
-1. safe terminal-native image preview when Herm has an OpenTUI-owned safe native renderer;
-2. Chafa symbol preview when the image file is supported and `chafa` can render it;
-3. media/file chip for every unsupported, missing, permission-denied, timeout, or no-capability path.
+1. Chafa symbol preview when the image file is supported and `chafa` can render it;
+2. media/file chip for every unsupported, missing, permission-denied, timeout, or no-capability path.
 
 Explicit exclusions: no new gateway RPCs, no raw inline escape output, no broad composer/layout redesign, no Docker/portability/sidebar/OpenTUI-upgrade work.
 
@@ -22,25 +21,23 @@ Explicit exclusions: no new gateway RPCs, no raw inline escape output, no broad 
 - `ChafaImage` currently checks `chafaBin()` and calls `renderChafa()` directly, then falls back to `MediaChip` on failure.
 - `MediaChip.classify()` is extension-only and treats remote image URLs as `url`, which is correct for a chip fallback but means local preview decisions must use local file support checks.
 - Composer and transcript both render local image previews through `ChafaImage`, so extracting strategy selection there gives shared behavior without touching unrelated composer layout.
-- OpenTUI has no safe terminal image primitive in this repo. Native image protocol escape output would bypass renderer ownership over redraw, scrollback, and copy behavior. Actual runtime should therefore not emit native previews yet; the pure strategy helper still models a safe native capability for tests and future renderer support.
+- OpenTUI has no safe terminal image primitive in this repo. Native image protocol escape output would bypass renderer ownership over redraw, scrollback, and copy behavior. Actual runtime should therefore not emit native previews, and this branch should not keep a native strategy surface.
 
 ## Implementation plan
 
 1. Add `src/utils/terminal-image.ts` with pure helpers:
    - supported image extension check;
-   - native capability input shape;
-   - `previewStrategy(input)` returning `native`, `chafa`, or `chip` plus reason.
+   - `previewStrategy(input)` returning `chafa` or `chip` plus reason.
 2. Improve `src/utils/chafa.ts` host-tool handling:
    - use `Bun.which("chafa")` before fixed paths when available;
    - export a test-only/reset helper only if needed for stable tests;
    - keep all chafa failures as `{ err }` so callers never render error chrome.
 3. Update `src/ui/ChafaImage.tsx` to call the shared strategy helper before rendering.
-   - Runtime native support remains disabled because no safe OpenTUI renderer exists.
    - Missing/unsupported/non-local paths go directly to `MediaChip`.
    - Chafa render failure falls back to `MediaChip`.
 4. Keep `MediaChip` as the universal final fallback and export reusable image extension support if it belongs there after implementation.
 5. Add tests before production changes:
-   - capability matrix native > chafa > chip;
+   - capability matrix chafa > chip;
    - unsupported/missing/non-local paths choose chip;
    - ChafaImage missing/unsupported path shows chip without error chrome;
    - composer/transcript surfaces continue sharing ChafaImage fallback behavior.

--- a/.ignore/ce/2026-06-11-001-u3-media-fallback-chain-plan.md
+++ b/.ignore/ce/2026-06-11-001-u3-media-fallback-chain-plan.md
@@ -1,0 +1,59 @@
+---
+title: "U3: Media image fallback chain"
+type: feat
+status: active
+date: 2026-06-11
+---
+
+# U3: Media image fallback chain
+
+## Scope
+
+Implement the transcript/composer image preview decision chain for Herm only:
+
+1. safe terminal-native image preview when Herm has an OpenTUI-owned safe native renderer;
+2. Chafa symbol preview when the image file is supported and `chafa` can render it;
+3. media/file chip for every unsupported, missing, permission-denied, timeout, or no-capability path.
+
+Explicit exclusions: no new gateway RPCs, no raw inline escape output, no broad composer/layout redesign, no Docker/portability/sidebar/OpenTUI-upgrade work.
+
+## Research findings
+
+- `ChafaImage` currently checks `chafaBin()` and calls `renderChafa()` directly, then falls back to `MediaChip` on failure.
+- `MediaChip.classify()` is extension-only and treats remote image URLs as `url`, which is correct for a chip fallback but means local preview decisions must use local file support checks.
+- Composer and transcript both render local image previews through `ChafaImage`, so extracting strategy selection there gives shared behavior without touching unrelated composer layout.
+- OpenTUI has no safe terminal image primitive in this repo. Native image protocol escape output would bypass renderer ownership over redraw, scrollback, and copy behavior. Actual runtime should therefore not emit native previews yet; the pure strategy helper still models a safe native capability for tests and future renderer support.
+
+## Implementation plan
+
+1. Add `src/utils/terminal-image.ts` with pure helpers:
+   - supported image extension check;
+   - native capability input shape;
+   - `previewStrategy(input)` returning `native`, `chafa`, or `chip` plus reason.
+2. Improve `src/utils/chafa.ts` host-tool handling:
+   - use `Bun.which("chafa")` before fixed paths when available;
+   - export a test-only/reset helper only if needed for stable tests;
+   - keep all chafa failures as `{ err }` so callers never render error chrome.
+3. Update `src/ui/ChafaImage.tsx` to call the shared strategy helper before rendering.
+   - Runtime native support remains disabled because no safe OpenTUI renderer exists.
+   - Missing/unsupported/non-local paths go directly to `MediaChip`.
+   - Chafa render failure falls back to `MediaChip`.
+4. Keep `MediaChip` as the universal final fallback and export reusable image extension support if it belongs there after implementation.
+5. Add tests before production changes:
+   - capability matrix native > chafa > chip;
+   - unsupported/missing/non-local paths choose chip;
+   - ChafaImage missing/unsupported path shows chip without error chrome;
+   - composer/transcript surfaces continue sharing ChafaImage fallback behavior.
+6. Run focused tests, full `bun test`, and `bunx tsc --noEmit`.
+7. Run code review/autofix before commit, persist changes, push `feat/media-fallback-chain`, open PR to `dev`, and watch CI.
+
+## Verification commands
+
+- `bun test test/chafa.test.ts test/chafa-image.test.tsx test/media.test.tsx test/attachments.test.tsx`
+- `bun test`
+- `bunx tsc --noEmit`
+
+## Risks
+
+- Native preview remains modeled but not rendered until OpenTUI exposes a safe owner path; this is intentional to avoid raw escape output.
+- Existing host-gated real Chafa fixture depends on local `~/Pictures/ko-fi_banner.png` and should skip cleanly when missing.

--- a/src/components/chat/MediaChip.tsx
+++ b/src/components/chat/MediaChip.tsx
@@ -6,13 +6,13 @@
 import { memo, useState } from "react"
 import { TextAttributes, type MouseEvent } from "@opentui/core"
 import { openFile } from "../../utils/open-file"
+import { image as imagePath } from "../../utils/terminal-image"
 import { useTheme } from "../../theme"
 
 // Ink's canonical regex. Match-per-line only — a MEDIA path is the
 // whole line, optionally wrapped in backticks/quotes by the model.
 export const MEDIA_LINE_RE = /^\s*[`"']?MEDIA:\s*(\S+?)[`"']?\s*$/
 
-const IMAGE_EXT = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp"])
 const AUDIO_EXT = new Set(["mp3", "wav", "ogg", "m4a", "flac", "opus"])
 const VIDEO_EXT = new Set(["mp4", "webm", "mov", "mkv"])
 const IMG_RE = /!\[[^\]\n]*\]\(([^)\s]+)(?:\s+[^)]*)?\)/g
@@ -21,8 +21,8 @@ export type MediaKind = "img" | "audio" | "video" | "file" | "url"
 
 export function classify(path: string): MediaKind {
   if (/^https?:\/\//i.test(path)) return "url"
+  if (imagePath(path)) return "img"
   const ext = path.split(".").pop()?.toLowerCase() ?? ""
-  if (IMAGE_EXT.has(ext)) return "img"
   if (AUDIO_EXT.has(ext)) return "audio"
   if (VIDEO_EXT.has(ext)) return "video"
   return "file"
@@ -70,7 +70,7 @@ export function splitContent(text: string): Seg[] {
     let hit = false
     for (const img of line.matchAll(IMG_RE)) {
       const path = img[1]
-      if (classify(path) !== "img") continue
+      if (!imagePath(path)) continue
       if (!hit) flush()
       if (img.index > at) out.push({ md: line.slice(at, img.index) })
       out.push({ media: path })

--- a/src/ui/ChafaImage.tsx
+++ b/src/ui/ChafaImage.tsx
@@ -9,6 +9,7 @@ import type { MouseEvent } from "@opentui/core"
 import { useTheme } from "../theme"
 import { openFile } from "../utils/open-file"
 import { renderChafa, hex, chafaBin } from "../utils/chafa"
+import { strategy } from "../utils/terminal-image"
 import { MediaChip } from "../components/chat/MediaChip"
 
 const basename = (p: string) => p.split(/[/\\]/).pop() || p
@@ -19,14 +20,15 @@ export const ChafaImage = memo(({ path, width, bare }: Props) => {
   const theme = useTheme().theme
   const [collapsed, setCollapsed] = useState(false)
   const w = Math.max(20, Math.min(80, width ?? 60))
-  const hasChafa = chafaBin() !== null
+  const bin = chafaBin()
+  const preview = strategy(path, bin !== null)
   const result = useMemo(
-    () => hasChafa ? renderChafa(path, w) : ({ err: "chafa not installed" } as const),
-    [path, w, hasChafa],
+    () => preview.kind === "chafa" ? renderChafa(path, w) : null,
+    [path, w, preview.kind],
   )
 
-  // chafa missing or render failed → stream the MediaChip, no chrome
-  if (!hasChafa || "err" in result) return <MediaChip path={path} bare={bare} />
+  // Native rendering stays disabled until OpenTUI owns redraw/scrollback.
+  if (preview.kind !== "chafa" || !result || "err" in result) return <MediaChip path={path} bare={bare} />
 
   // Collapsed → chip re-expands on click. Override MediaChip's default
   // openFile so the click does exactly one thing; stopPropagation keeps

--- a/src/ui/ChafaImage.tsx
+++ b/src/ui/ChafaImage.tsx
@@ -27,7 +27,6 @@ export const ChafaImage = memo(({ path, width, bare }: Props) => {
     [path, w, preview.kind],
   )
 
-  // Native rendering stays disabled until OpenTUI owns redraw/scrollback.
   if (preview.kind !== "chafa" || !result || "err" in result) return <MediaChip path={path} bare={bare} />
 
   // Collapsed → chip re-expands on click. Override MediaChip's default

--- a/src/utils/chafa.ts
+++ b/src/utils/chafa.ts
@@ -106,6 +106,8 @@ let cachedBin: string | null | undefined = undefined
 /** Locate the chafa binary once per process. null → not installed. */
 export function chafaBin(): string | null {
   if (cachedBin !== undefined) return cachedBin
+  const bin = Bun.which?.("chafa") ?? null
+  if (bin) { cachedBin = bin; return bin }
   for (const p of CHAFA_PATHS) if (existsSync(p)) { cachedBin = p; return p }
   cachedBin = null
   return null

--- a/src/utils/terminal-image.ts
+++ b/src/utils/terminal-image.ts
@@ -1,0 +1,43 @@
+import { existsSync } from "fs"
+
+export type PreviewKind = "native" | "chafa" | "chip"
+export type PreviewReason = "native-supported" | "chafa-supported" | "no-renderer" | "missing" | "unsupported" | "remote"
+export type PreviewStrategy = { kind: PreviewKind; reason: PreviewReason }
+
+const IMAGE_EXT = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp"])
+const URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i
+
+export function image(path: string): boolean {
+  return IMAGE_EXT.has((path.split(/[?#]/)[0].split(".").pop() ?? "").toLowerCase())
+}
+
+export function remote(path: string): boolean {
+  return URL_RE.test(path)
+}
+
+export function safeNative(): boolean {
+  return false
+}
+
+export function previewStrategy(opts: {
+  path: string
+  exists: boolean
+  native: boolean
+  chafa: boolean
+}): PreviewStrategy {
+  if (remote(opts.path)) return { kind: "chip", reason: "remote" }
+  if (!image(opts.path)) return { kind: "chip", reason: "unsupported" }
+  if (!opts.exists) return { kind: "chip", reason: "missing" }
+  if (opts.native) return { kind: "native", reason: "native-supported" }
+  if (opts.chafa) return { kind: "chafa", reason: "chafa-supported" }
+  return { kind: "chip", reason: "no-renderer" }
+}
+
+export function strategy(path: string, chafa: boolean): PreviewStrategy {
+  return previewStrategy({
+    path,
+    chafa,
+    native: safeNative(),
+    exists: remote(path) ? false : existsSync(path.startsWith("~") ? (process.env.HOME ?? "") + path.slice(1) : path),
+  })
+}

--- a/src/utils/terminal-image.ts
+++ b/src/utils/terminal-image.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs"
 
-export type PreviewKind = "native" | "chafa" | "chip"
-export type PreviewReason = "native-supported" | "chafa-supported" | "no-renderer" | "missing" | "unsupported" | "remote"
+export type PreviewKind = "chafa" | "chip"
+export type PreviewReason = "chafa-supported" | "no-renderer" | "missing" | "unsupported" | "remote"
 export type PreviewStrategy = { kind: PreviewKind; reason: PreviewReason }
 
 const IMAGE_EXT = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp"])
@@ -15,20 +15,14 @@ export function remote(path: string): boolean {
   return URL_RE.test(path)
 }
 
-export function safeNative(): boolean {
-  return false
-}
-
 export function previewStrategy(opts: {
   path: string
   exists: boolean
-  native: boolean
   chafa: boolean
 }): PreviewStrategy {
   if (remote(opts.path)) return { kind: "chip", reason: "remote" }
   if (!image(opts.path)) return { kind: "chip", reason: "unsupported" }
   if (!opts.exists) return { kind: "chip", reason: "missing" }
-  if (opts.native) return { kind: "native", reason: "native-supported" }
   if (opts.chafa) return { kind: "chafa", reason: "chafa-supported" }
   return { kind: "chip", reason: "no-renderer" }
 }
@@ -37,7 +31,6 @@ export function strategy(path: string, chafa: boolean): PreviewStrategy {
   return previewStrategy({
     path,
     chafa,
-    native: safeNative(),
     exists: remote(path) ? false : existsSync(path.startsWith("~") ? (process.env.HOME ?? "") + path.slice(1) : path),
   })
 }

--- a/test/attachments.test.tsx
+++ b/test/attachments.test.tsx
@@ -1,10 +1,18 @@
 import { describe, expect, test } from "bun:test"
 import { act } from "react"
+import { previewStrategy } from "../src/utils/terminal-image"
 import { mount, mountNode, until } from "./harness"
 import { Composer } from "../src/components/chat/Composer"
 import { LOCAL_COMMANDS } from "../src/app/slashCommands"
 
 describe("composer: image attachments (D4+D7)", () => {
+  test("composer images use the shared preview strategy", () => {
+    expect(previewStrategy({ path: "/tmp/clip_1.png", exists: true, native: false, chafa: true })).toEqual({
+      kind: "chafa",
+      reason: "chafa-supported",
+    })
+  })
+
   test("Ctrl+V → clipboard.paste → chip renders; clears on send", async () => {
     const t = await mount({
       handlers: {

--- a/test/attachments.test.tsx
+++ b/test/attachments.test.tsx
@@ -7,7 +7,7 @@ import { LOCAL_COMMANDS } from "../src/app/slashCommands"
 
 describe("composer: image attachments (D4+D7)", () => {
   test("composer images use the shared preview strategy", () => {
-    expect(previewStrategy({ path: "/tmp/clip_1.png", exists: true, native: false, chafa: true })).toEqual({
+    expect(previewStrategy({ path: "/tmp/clip_1.png", exists: true, chafa: true })).toEqual({
       kind: "chafa",
       reason: "chafa-supported",
     })

--- a/test/chafa.test.ts
+++ b/test/chafa.test.ts
@@ -1,7 +1,49 @@
 import { describe, expect, test } from "bun:test"
 import { parseChafaLine, parseChafa, hex } from "../src/utils/chafa"
+import { previewStrategy } from "../src/utils/terminal-image"
 
 const ESC = "\x1b"
+
+describe("image preview strategy", () => {
+  test("safe native capability wins before chafa", () => {
+    expect(previewStrategy({ path: "/tmp/a.png", exists: true, native: true, chafa: true })).toEqual({
+      kind: "native",
+      reason: "native-supported",
+    })
+  })
+
+  test("chafa wins when native preview is unavailable", () => {
+    expect(previewStrategy({ path: "/tmp/a.png", exists: true, native: false, chafa: true })).toEqual({
+      kind: "chafa",
+      reason: "chafa-supported",
+    })
+  })
+
+  test("chip is the final fallback without native or chafa", () => {
+    expect(previewStrategy({ path: "/tmp/a.png", exists: true, native: false, chafa: false })).toEqual({
+      kind: "chip",
+      reason: "no-renderer",
+    })
+  })
+
+  test("missing and unsupported images use chip", () => {
+    expect(previewStrategy({ path: "/tmp/missing.png", exists: false, native: true, chafa: true })).toEqual({
+      kind: "chip",
+      reason: "missing",
+    })
+    expect(previewStrategy({ path: "/tmp/not-image.txt", exists: true, native: true, chafa: true })).toEqual({
+      kind: "chip",
+      reason: "unsupported",
+    })
+  })
+
+  test("remote urls stay chips even when the extension looks image-like", () => {
+    expect(previewStrategy({ path: "https://x.test/a.png", exists: true, native: true, chafa: true })).toEqual({
+      kind: "chip",
+      reason: "remote",
+    })
+  })
+})
 
 describe("chafa parser", () => {
   test("empty line → no cells", () => {

--- a/test/chafa.test.ts
+++ b/test/chafa.test.ts
@@ -5,40 +5,33 @@ import { previewStrategy } from "../src/utils/terminal-image"
 const ESC = "\x1b"
 
 describe("image preview strategy", () => {
-  test("safe native capability wins before chafa", () => {
-    expect(previewStrategy({ path: "/tmp/a.png", exists: true, native: true, chafa: true })).toEqual({
-      kind: "native",
-      reason: "native-supported",
-    })
-  })
-
-  test("chafa wins when native preview is unavailable", () => {
-    expect(previewStrategy({ path: "/tmp/a.png", exists: true, native: false, chafa: true })).toEqual({
+  test("chafa wins when image exists and chafa is available", () => {
+    expect(previewStrategy({ path: "/tmp/a.png", exists: true, chafa: true })).toEqual({
       kind: "chafa",
       reason: "chafa-supported",
     })
   })
 
-  test("chip is the final fallback without native or chafa", () => {
-    expect(previewStrategy({ path: "/tmp/a.png", exists: true, native: false, chafa: false })).toEqual({
+  test("chip is the final fallback without chafa", () => {
+    expect(previewStrategy({ path: "/tmp/a.png", exists: true, chafa: false })).toEqual({
       kind: "chip",
       reason: "no-renderer",
     })
   })
 
   test("missing and unsupported images use chip", () => {
-    expect(previewStrategy({ path: "/tmp/missing.png", exists: false, native: true, chafa: true })).toEqual({
+    expect(previewStrategy({ path: "/tmp/missing.png", exists: false, chafa: true })).toEqual({
       kind: "chip",
       reason: "missing",
     })
-    expect(previewStrategy({ path: "/tmp/not-image.txt", exists: true, native: true, chafa: true })).toEqual({
+    expect(previewStrategy({ path: "/tmp/not-image.txt", exists: true, chafa: true })).toEqual({
       kind: "chip",
       reason: "unsupported",
     })
   })
 
   test("remote urls stay chips even when the extension looks image-like", () => {
-    expect(previewStrategy({ path: "https://x.test/a.png", exists: true, native: true, chafa: true })).toEqual({
+    expect(previewStrategy({ path: "https://x.test/a.png", exists: true, chafa: true })).toEqual({
       kind: "chip",
       reason: "remote",
     })

--- a/test/media.test.tsx
+++ b/test/media.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { act } from "react"
 import { mountNode, until } from "./harness"
 import { splitContent, classify, MEDIA_LINE_RE } from "../src/components/chat/MediaChip"
+import { previewStrategy } from "../src/utils/terminal-image"
 import { MessageItem } from "../src/components/chat/MessageItem"
 import type { Message } from "../src/types/message"
 
@@ -34,6 +35,14 @@ describe("MediaChip > splitContent", () => {
     expect(s).toEqual([
       { code: "MEDIA:/tmp/x.png", lang: "sh" },
       { media: "/tmp/y.png" },
+    ])
+  })
+
+  test("extracts remote markdown images as chip media", () => {
+    expect(splitContent("see ![alt](https://x.test/a.png) now")).toEqual([
+      { md: "see " },
+      { media: "https://x.test/a.png" },
+      { md: " now" },
     ])
   })
 
@@ -88,6 +97,13 @@ describe("MediaChip > classify", () => {
 })
 
 describe("MessageItem > media rendering", () => {
+  test("transcript images use the shared preview strategy", () => {
+    expect(previewStrategy({ path: "/tmp/screenshot.png", exists: true, native: false, chafa: false })).toEqual({
+      kind: "chip",
+      reason: "no-renderer",
+    })
+  })
+
   const msg = (content: string): Message => ({
     id: "a1", role: "assistant", timestamp: 0, model: "test",
     parts: [{ type: "text", content, streaming: false }],

--- a/test/media.test.tsx
+++ b/test/media.test.tsx
@@ -98,7 +98,7 @@ describe("MediaChip > classify", () => {
 
 describe("MessageItem > media rendering", () => {
   test("transcript images use the shared preview strategy", () => {
-    expect(previewStrategy({ path: "/tmp/screenshot.png", exists: true, native: false, chafa: false })).toEqual({
+    expect(previewStrategy({ path: "/tmp/screenshot.png", exists: true, chafa: false })).toEqual({
       kind: "chip",
       reason: "no-renderer",
     })


### PR DESCRIPTION
## What changed
- Adds a pure media preview strategy for choosing Chafa preview or chip fallback.
- Routes transcript and composer image previews through the shared strategy.
  ![Screenshot of actual Herm showing Chafa image render and chip fallback](https://files.catbox.moe/hj7q0o.png)
- Improves Chafa discovery by checking `PATH` before fixed host paths.
- Converts missing files, unsupported images, Chafa failures, and remote markdown images into chip fallback instead of red error chrome.
- Keeps non-image files on the chip path.

## Review notes
- Actual Herm runtime chooses Chafa when a local image file can be rendered and falls back to chips for missing, remote, unsupported, or no-renderer paths.
- Chafa-dependent tests remain host-gated and skip cleanly when `chafa` is unavailable.
- Native terminal image rendering is not included because OpenTUI does not provide a safe native image primitive for renderer-owned redraw, scrollback, and copy behavior.

## Verification
- `bun test test/chafa.test.ts test/chafa-image.test.tsx test/media.test.tsx test/attachments.test.tsx`
- `bun test`
- `bunx tsc --noEmit`

## Out of scope
- Native inline image rendering remains deferred until OpenTUI can safely own it.
