### PR TITLE
fix(chat): show copy feedback consistently

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,7 +15,7 @@ import { SessionsGroup } from "./tabs/SessionsGroup"
 import { Automation } from "./tabs/Automation"
 import { ConfigGroup } from "./tabs/ConfigGroup"
 import { EikonGroup } from "./tabs/EikonGroup"
-import { copySelection, copy as clipCopy } from "./utils/clipboard"
+import { copySelection, copyText as clipCopy } from "./utils/clipboard"
 import { ThemeProvider, useTheme } from "./theme"
 import { DialogProvider, useDialog } from "./ui/dialog"
 import { ToastProvider, useToast } from "./ui/toast"
@@ -549,8 +549,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const msgMenu = useCallback((m: Message) => {
     if (turnRef.current.streaming) return
-    openMessage(dialog, m, { rewind, fork })
-  }, [dialog, rewind, fork])
+    openMessage(dialog, m, { rewind, fork, toast })
+  }, [dialog, rewind, fork, toast])
   // Gateway owns the canonical list (session["attached_images"]); chips
   // are a client-side mirror. prompt.submit drains server-side, so clear
   // here too. No image.detach RPC yet — chips are display-only.
@@ -759,8 +759,9 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     onCopyLast: () => {
       const m = [...turnRef.current.messages].reverse()
         .find(x => x.role === "assistant" && msgText(x))
-      if (m) void clipCopy(msgText(m))
+      if (m) void clipCopy(msgText(m), toast)
     },
+    onCopyToast: toast.show,
     onAttachClipboard: attachClipboard,
     // Client-side drop only. Gateway's session["attached_images"] still
     // has the orphaned path until the next prompt.submit drains it, or
@@ -811,9 +812,9 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     const inner = (() => {
       switch (tab) {
         case CHAT_TAB: return <Chat messages={turn.messages} streaming={turn.streaming}
-                                    prompt={promptWire}
-                                    cloud={cloud} cloudH={cloudH} pick={pick}
-                                    onResize={setCloudH} onPick={onPick} onClose={closeCloud} onRewind={msgMenu} />
+                               prompt={promptWire}
+                               cloud={cloud} cloudH={cloudH} pick={pick}
+                               onResize={setCloudH} onPick={onPick} onClose={closeCloud} onRewind={msgMenu} />
         case SESSIONS_TAB: return <SessionsGroup focused={contentFocused}
                                                  sub={subTabs[SESSIONS_TAB] ?? 0}
                                                  setSub={sessSub}
@@ -845,7 +846,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   }
 
   const theme = themeCtx.theme
-  const onMouseUp = useCallback(() => copySelection(renderer), [renderer])
+  const onMouseUp = useCallback(() => copySelection(renderer, toast), [renderer, toast])
   // Composer defocuses while any prompt is pending. Approval/clarify
   // list-mode don't need input, and this guarantees the textarea's
   // `focused` prop flips false→true on answer so OpenTUI refocuses it

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -29,7 +29,7 @@ import { openHistory } from "../dialogs/history"
 import { openStatus, openUsage, openProfile } from "../dialogs/info"
 import { openChafa } from "../dialogs/chafa"
 import { SKINS, type SkinState } from "../context/skin"
-import { copy as clipCopy } from "../utils/clipboard"
+import { copyText as clipCopy } from "../utils/clipboard"
 import * as preferences from "../context/preferences"
 import { redraw } from "./useAppKeys"
 import { quit } from "./exit"
@@ -361,8 +361,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           const m = all[n - 1]
           if (!m) { toast.show({ variant: "info", message: "nothing to copy" }); return }
           const body = msgText(m)
-          void clipCopy(body)
-          toast.show({ variant: "success", message: `copied ${body.length} chars` })
+          void clipCopy(body, toast, `copied ${body.length} chars`)
           return
         }
         case "paste": x.attachClipboard(); return

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -23,6 +23,7 @@ import { print as chordPrint } from "../keys/chord"
 import { isDegradedMouseInput } from "./mouseFilter"
 import type { ComposerHandle } from "../components/chat/Composer"
 import { isVoiceToggleKey } from "../voice/platform"
+import type { ToastContext } from "../ui/toast"
 import type { VoiceKey } from "../voice/types"
 
 const INTERRUPT_MS = 5000
@@ -57,6 +58,7 @@ type Opts = {
   onQuit: () => void
   onQuitArm: (label: string) => void
   onCopyLast: () => void
+  onCopyToast: ToastContext["show"]
   onAttachClipboard: () => void
   /** Remove the last pending attachment (backspace on empty composer). */
   onDetachLast: () => boolean
@@ -112,7 +114,7 @@ export function useAppKeys(o: Opts) {
     // clears it (not the dialog, not the interrupt counter), Ctrl+C
     // copies it (not input.clear/app.exit), any other key clears it
     // unless the selection belongs to the focused textarea.
-    if (Selection.key(renderer, key)) { key.stopPropagation(); return }
+    if (Selection.key(renderer, key, { show: o.onCopyToast, clear: () => {}, error: () => {} })) { key.stopPropagation(); return }
 
     // oc parity: input_clear (ctrl+c) with non-empty buffer clears and
     // consumes; app_exit (also ctrl+c) fires on the next press. A draft

--- a/src/dialogs/message.tsx
+++ b/src/dialogs/message.tsx
@@ -5,12 +5,14 @@
 
 import { DialogSelect } from "../ui/dialog-select"
 import type { DialogContext } from "../ui/dialog"
+import type { ToastContext } from "../ui/toast"
 import type { Message } from "../types/message"
-import { copy } from "../utils/clipboard"
+import { copyText } from "../utils/clipboard"
 
 export type MessageOps = {
   rewind: (m: Message) => void
   fork: (m: Message) => void
+  toast?: ToastContext
 }
 
 export function openMessage(dialog: DialogContext, m: Message, ops: MessageOps) {
@@ -29,7 +31,7 @@ export function openMessage(dialog: DialogContext, m: Message, ops: MessageOps) 
       ]}
       onSelect={(o) => {
         dialog.clear()
-        if (o.value === "copy") return void copy(text)
+        if (o.value === "copy") return void copyText(text, ops.toast)
         if (o.value === "rewind") return ops.rewind(m)
         if (o.value === "fork") return ops.fork(m)
       }}

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,4 +1,5 @@
 import { platform } from "os"
+import type { ToastContext } from "../ui/toast"
 
 // Terminals known to correctly implement OSC 52 clipboard writes. On these,
 // firing a native tool (wl-copy/xclip/pbcopy) alongside OSC 52 races the
@@ -115,12 +116,22 @@ export async function copy(text: string): Promise<void> {
   }
 }
 
-export function copySelection(renderer: { getSelection: () => { getSelectedText: () => string } | null; clearSelection: () => void }): boolean {
+export function copied(toast: ToastContext, message = "Copied to clipboard"): void {
+  toast.show({ key: "clipboard.copy", variant: "success", message })
+}
+
+export function copyText(text: string, toast?: ToastContext, message = "Copied to clipboard"): Promise<void> {
+  const p = copy(text)
+  if (toast) copied(toast, message)
+  return p
+}
+
+export function copySelection(renderer: { getSelection: () => { getSelectedText: () => string } | null; clearSelection: () => void }, toast?: ToastContext): boolean {
   const sel = renderer.getSelection()
   const text = sel?.getSelectedText()
   if (!text) return false
 
-  copy(text).catch(() => {})
+  copyText(text, toast).catch(() => {})
   renderer.clearSelection()
   return true
 }

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -1,7 +1,8 @@
 import type { ParsedKey, Renderable } from "@opentui/core"
-import { copy } from "./clipboard"
+import { copyText } from "./clipboard"
+import type { ToastContext } from "../ui/toast"
 
-type Toast = { push: (msg: string, kind?: "info" | "ok" | "warn" | "err") => void }
+type Toast = ToastContext
 
 type Renderer = {
   getSelection: () => { getSelectedText: () => string; selectedRenderables: Renderable[] } | null
@@ -12,9 +13,8 @@ type Renderer = {
 export function yank(renderer: Renderer, toast?: Toast): boolean {
   const text = renderer.getSelection()?.getSelectedText()
   if (!text) return false
-  void copy(text)
-    .then(() => toast?.push("Copied to clipboard", "info"))
-    .catch(() => toast?.push("Clipboard write failed", "err"))
+  void copyText(text, toast)
+    .catch(() => toast?.show({ variant: "error", message: "Clipboard write failed" }))
   renderer.clearSelection()
   return true
 }

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -292,6 +292,24 @@ describe("app", () => {
     t.destroy()
   })
 
+  test("copy-last shows toast", async () => {
+    const t = await mount({ width: 130, height: 18 })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("user one") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+    act(() => {
+      t.gw.push({ type: "message.start" })
+      t.gw.push({ type: "message.complete", payload: { text: "agent one", usage: { input: 1, output: 1, total: 2 } } })
+    })
+    await until(t, () => t.frame().includes("agent one"))
+
+    act(() => { t.keys.pressKey("x", { ctrl: true }); t.keys.pressKey("y") })
+    await until(t, () => t.frame().includes("Copied to clipboard"))
+    t.destroy()
+  })
+
 
   test("marketplace detail preview does not change active sidebar preference", async () => {
     const HH = process.env.HERMES_HOME!

--- a/test/selection.test.ts
+++ b/test/selection.test.ts
@@ -8,6 +8,7 @@ const key = (name: string, ctrl = false): ParsedKey =>
 
 function stub(text: string, focused?: Renderable, inSel: Renderable[] = []) {
   let cleared = false
+  let toasts = 0
   return {
     renderer: {
       getSelection: () => text
@@ -16,7 +17,13 @@ function stub(text: string, focused?: Renderable, inSel: Renderable[] = []) {
       clearSelection: () => { cleared = true },
       currentFocusedRenderable: focused ?? null,
     },
+    toast: {
+      show: () => { toasts++ },
+      clear: () => {},
+      error: () => {},
+    },
     cleared: () => cleared,
+    toasts: () => toasts,
   }
 }
 
@@ -35,8 +42,9 @@ describe("Selection.key", () => {
 
   test("Ctrl+C with selection → yanks + consumes", () => {
     const s = stub("highlighted text")
-    expect(Selection.key(s.renderer, key("c", true))).toBe(true)
+    expect(Selection.key(s.renderer, key("c", true), s.toast)).toBe(true)
     expect(s.cleared()).toBe(true)
+    expect(s.toasts()).toBe(1)
   })
 
   test("other key clears unless selection is inside focused renderable", () => {


### PR DESCRIPTION
## What changed
- Centralizes copied-to-clipboard success toasts across selection copy, copy-last-reply, `/copy`, and message action copy.
- Passes toast context into the message action dialog so message-copy actions get the same feedback as other copy paths.

## Verification
- `bun test test/app.test.tsx test/selection.test.ts test/messagelist.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
