### PR TITLE
feat: move composer attachments into status tray

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,7 +9,7 @@ import { text as msgText } from "./types/message"
 import { CLOUD_MIN } from "./components/chat/ThoughtCloud"
 import type { AvatarState } from "./components/avatar/states"
 import { TabBar } from "./components/tabs/TabBar"
-import { Sidebar } from "./components/sidebar/Sidebar"
+import { Sidebar, hidden as hiddenSidebar } from "./components/sidebar/Sidebar"
 import { Chat } from "./tabs/Chat"
 import { SessionsGroup } from "./tabs/SessionsGroup"
 import { Automation } from "./tabs/Automation"
@@ -55,6 +55,7 @@ import { BackgroundProvider } from "./app/background"
 import { useVoice } from "./voice/useVoice"
 import { VoiceIndicator } from "./voice/Indicator"
 import { sessionCapabilities } from "./app/sessionCapabilities"
+import { useGitBranch } from "./utils/git"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch; keyOverrides?: Record<string, string> }
 
@@ -852,6 +853,10 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // Keys still reach the card via onPromptKey on the global bus.
   const inputFocused = focusRegion === "input" && !prompt
   const sidebarVisible = dims.width >= (tab === CHAT_TAB ? 120 : 140) && !hideSidebar
+  const branch = useGitBranch(info?.cwd)
+  const hidden = !sidebarVisible ? hiddenSidebar({
+    info, usage, profile: activeProfileName(), title: caption, branch,
+  }) : undefined
 
   return (
     <Profiler id="shell" onRender={perf.onRender}>
@@ -880,6 +885,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming}
                 status={status}
                 model={info?.model}
+                hidden={hidden}
                 escHint={escHint}
                 queue={queue}
                 attachments={attachments}

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -364,11 +364,13 @@ export function useAppKeys(o: Opts) {
         const ok = c?.historyDown()
         return void (ok && c?.value() !== before && key.stopPropagation())
       }
-      // Backspace on an empty buffer with attachments → detach the last.
-      // Swallow before the textarea sees it so a subsequent backspace on
-      // a still-empty buffer keeps peeling attachments off, not chars.
+      // Backspace at a line start with attachments peels the last
+      // attachment. This lets the user detach while drafting without
+      // clearing the whole buffer first; mid-line backspace still edits
+      // text through the textarea.
       if (key.name === "backspace" && !key.ctrl && !key.meta
-          && c?.isEmpty() && o.onDetachLast()) {
+          && c && (c.isEmpty() || c.caret() === 0 || c.value()[c.caret() - 1] === "\n")
+          && o.onDetachLast()) {
         key.stopPropagation()
         return
       }

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -231,8 +231,9 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   //     hits append to session["attached_images"] server-side; herm mirrors
   //     the chip and inserts only the trailing remainder text, not the
   //     `[User attached image: …]` placeholder (that's for blind clients).
-  //     Non-image hits (pdf/txt/…) insert the `[User attached file: …]`
-  //     wrapper so the agent sees the path. Any miss falls through.
+  //     Non-image hits (pdf/txt/…) mirror as chips and insert the
+  //     `[User attached file: …]` wrapper so the agent sees the path.
+  //     Any miss falls through.
   //  2. ≥5 lines → gateway writes a temp file and hands back a
   //     `[Pasted #N …]` placeholder (hermes CLI convention; expanded
   //     server-side in prompt.submit).
@@ -260,6 +261,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
             if (!r.text.startsWith("[User attached")) ta.current?.insertText(r.text + " ")
             return
           }
+          live.current.props.onAttach?.({ attached: true, path: r.path, name: r.name })
           ta.current?.insertText(r.text + " ")
         })
         .catch(verbatim)

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -22,6 +22,9 @@ import { SlashPopover } from "./SlashPopover"
 import { AtRefPopover } from "./AtRefPopover"
 import { ChafaImage } from "../../ui/ChafaImage"
 import { trunc } from "../../ui/fmt"
+import { prefs } from "../../context/preferences"
+import { MediaChip, classify } from "./MediaChip"
+import type { HiddenContext } from "../sidebar/Sidebar"
 
 export type ComposerHandle = {
   value: () => string
@@ -59,6 +62,7 @@ type Props = {
   escHint?: boolean
   queue?: ReadonlyArray<string>
   attachments?: ReadonlyArray<ImageAttachResponse>
+  hidden?: HiddenContext
   cmds: ReadonlyArray<SlashCommand>
   onSend: (text: string, parts?: readonly Part[]) => void
   onSlash: (cmd: SlashCommand) => void
@@ -77,6 +81,8 @@ type Props = {
 }
 
 const MAX_ROWS = 6
+const MAX_PREVIEWS = 2
+const FRAMES = ["▰▱▱▰", "▱▰▰▱", "▱▰▰▱", "▰▱▱▰"]
 
 function fmt(n: number): string {
   if (n < 1000) return String(n)
@@ -102,6 +108,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   // history are disabled in shell mode.
   const [mode, setMode] = useState<"normal" | "shell">("normal")
   const modeRef = useRef(mode); modeRef.current = mode
+  const [frame, setFrame] = useState(0)
 
   // Slash and @-ref popovers are cursor-relative over the current buffer.
   // Slash command execution stays whole-buffer only; mixed prose accepts
@@ -152,6 +159,12 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     wasDirty.current = dirty
     live.current.props.onDirty?.(dirty)
   }, [input])
+
+  useEffect(() => {
+    if (!props.streaming || prefs.get("animations") === false) return
+    const id = setInterval(() => setFrame(n => (n + 1) % FRAMES.length), 160)
+    return () => clearInterval(id)
+  }, [props.streaming])
 
   // Selecting a popover entry: subcommand synthetics (name contains a
   // space) complete the input for further typing; real commands dispatch.
@@ -394,12 +407,24 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   // Logical-line row count (wrap-induced growth ignored; yoga sizes the
   // textarea, this only positions the absolute popover above the border).
   const rows = Math.min(MAX_ROWS, Math.max(1, input.split("\n").length))
-  const lift = rows + 3
+  const all = props.attachments ?? []
+  const previews = all.filter(a => a.path && classify(a.path) === "img").slice(0, MAX_PREVIEWS)
+  const chips = all.filter(a => !previews.includes(a)).slice(0, MAX_PREVIEWS)
+  const shown = new Set([...previews, ...chips])
+  const attRows = all.length > 0 ? (previews.length > 0 ? 2 : 1) : 0
+  const lift = rows + attRows + 3
+  const more = all.filter(a => !shown.has(a)).length
+  const bits = [
+    props.hidden?.profile,
+    props.hidden?.title,
+    props.hidden?.place,
+    props.hidden?.context,
+  ].filter(Boolean)
 
   return (
     <box flexDirection="column" position="relative">
       {props.focused && pop.open ? (
-        <box position="absolute" bottom={lift} left={0} right={0}>
+        <box position="absolute" bottom={lift} left={0} right={0} zIndex={2}>
           <SlashPopover
             commands={pop.popover!}
             cursor={pop.cursor}
@@ -408,7 +433,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
           />
         </box>
       ) : props.focused && at.open ? (
-        <box position="absolute" bottom={lift} left={0} right={0}>
+        <box position="absolute" bottom={lift} left={0} right={0} zIndex={2}>
           <AtRefPopover
             items={at.items}
             cursor={at.cursor}
@@ -417,7 +442,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
           />
         </box>
       ) : props.focused && comp.open ? (
-        <box position="absolute" bottom={lift} left={0} right={0}>
+        <box position="absolute" bottom={lift} left={0} right={0} zIndex={2}>
           <AtRefPopover
             items={comp.items}
             cursor={comp.cursor}
@@ -443,77 +468,79 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         </box>
       ) : null}
 
-      {(props.attachments?.length ?? 0) > 0 ? (
-        <box flexDirection="column" paddingX={1} paddingBottom={1} gap={1}>
-          {props.attachments!.map(a => a.path
-            ? <ChafaImage key={`p-${a.path}`} path={a.path} width={60} />
-            : null)}
-        </box>
-      ) : null}
-
-      {(props.attachments?.length ?? 0) > 0 ? (
-        <box flexDirection="row" flexWrap="wrap" gap={1} paddingX={1} paddingBottom={1}>
-          {props.attachments!.map((a, i) => (
-            <text key={a.path ?? i}>
-              <span bg={theme.accent} fg={theme.background}> img </span>
-              <span bg={theme.backgroundElement} fg={theme.textMuted}> {a.name ?? `image ${i + 1}`} </span>
-              {a.width && a.height
-                ? <span bg={theme.backgroundElement} fg={theme.textMuted}>{a.width}×{a.height} </span>
-                : null}
-              {a.token_estimate
-                ? <span bg={theme.backgroundElement} fg={theme.textMuted}>~{fmt(a.token_estimate)}t </span>
-                : null}
-              <span fg={theme.textMuted}>  </span>
-              <span fg={theme.textMuted}>⌫ to detach</span>
-            </text>
-          ))}
-        </box>
-      ) : null}
-
       <box
         border
         borderStyle="single"
         borderColor={mode === "shell" ? theme.primary
           : props.focused ? theme.borderActive : theme.border}
-        flexDirection="row"
+        flexDirection="column"
         position="relative"
       >
-        <box width={1}><text fg={theme.primary}>{mode === "shell" ? "$" : ">"}</text></box>
-        <box width={1} />
-        <textarea
-          ref={taRef}
-          syntaxStyle={syntaxStyle}
-          onContentChange={() => {
-            const t = ta.current
-            setInput(t?.plainText ?? "")
-            setCaret(t?.cursorOffset ?? 0)
-          }}
-          onCursorChange={() => {
-            // Only worth a re-render when @-completion might retarget;
-            // otherwise ←/→ in a long prompt would reconcile Composer
-            // on every keystroke for no observable effect.
-            if (!live.current.input.includes("@") && !live.current.input.includes("/")) return
-            const off = ta.current?.cursorOffset ?? 0
-            setCaret(c => c === off ? c : off)
-          }}
-          onSubmit={submit}
-          onPaste={paste}
-          keyBindings={bindings}
-          wrapMode="word"
-          minHeight={1}
-          maxHeight={MAX_ROWS}
-          placeholder={mode === "shell" ? "Run a shell command (30s cap, cwd) — esc or ⌫ to exit" : props.streaming ? "Type to queue... (Enter queues, click chip to edit)" : "Message Hermes... (/ for commands, Shift+Enter for newline)"}
-          focused={props.focused}
-          textColor={theme.text}
-          focusedTextColor={theme.text}
-          placeholderColor={theme.textMuted}
-          cursorColor={theme.text}
-          backgroundColor="transparent"
-          focusedBackgroundColor="transparent"
-          flexGrow={1}
-        />
+        {previews.length > 0 ? (
+          <box flexDirection="column" paddingX={1} maxHeight={MAX_PREVIEWS} overflow="hidden">
+            {previews.map(a => <ChafaImage key={`p-${a.path}`} path={a.path!} width={60} bare />)}
+          </box>
+        ) : null}
+        {chips.length > 0 ? (
+          <box flexDirection="row" flexWrap="wrap" gap={1} paddingX={1} paddingTop={previews.length > 0 ? 0 : 1} paddingBottom={1}>
+            {chips.map((a, i) => {
+              if (a.path) {
+                const kind = classify(a.path)
+                return (
+                  <box key={a.path} flexDirection="row" height={1}>
+                    <MediaChip path={a.path} bare={kind === "img"} />
+                    {kind !== "img" && a.token_estimate ? <text fg={theme.textMuted}> ~{fmt(a.token_estimate)}t</text> : null}
+                  </box>
+                )
+              }
+              return (
+                <text key={a.name ?? i}>
+                  <span bg={theme.secondary} fg={theme.background}> file </span>
+                  <span bg={theme.backgroundElement} fg={theme.textMuted}> {a.name ?? `file ${i + 1}`} </span>
+                </text>
+              )
+            })}
+            {more > 0 ? <text fg={theme.textMuted}>+{more}</text> : null}
+          </box>
+        ) : null}
+        <box flexDirection="row">
+          <box width={1}><text fg={theme.primary}>{mode === "shell" ? "$" : ">"}</text></box>
+          <box width={1} />
+          <textarea
+            ref={taRef}
+            syntaxStyle={syntaxStyle}
+            onContentChange={() => {
+              const t = ta.current
+              setInput(t?.plainText ?? "")
+              setCaret(t?.cursorOffset ?? 0)
+            }}
+            onCursorChange={() => {
+              // Only worth a re-render when @-completion might retarget;
+              // otherwise ←/→ in a long prompt would reconcile Composer
+              // on every keystroke for no observable effect.
+              if (!live.current.input.includes("@") && !live.current.input.includes("/")) return
+              const off = ta.current?.cursorOffset ?? 0
+              setCaret(c => c === off ? c : off)
+            }}
+            onSubmit={submit}
+            onPaste={paste}
+            keyBindings={bindings}
+            wrapMode="word"
+            minHeight={1}
+            maxHeight={MAX_ROWS}
+            placeholder={mode === "shell" ? "Run a shell command (30s cap, cwd) — esc or ⌫ to exit" : props.streaming ? "Type to queue... (Enter queues, click chip to edit)" : "Message Hermes... (/ for commands, Shift+Enter for newline)"}
+            focused={props.focused}
+            textColor={theme.text}
+            focusedTextColor={theme.text}
+            placeholderColor={theme.textMuted}
+            cursorColor={theme.text}
+            backgroundColor="transparent"
+            focusedBackgroundColor="transparent"
+            flexGrow={1}
+          />
+        </box>
         {pop.ghost && props.focused && rows === 1 && pop.spot?.whole ? (
-          <box position="absolute" top={0} left={2 + input.length} height={1}>
+          <box position="absolute" top={attRows} left={2 + input.length} height={1}>
             <text fg={theme.textMuted}>{pop.ghost}</text>
           </box>
         ) : null}
@@ -522,6 +549,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       <box height={1} flexDirection="row" paddingX={1}>
         <text>
           <span fg={dot}>● </span>
+          {props.streaming ? <span fg={theme.primary}>{prefs.get("animations") === false ? "▰▱▱▰ " : `${FRAMES[frame]} `}</span> : null}
           <span fg={theme.textMuted}>{mode === "shell" ? "Shell" : label}</span>
           {mode === "shell"
             ? <span fg={theme.textMuted}>  esc exit shell mode</span>
@@ -536,6 +564,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
           <text fg={theme.textMuted}>{keys.print("queue.flush")} to send queued now  </text>
         ) : null}
         {bg.count > 0 ? <text fg={theme.text}>▶ {bg.count}  </text> : null}
+        {bits.length > 0 ? <text fg={theme.textMuted}>{trunc(bits.join(" · "), 56)}  </text> : null}
         {props.model ? <text fg={theme.textMuted}>{props.model}</text> : null}
       </box>
     </box>

--- a/src/components/chat/MediaChip.tsx
+++ b/src/components/chat/MediaChip.tsx
@@ -97,6 +97,7 @@ export function splitContent(text: string): Seg[] {
 
 export const MediaChip = memo((props: {
   path: string
+  bare?: boolean
   /** Override the default open-file click. Handlers stopPropagation so
    *  the enclosing message's useClick (→ actions menu) never sees the
    *  down event. Pass to repurpose the chip (e.g. ChafaImage collapse). */
@@ -111,6 +112,21 @@ export const MediaChip = memo((props: {
   }[kind]
   const click = props.onMouseDown
     ?? ((e: MouseEvent) => { e.stopPropagation(); openFile(props.path) })
+  if (props.bare) return (
+    <box
+      flexDirection="row" height={1}
+      onMouseDown={click}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+    >
+      <text>
+        <span fg={theme.text}
+              attributes={hover ? TextAttributes.UNDERLINE : TextAttributes.NONE}>
+          {basename(props.path)}
+        </span>
+      </text>
+    </box>
+  )
   return (
     <box
       flexDirection="row" height={1}

--- a/src/components/chat/MediaChip.tsx
+++ b/src/components/chat/MediaChip.tsx
@@ -28,7 +28,7 @@ export function classify(path: string): MediaKind {
   return "file"
 }
 
-const basename = (p: string) => p.split(/[/\\]/).pop() || p
+export const basename = (p: string) => p.split(/[/\\]/).pop() || p
 
 export type Seg = { md: string } | { media: string } | { code: string; lang?: string }
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -9,6 +9,14 @@ import { useGitBranch, rtrunc } from "../../utils/git"
 import { Tail } from "../chat/ThoughtCloud"
 import { ContextGauge } from "./ContextGauge"
 
+export type HiddenContext = {
+  profile?: string
+  model?: string
+  title?: string
+  place?: string
+  context?: string
+}
+
 // The pillar body carries a compact identity block, the MCP operational
 // section, and a context-usage gauge at the bottom. Stats/Memory/Recent/
 // Identity wrapper and the Plugins section were removed — they duplicated
@@ -20,6 +28,23 @@ const PAD_L = 12
 const INNER = WIDTH - 4
 
 const trunc = (s: string, max: number) => s.length <= max ? s : s.slice(0, max - 1) + "…"
+
+export function hidden(props: {
+  info?: SessionInfo | null
+  usage?: Usage
+  profile?: string
+  title?: string
+  branch?: string | null
+}): HiddenContext {
+  const cwd = props.info?.cwd?.split(/[/\\]/).filter(Boolean).pop()
+  return {
+    profile: props.profile,
+    model: props.info?.model,
+    title: props.title,
+    place: props.branch ?? cwd,
+    context: typeof props.usage?.context_percent === "number" ? `${props.usage.context_percent}%` : undefined,
+  }
+}
 
 const Section = memo((props: {
   title: string; hint?: string

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -223,10 +223,9 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       const kind = ev.payload?.kind
       const text = ev.payload?.text ?? ""
       side.onStatus?.(text)
-      // Generic "status" and compression lifecycle lines are cosmetic;
-      // error/warn and non-compression lifecycle lines carry real signal
-      // (retries, fallbacks, auth failures) and still persist.
-      if (!kind || kind === "status" || (kind === "lifecycle" && /compression/i.test(text))) return null
+      // Generic "status" is cosmetic; lifecycle/error/warn carry real
+      // signal (retries, fallbacks, auth failures) and must persist.
+      if (!kind || kind === "status") return null
       // process: route through debounced accumulator instead of dispatching
       // directly — prevents TUI lag when many terminal(background=true)
       // processes finish in rapid succession.

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -223,9 +223,10 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       const kind = ev.payload?.kind
       const text = ev.payload?.text ?? ""
       side.onStatus?.(text)
-      // Generic "status" is cosmetic; lifecycle/error/warn carry real
-      // signal (retries, fallbacks, auth failures) and must persist.
-      if (!kind || kind === "status") return null
+      // Generic "status" and compression lifecycle lines are cosmetic;
+      // error/warn and non-compression lifecycle lines carry real signal
+      // (retries, fallbacks, auth failures) and still persist.
+      if (!kind || kind === "status" || (kind === "lifecycle" && /compression/i.test(text))) return null
       // process: route through debounced accumulator instead of dispatching
       // directly — prevents TUI lag when many terminal(background=true)
       // processes finish in rapid succession.

--- a/src/ui/ChafaImage.tsx
+++ b/src/ui/ChafaImage.tsx
@@ -13,9 +13,9 @@ import { MediaChip } from "../components/chat/MediaChip"
 
 const basename = (p: string) => p.split(/[/\\]/).pop() || p
 
-type Props = { path: string; width?: number }
+type Props = { path: string; width?: number; bare?: boolean }
 
-export const ChafaImage = memo(({ path, width }: Props) => {
+export const ChafaImage = memo(({ path, width, bare }: Props) => {
   const theme = useTheme().theme
   const [collapsed, setCollapsed] = useState(false)
   const w = Math.max(20, Math.min(80, width ?? 60))
@@ -26,7 +26,7 @@ export const ChafaImage = memo(({ path, width }: Props) => {
   )
 
   // chafa missing or render failed → stream the MediaChip, no chrome
-  if (!hasChafa || "err" in result) return <MediaChip path={path} />
+  if (!hasChafa || "err" in result) return <MediaChip path={path} bare={bare} />
 
   // Collapsed → chip re-expands on click. Override MediaChip's default
   // openFile so the click does exactly one thing; stopPropagation keeps
@@ -34,14 +34,15 @@ export const ChafaImage = memo(({ path, width }: Props) => {
   if (collapsed) {
     return (
       <MediaChip path={path}
+        bare={bare}
         onMouseDown={(e: MouseEvent) => { e.stopPropagation(); setCollapsed(false) }} />
     )
   }
 
   return (
-    <box flexDirection="column" marginTop={1}>
+    <box flexDirection="column" marginTop={bare ? 0 : 1}>
       <box flexDirection="column"
-           onMouseDown={(e: MouseEvent) => { e.stopPropagation(); setCollapsed(true) }}>
+           onMouseDown={(e: MouseEvent) => { e.stopPropagation(); if (!bare) setCollapsed(true) }}>
         {result.rows.map((row, i) => (
           <text key={i}>
             {row.map((c, j) => (
@@ -50,7 +51,7 @@ export const ChafaImage = memo(({ path, width }: Props) => {
           </text>
         ))}
       </box>
-      <box height={1}
+      {bare ? null : <box height={1}
            onMouseDown={(e: MouseEvent) => { e.stopPropagation(); openFile(path) }}>
         <text>
           <span fg={theme.textMuted}>{"  "}</span>
@@ -58,7 +59,7 @@ export const ChafaImage = memo(({ path, width }: Props) => {
           <span fg={theme.text}>{basename(path)}</span>
           <span fg={theme.textMuted}>{"  click image to collapse · click name to open"}</span>
         </text>
-      </box>
+      </box>}
     </box>
   )
 })

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1204,7 +1204,7 @@ describe("app", () => {
     t.destroy()
   })
 
-  test("streaming status tray shows compression below composer", async () => {
+  test("compression lifecycle stays in the transcript while streaming", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
     act(() => {
@@ -1213,11 +1213,6 @@ describe("app", () => {
     })
     await until(t, () => t.frame().includes("Preflight compression"))
 
-    const rows = t.frame().split("\n")
-    const top = rows.findIndex(l => l.startsWith("┌"))
-    const bot = rows.findIndex((l, i) => i > top && l.startsWith("└"))
-    const status = rows.findIndex(l => l.includes("Preflight compression"))
-    expect(status).toBeGreaterThan(bot)
     expect(t.frame()).toContain("▰▱▱▰")
 
     act(() => t.gw.push({ type: "message.complete", payload: { text: "done", usage: { input: 1, output: 1, total: 2 } } }))
@@ -1225,7 +1220,7 @@ describe("app", () => {
     const done = t.frame().split("\n")
     const line = done.find(l => l.includes("Ready")) ?? ""
     expect(line).not.toContain("Preflight compression")
-    expect(t.frame()).not.toContain("Preflight compression")
+    expect(t.frame()).toContain("Preflight compression")
     t.destroy()
   })
 
@@ -1243,8 +1238,15 @@ describe("app", () => {
     expect(t.frame()).not.toContain("p:default")
 
     t.resize(100, 48)
-    await until(t, () => t.frame().includes("p:default") && t.frame().includes("m:wide-model"))
-    expect(t.frame()).toContain("b:herm-work")
+    await until(t, () => {
+      const f = t.frame()
+      return f.includes("default") && f.includes("wide-model") && f.includes("herm-work")
+        && !/Profile\s+default/.test(f)
+    })
+    expect(t.frame()).not.toContain("p:default")
+    expect(t.frame()).not.toContain("m:wide-model")
+    expect(t.frame()).not.toContain("b:herm-work")
+    expect(t.frame()).not.toContain("ctx:")
     expect(t.frame()).not.toMatch(/Profile\s+default/)
     t.destroy()
   })

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1225,6 +1225,7 @@ describe("app", () => {
     const done = t.frame().split("\n")
     const line = done.find(l => l.includes("Ready")) ?? ""
     expect(line).not.toContain("Preflight compression")
+    expect(t.frame()).not.toContain("Preflight compression")
     t.destroy()
   })
 

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1204,6 +1204,50 @@ describe("app", () => {
     t.destroy()
   })
 
+  test("streaming status tray shows compression below composer", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+    act(() => {
+      t.gw.push({ type: "message.start" })
+      t.gw.push({ type: "status.update", payload: { kind: "lifecycle", text: "📦 Preflight compression: ~230,802 tokens >= 217,600 threshold. This may take a moment." } })
+    })
+    await until(t, () => t.frame().includes("Preflight compression"))
+
+    const rows = t.frame().split("\n")
+    const top = rows.findIndex(l => l.startsWith("┌"))
+    const bot = rows.findIndex((l, i) => i > top && l.startsWith("└"))
+    const status = rows.findIndex(l => l.includes("Preflight compression"))
+    expect(status).toBeGreaterThan(bot)
+    expect(t.frame()).toContain("▰▱▱▰")
+
+    act(() => t.gw.push({ type: "message.complete", payload: { text: "done", usage: { input: 1, output: 1, total: 2 } } }))
+    await until(t, () => t.frame().includes("Ready"))
+    const done = t.frame().split("\n")
+    const line = done.find(l => l.includes("Ready")) ?? ""
+    expect(line).not.toContain("Preflight compression")
+    t.destroy()
+  })
+
+  test("hidden sidebar context moves to composer tray only when sidebar is hidden", async () => {
+    const gw = new MockGateway()
+    const t = await mount({ gw, width: 160, height: 48 })
+    act(() => gw.push({
+      type: "session.info",
+      payload: {
+        model: "wide-model", session_id: "test-sid", cwd: "/tmp/herm-work", tools: {}, skills: {},
+      },
+    }))
+    await until(t, () => t.frame().includes("wide-model"))
+    expect(t.frame()).toMatch(/Profile\s+default/)
+    expect(t.frame()).not.toContain("p:default")
+
+    t.resize(100, 48)
+    await until(t, () => t.frame().includes("p:default") && t.frame().includes("m:wide-model"))
+    expect(t.frame()).toContain("b:herm-work")
+    expect(t.frame()).not.toMatch(/Profile\s+default/)
+    t.destroy()
+  })
+
   test("preflight compression stderr does not end the active turn", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))

--- a/test/attachments.test.tsx
+++ b/test/attachments.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { act } from "react"
-import { mount, until } from "./harness"
+import { mount, mountNode, until } from "./harness"
+import { Composer } from "../src/components/chat/Composer"
+import { LOCAL_COMMANDS } from "../src/app/slashCommands"
 
 describe("composer: image attachments (D4+D7)", () => {
   test("Ctrl+V → clipboard.paste → chip renders; clears on send", async () => {
@@ -175,6 +177,71 @@ describe("composer: image attachments (D4+D7)", () => {
     act(() => t.keys.pressEnter())
     await t.settle()
     expect(t.gw.last("prompt.submit")).toBeUndefined()
+    t.destroy()
+  })
+
+  test("attachments render inside the composer border", async () => {
+    const t = await mount({
+      handlers: {
+        "clipboard.paste": () => ({
+          attached: true, path: "/tmp/inside.png", name: "inside.png",
+          count: 1, width: 640, height: 480,
+        }),
+      },
+    })
+    await until(t, () => t.frame().includes("Ready"))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
+    await until(t, () => t.frame().includes("inside.png"))
+
+    const rows = t.frame().split("\n")
+    const top = rows.findIndex(l => l.startsWith("┌"))
+    const img = rows.findIndex(l => l.includes("inside.png"))
+    const bot = rows.findIndex((l, i) => i > top && l.startsWith("└"))
+    expect(top).toBeGreaterThan(-1)
+    expect(img).toBeGreaterThan(top)
+    expect(img).toBeLessThan(bot)
+    t.destroy()
+  })
+
+  test("path-backed non-image attachment renders only a file chip", async () => {
+    const t = await mountNode(
+      <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+        <box flexGrow={1} />
+        <Composer
+          focused canSubmitPrompt={true} ready streaming={false} cmds={LOCAL_COMMANDS}
+          attachments={[{ attached: true, path: "/tmp/report.pdf", name: "report.pdf", count: 1 }]}
+          onSend={() => {}} onSlash={() => {}}
+        />
+      </box>,
+      { width: 120, height: 30 },
+    )
+    await until(t, () => t.frame().includes("report.pdf"))
+
+    expect(t.frame()).toContain(" file ")
+    expect(t.frame()).not.toContain(" img ")
+    t.destroy()
+  })
+
+  test("attachment overflow counts only attachments hidden from previews and chips", async () => {
+    const t = await mountNode(
+      <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+        <box flexGrow={1} />
+        <Composer
+          focused canSubmitPrompt={true} ready streaming={false} cmds={LOCAL_COMMANDS}
+          attachments={[
+            { attached: true, path: "/tmp/one.pdf", name: "one.pdf", count: 1 },
+            { attached: true, path: "/tmp/two.txt", name: "two.txt", count: 2 },
+            { attached: true, path: "/tmp/three.png", name: "three.png", count: 3 },
+          ]}
+          onSend={() => {}} onSlash={() => {}}
+        />
+      </box>,
+      { width: 120, height: 30 },
+    )
+    await until(t, () => t.frame().includes("one.pdf") && t.frame().includes("two.txt"))
+
+    expect(t.frame()).toContain("three.png")
+    expect(t.frame()).not.toContain("+1")
     t.destroy()
   })
 })

--- a/test/attachments.test.tsx
+++ b/test/attachments.test.tsx
@@ -21,9 +21,10 @@ describe("composer: image attachments (D4+D7)", () => {
     await until(t, () => t.frame().includes("clip_1.png"))
 
     const f = t.frame()
-    expect(f).toContain(" img ")
-    expect(f).toContain("800×600")
-    expect(f).toContain("~1.1kt")
+    expect(f).not.toContain(" img ")
+    expect(f).not.toContain("800×600")
+    expect(f).not.toContain("~1.1kt")
+    expect(f).not.toContain("⌫ to detach")
     // stopPropagation: <input> didn't receive the literal "v"
     expect(f).not.toMatch(/> v\b/)
 
@@ -39,8 +40,8 @@ describe("composer: image attachments (D4+D7)", () => {
     // gateway's text-mode image routing owns the analysis-block prefix
     // without duplicating the path. See app.tsx:send for rationale.
     expect(t.gw.last("prompt.submit")?.params.text).toBe("describe this")
-    // Pre-send tray chip — the one with 800×600 dims — is gone.
-    await until(t, () => !t.frame().includes("800×600"))
+    // Pre-send tray metadata is gone.
+    await until(t, () => !t.frame().includes("~1.1kt"))
     // But the transcript MEDIA echo is visible: basename in the user turn.
     expect(t.frame()).toContain("clip_1.png")
     t.destroy()
@@ -61,7 +62,7 @@ describe("composer: image attachments (D4+D7)", () => {
     t.destroy()
   })
 
-  test("multiple attachments stack as separate chips", async () => {
+  test("multiple image attachments stay visible", async () => {
     let n = 0
     const t = await mount({
       handlers: {
@@ -112,7 +113,7 @@ describe("composer: image attachments (D4+D7)", () => {
     t.destroy()
   })
 
-  test("backspace with text in buffer edits text, doesn't detach", async () => {
+  test("backspace mid-text edits text, not attachments", async () => {
     const t = await mount({
       handlers: {
         "clipboard.paste": () => ({
@@ -132,6 +133,27 @@ describe("composer: image attachments (D4+D7)", () => {
     t.destroy()
   })
 
+  test("backspace at line start detaches even when composer has text", async () => {
+    const t = await mount({
+      handlers: {
+        "clipboard.paste": () => ({
+          attached: true, path: "/tmp/clip_1.png", name: "clip_1.png", count: 1,
+        }),
+      },
+    })
+    await until(t, () => t.frame().includes("Ready"))
+    act(() => t.keys.pressKey("v", { ctrl: true }))
+    await until(t, () => t.frame().includes("clip_1.png"))
+    await act(async () => { await t.keys.typeText("hi") })
+    act(() => t.keys.pressKey("HOME"))
+    await t.settle()
+
+    act(() => t.keys.pressBackspace())
+    await until(t, () => !t.frame().includes("clip_1.png"))
+    expect(t.frame()).toContain("hi")
+    t.destroy()
+  })
+
   test("Enter with empty buffer + attachment → sends empty prompt with image", async () => {
     const t = await mount({
       handlers: {
@@ -143,14 +165,15 @@ describe("composer: image attachments (D4+D7)", () => {
     })
     await until(t, () => t.frame().includes("Ready"))
     act(() => t.keys.pressKey("v", { ctrl: true }))
-    await until(t, () => t.frame().includes("⌫ to detach"))
+    await until(t, () => t.frame().includes("clip_1.png"))
+    expect(t.frame()).not.toContain("⌫ to detach")
     // Enter with no typed text — should still submit (gateway has the image).
     act(() => t.keys.pressEnter())
     await until(t, () => t.gw.last("prompt.submit") !== undefined)
     expect(t.gw.last("prompt.submit")?.params.text).toBe("")
-    // Pre-send tray is gone (detach hint disappears; chip still appears in
-    // the transcript MEDIA echo, which is expected).
-    await until(t, () => !t.frame().includes("⌫ to detach"))
+    // Pre-send tray is gone; chip still appears in the transcript MEDIA
+    // echo, which is expected.
+    await until(t, () => t.frame().includes("Ready"))
     t.destroy()
   })
 

--- a/test/composer.test.tsx
+++ b/test/composer.test.tsx
@@ -671,7 +671,7 @@ describe("composer: paste → file drop detection", () => {
     t.destroy()
   })
 
-  test("non-image file → wrapped text inserted, no chip", async () => {
+  test("non-image file → wrapped text inserted and chip mirrored", async () => {
     const { t, ref, attached } = await dropSetup(() => ({
       matched: true, is_image: false, path: "/tmp/report.pdf", name: "report.pdf",
       text: "[User attached file: /tmp/report.pdf]",
@@ -679,7 +679,7 @@ describe("composer: paste → file drop detection", () => {
     await act(async () => { await t.keys.pasteBracketedText("/tmp/report.pdf") })
     await until(t, () => (ref.current?.value() ?? "").length > 0)
     expect(ref.current?.value()).toBe("[User attached file: /tmp/report.pdf] ")
-    expect(attached).toEqual([])
+    expect(attached).toEqual([{ attached: true, path: "/tmp/report.pdf", name: "report.pdf" }])
     t.destroy()
   })
 


### PR DESCRIPTION
## What changed
- Moves attachment previews and chips inside the bordered composer area without picture dimensions or detach hint text.
  ![Screenshot of attachments inside composer with the status tray below](https://files.catbox.moe/251crx.png)
- Adds capped image preview rows, compact file chips, and overflow accounting for hidden attachments.
- Mirrors non-image file attachments into composer chips while still inserting the file wrapper text the prompt needs.
- Backspace at the start of a composer line detaches the last attachment even while draft text remains.
- Adds a one-line composer status tray below the composer for streaming/compression state, queue/background indicators, model text, and hidden-sidebar context.
- Keeps compression lifecycle status in the composer tray instead of persisting cosmetic compression lines into transcript history.
- Mirrors compact profile/model/title/place/context details into the composer tray only when the sidebar is hidden.
- Adjusts popover lift calculations so command and at-ref popovers account for internal attachment rows.

## Review notes
- Attachments remain detachable before send and clear after submit.
- The tray uses a deterministic inward-moving Unicode animation while streaming, and respects disabled animations.
- Hidden-sidebar context is intentionally compact and omits sidebar-only preview content.

## Verification
- `bun test test/attachments.test.tsx test/composer.test.tsx test/app.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- GitHub `test` check is passing.

## Out of scope
- This does not implement the broader responsive/mobile layout pass or broad sidebar expressiveness work.
