### PR TITLE
feat: preserve prompt answer context

### DIFF
--- a/.ignore/ce/2026-06-11-u5-chat-message-prompt-chrome-plan.md
+++ b/.ignore/ce/2026-06-11-u5-chat-message-prompt-chrome-plan.md
@@ -1,0 +1,73 @@
+---
+title: "U5: Chat message and prompt chrome"
+type: feat
+status: active
+date: 2026-06-11
+parent: /home/kaio/Dev/herm/.ignore/ce/2026-06-11-001-feat-herm-ux-polish-child-prs-plan.md
+---
+
+# U5: Chat message and prompt chrome
+
+## Scope
+
+Implement the U5 slice only on `feat/chat-message-prompt-chrome` targeting `dev`:
+
+- Remove user-message top/bottom border-rule glyph indicators.
+- Keep user turns easier to scan through token-driven background, spacing, label, and a non-border structural cue.
+- Preserve assistant/tool/system/error/media/code/diff rendering.
+- Preserve prompt question context after clarify outcomes, including selected and freeform answers.
+- Preserve safe context for approval/sudo/secret outcomes without leaking secret values or full command bodies.
+
+Explicitly out of scope: portability, Docker, OpenTUI upgrade, broad Sidebar work, responsive/mobile layout, TabShell/selected-panel border redesigns, fit-to-content pane alignment, skill composer redesign, kanban-detail keyboard overhaul, and new Hermes Agent gateway RPCs.
+
+## Current findings
+
+- `MessageItem.tsx` currently renders user turns with `BOTTOM_RULE` and `TOP_RULE` one-cell-high border rows around the user body. Tests assert `▁` and `▔`, so implementation must update those assertions.
+- Assistant/tool/system rendering is separated from `UserMessage`; preserving it mainly means avoiding broad changes outside `UserMessage`.
+- `PromptCard.tsx` collapses answered prompts to one line. Clarify outcomes currently show only `chose: <answer>`, losing the question. Approval outcomes show only the choice, sudo/secret show safe labels.
+- `PromptPart` already carries the original request under `part.req`, so no gateway contract change is needed for live prompts.
+- Replayed prompt-like transcript rows may already contain question text as normal text plus an outcome part; answer rendering must avoid duplicating question text inside the same outcome if the answer label already includes it.
+
+## Implementation plan
+
+1. Replace `UserMessage` rule rows with a compact token-based card:
+   - Add a left structural glyph/rail using text/glyph weight rather than OpenTUI border rules.
+   - Add a `You` label row with muted/accent text so low-color terminals still distinguish user turns.
+   - Use existing theme tokens (`backgroundElement`, `backgroundPanel`, `primary`, `text`, `textMuted`) and existing `mix()` helper for hover/highlight; no raw colors.
+   - Preserve click-to-rewind behavior and all part rendering for text, media, and code.
+
+2. Enrich prompt answered state:
+   - Extend `PromptPart.answered` with optional `question?: string` so the reducer can persist answer context even if a prompt part is later serialized or replayed with reduced request payload.
+   - On `prompt.answered`, derive a safe question string from `PromptReq` and store it in `answered.question`.
+   - Keep type changes Herm-local only.
+
+3. Update `PromptCard` outcome rendering:
+   - Clarify outcome: show `ask <question>` and `answer: <label>` in a compact transcript-safe block.
+   - Avoid duplicate question text if the answer label already includes the question.
+   - Approval outcome: preserve subject/description context, not full command body.
+   - Sudo outcome: show safe elevation context only.
+   - Secret outcome: show env var and provided/cancelled label only; never render the secret value.
+
+4. Update tests:
+   - `test/messagelist.test.tsx`: assert user message has no `▁`/`▔`, contains the user label/cue, and assistant trail/header still render.
+   - `test/prompt-card.test.tsx`: answered clarify shows question and answer; freeform answer wraps/truncates safely enough to keep question visible; approval/sudo/secret outcomes hide sensitive command/secret bodies.
+   - `test/app.test.tsx`: clarify outcome persists with question and selected answer after turn completion; secret remains masked and outcome safe.
+
+## Verification plan
+
+Run, in order:
+
+```bash
+export PATH="/home/kaio/.bun/bin:$PATH"
+bun test test/prompt-card.test.tsx test/messagelist.test.tsx test/app.test.tsx
+bun test
+bunx tsc --noEmit
+```
+
+If browser smoke is applicable, run the available CE/browser smoke command discovered in the repo. If no browser-specific surface exists for this OpenTUI-only change, record it as not applicable with focused component/app frame tests as the smoke gate.
+
+## Risks
+
+- OpenTUI frame rendering can make visual assertions brittle. Prefer semantic strings/glyph absence over exact full-frame snapshots.
+- Prompt outcomes need context without leaking command or secret values. Keep approval command body out of answered rows and preserve only description/subject.
+- Do not change gateway wire types beyond local optional fields; upstream events remain unchanged.

--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -171,7 +171,7 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
       return {
         ...state,
         messages: updatePrompt(state.messages, a.id, p => ({
-          ...p, answered: { label: a.label, ok: a.ok, at: Date.now() },
+          ...p, answered: { label: a.label, ok: a.ok, at: Date.now(), question: promptQuestion(p.req) },
         })),
       }
 
@@ -352,6 +352,13 @@ function updatePrompt(messages: Message[], id: string, fn: (p: PromptPart) => Pr
     if (!m.parts.some(p => p.type === "prompt" && p.id === id)) return m
     return { ...m, parts: m.parts.map(p => p.type === "prompt" && p.id === id ? fn(p) : p) }
   })
+}
+
+function promptQuestion(req: PromptReq): string | undefined {
+  if (req.variant === "clarify") return req.question
+  if (req.variant === "approval") return req.description || "Shell command"
+  if (req.variant === "sudo") return "Sudo required"
+  return req.env_var ? `Secret: ${req.env_var}` : "Secret required"
 }
 
 function upsertThinking(messages: Message[], text: string, final: boolean, verbose?: boolean): Message[] {

--- a/src/components/chat/PromptCard.tsx
+++ b/src/components/chat/PromptCard.tsx
@@ -338,22 +338,54 @@ const Masked = forwardRef<PromptCardHandle, {
   )
 })
 
+function same(a: string | undefined, b: string): boolean {
+  return Boolean(a && b && b.toLowerCase().includes(a.toLowerCase()))
+}
+
+function cap(s: string, n = 160): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…"
+}
+
+function question(part: PromptPart): string {
+  const a = part.answered?.question
+  if (a) return a
+  if (part.req.variant === "clarify") return part.req.question
+  if (part.req.variant === "approval") return mkApproval(part.req).question
+  if (part.req.variant === "sudo") return "Sudo required"
+  return part.req.env_var ? `Secret: ${part.req.env_var}` : "Secret required"
+}
+
+function outcome(part: PromptPart): { head: string; body?: string } {
+  const a = part.answered!
+  if (part.variant === "clarify") {
+    const q = cap(question(part))
+    const body = `answer: ${cap(a.label)}`
+    return same(q, a.label) ? { head: body } : { head: `ask ${q}`, body }
+  }
+  if (part.variant === "approval") {
+    const q = cap(question(part), 96)
+    return { head: a.label, body: q }
+  }
+  if (part.variant === "sudo") return { head: `sudo ${a.label}` }
+  const req = part.req as Extract<PromptReq, { variant: "secret" }>
+  return { head: `${req.env_var ?? "secret"} ${a.label}` }
+}
+
 const Outcome = memo(({ part }: { part: PromptPart }) => {
   const theme = useTheme().theme
   const a = part.answered!
   const glyph = a.ok ? "✓" : "✗"
   const fg = a.ok ? theme.success : theme.error
-  const what =
-    part.variant === "approval" ? a.label
-    : part.variant === "clarify" ? `chose: ${a.label}`
-    : part.variant === "sudo" ? `sudo ${a.label}`
-    : `${(part.req as { env_var?: string }).env_var ?? "secret"} ${a.label}`
+  const text = outcome(part)
   return (
-    <box height={1} paddingLeft={3} marginBottom={1}>
-      <text>
-        <span fg={fg}>{glyph} </span>
-        <span fg={theme.textMuted}>{what}</span>
-      </text>
+    <box flexDirection="row" paddingLeft={3} marginBottom={1}>
+      <box width={2} flexShrink={0}>
+        <text fg={fg}>{glyph}</text>
+      </box>
+      <box flexDirection="column" flexGrow={1} flexShrink={1}>
+        <text fg={theme.textMuted} wrapMode="word">{text.head}</text>
+        {text.body ? <text fg={theme.textMuted} wrapMode="word">{text.body}</text> : null}
+      </box>
     </box>
   )
 })

--- a/src/components/chat/PromptCard.tsx
+++ b/src/components/chat/PromptCard.tsx
@@ -359,8 +359,8 @@ function outcome(part: PromptPart): { head: string; body?: string } {
   const a = part.answered!
   if (part.variant === "clarify") {
     const q = cap(question(part))
-    const body = `answer: ${cap(a.label)}`
-    return same(q, a.label) ? { head: body } : { head: `ask ${q}`, body }
+    const body = cap(a.label)
+    return same(q, a.label) ? { head: body } : { head: q, body }
   }
   if (part.variant === "approval") {
     const q = cap(question(part), 96)

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -47,7 +47,7 @@ export type PromptPart = {
   id: string
   variant: "approval" | "clarify" | "sudo" | "secret"
   req: PromptReq
-  answered?: { label: string; ok: boolean; at: number }
+  answered?: { label: string; ok: boolean; at: number; question?: string }
 }
 
 export type PromptReq =

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -545,8 +545,8 @@ describe("app", () => {
     expect(t.gw.last("clarify.respond")?.params).toMatchObject({ request_id: "c1", answer: "blue" })
     // Outcome persists after turn ends with question context.
     act(() => t.gw.push({ type: "message.complete", payload: { text: "ok", usage: { input: 0, output: 0, total: 0 } } }))
-    await until(t, () => t.frame().includes("answer: blue"))
-    expect(t.frame()).toContain("ask which one?")
+    await until(t, () => t.frame().includes("blue"))
+    expect(t.frame()).toContain("which one?")
     t.destroy()
   })
 

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -543,9 +543,10 @@ describe("app", () => {
     await act(async () => { await t.keys.typeText("2") })
     await until(t, () => t.gw.last("clarify.respond") !== undefined)
     expect(t.gw.last("clarify.respond")?.params).toMatchObject({ request_id: "c1", answer: "blue" })
-    // Outcome persists after turn ends.
+    // Outcome persists after turn ends with question context.
     act(() => t.gw.push({ type: "message.complete", payload: { text: "ok", usage: { input: 0, output: 0, total: 0 } } }))
-    await until(t, () => t.frame().includes("chose: blue"))
+    await until(t, () => t.frame().includes("answer: blue"))
+    expect(t.frame()).toContain("ask which one?")
     t.destroy()
   })
 

--- a/test/prompt-card.test.tsx
+++ b/test/prompt-card.test.tsx
@@ -162,10 +162,10 @@ describe("PromptCard.Clarify", () => {
       { width: 90, height: 20 },
     )
     const f = t.frame()
-    expect(f).toContain("ask which one?")
-    expect(f).toContain("answer: blue")
+    expect(f).toContain("which one?")
+    expect(f).toContain("blue")
     expect(f).toContain("write a concise status update")
-    expect(f).toContain("answer: Use the shorter terminal-friendly wording")
+    expect(f).toContain("Use the shorter terminal-friendly wording")
   })
 })
 

--- a/test/prompt-card.test.tsx
+++ b/test/prompt-card.test.tsx
@@ -93,12 +93,35 @@ describe("PromptCard.Approval", () => {
 
   test("answered part collapses to Outcome line", async () => {
     await using t = await mountNode(
-      <PromptCard part={{ ...approval(), answered: { label: "Allow once", ok: true, at: 0 } }}
+      <PromptCard part={{ ...approval(), answered: { label: "Allow once", ok: true, at: 0, question: "recursive rm" } }}
         onAnswer={() => {}} />,
     )
     expect(t.frame()).toContain("✓")
     expect(t.frame()).toContain("Allow once")
+    expect(t.frame()).toContain("recursive rm")
     expect(t.frame()).not.toContain("$ rm")
+  })
+
+  test("answered approval and secret outcomes preserve safe context only", async () => {
+    await using t = await mountNode(
+      <box flexDirection="column">
+        <PromptCard part={{
+          ...approval({ command: "cat /etc/shadow", description: "read shadow" }),
+          answered: { label: "Deny", ok: false, at: 0, question: "read shadow" },
+        }} onAnswer={() => {}} />
+        <PromptCard part={{
+          type: "prompt", id: "s1", variant: "secret",
+          req: { variant: "secret", request_id: "s1", prompt: "paste token hunter2", env_var: "API_KEY" },
+          answered: { label: "(provided)", ok: true, at: 0, question: "Secret: API_KEY" },
+        }} onAnswer={() => {}} />
+      </box>,
+    )
+    const f = t.frame()
+    expect(f).toContain("read shadow")
+    expect(f).not.toContain("cat /etc/shadow")
+    expect(f).toContain("API_KEY (provided)")
+    expect(f).not.toContain("hunter2")
+    expect(f).not.toContain("paste token")
   })
 })
 
@@ -119,6 +142,30 @@ describe("PromptCard.Clarify", () => {
     act(() => ref.current!.feed({ name: "return" } as never))
     await t.settle()
     expect(gw.last("clarify.respond")?.params).toMatchObject({ request_id: "r1", answer: "B" })
+  })
+
+  test("answered outcomes keep question and selected/freeform answers visible", async () => {
+    const long = "write a concise status update that explains the work done without mentioning private implementation process details"
+    await using t = await mountNode(
+      <box flexDirection="column">
+        <PromptCard part={{
+          type: "prompt", id: "c1", variant: "clarify",
+          req: { variant: "clarify", request_id: "r1", question: "which one?", choices: ["red", "blue"] },
+          answered: { label: "blue", ok: true, at: 0, question: "which one?" },
+        }} onAnswer={() => {}} />
+        <PromptCard part={{
+          type: "prompt", id: "c2", variant: "clarify",
+          req: { variant: "clarify", request_id: "r2", question: long, choices: null },
+          answered: { label: "Use the shorter terminal-friendly wording", ok: true, at: 0, question: long },
+        }} onAnswer={() => {}} />
+      </box>,
+      { width: 90, height: 20 },
+    )
+    const f = t.frame()
+    expect(f).toContain("ask which one?")
+    expect(f).toContain("answer: blue")
+    expect(f).toContain("write a concise status update")
+    expect(f).toContain("answer: Use the shorter terminal-friendly wording")
   })
 })
 


### PR DESCRIPTION
## What changed
- Persists prompt question context into answered prompt parts.
- Renders clarify outcomes as question plus selected or freeform answer without `ask` or `answer:` labels, so transcript readers can see what was asked after the prompt collapses.
  ![Screenshot of answered prompt preserving question and answer context](https://files.catbox.moe/wmnwvw.png)
- Keeps approval, sudo, and secret answered rows safe by showing context labels without leaking secret values or full command bodies.
- Updates turn reducer handling so answered prompt parts keep the context needed by PromptCard.

## Review notes
- User message style and appearance are unchanged from `dev`.
- Assistant, user, tool, system, media, code, diff, and error rendering paths are otherwise left intact.
- Secret and sudo paths intentionally avoid echoing sensitive input in collapsed outcome rows.

## Verification
- `bun test test/prompt-card.test.tsx test/app.test.tsx test/messagelist.test.tsx`
- `bun test`
- `bunx tsc --noEmit`

## Out of scope
- Message chrome/style changes, selected-panel double borders, TabShell border/title changes, and broad chat panel redesign are not included.
