### PR TITLE
fix(chat): expire stale approval prompts

### DIFF
--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -304,10 +304,24 @@ function finalize(messages: Message[], final?: string, usage?: Usage): Message[]
       : final && !dup && !sameText(joinText(last.parts), final)
         ? [...last.parts, { type: "text" as const, content: final, streaming: false }]
         : seal(last.parts)
-    return [...messages.slice(0, -1), { ...last, parts, usage }]
+    return expirePrompts([...messages.slice(0, -1), { ...last, parts, usage }])
   }
-  if (!final) return messages
-  return [...messages, { ...assistant([{ type: "text", content: final, streaming: false }]), usage }]
+  const next = final
+    ? [...messages, { ...assistant([{ type: "text", content: final, streaming: false }]), usage }]
+    : messages
+  return expirePrompts(next)
+}
+
+function expirePrompts(messages: Message[]): Message[] {
+  const at = Date.now()
+  return messages.map(m => m.role === "assistant"
+    ? {
+      ...m,
+      parts: m.parts.map(p => p.type === "prompt" && !p.answered
+        ? { ...p, answered: { label: "Timed out", ok: false, at, question: promptQuestion(p.req) } }
+        : p),
+    }
+    : m)
 }
 
 function joinText(parts: Part[]): string {

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -506,6 +506,31 @@ describe("app", () => {
     t.destroy()
   })
 
+  test("approval prompt expires when the gateway times out and the turn completes", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("go") })
+    act(() => t.keys.pressEnter())
+    act(() => t.gw.push({ type: "message.start" }))
+    act(() => t.gw.push({
+      type: "approval.request",
+      payload: { command: "rm -rf /tmp/x", description: "delete temp tree" },
+    }))
+    await until(t, () => t.frame().includes("Permission required"))
+
+    act(() => t.gw.push({
+      type: "message.complete",
+      payload: { text: "approval timed out", usage: { input: 0, output: 0, total: 0 } },
+    }))
+    await until(t, () => t.frame().includes("Timed out") && !t.frame().includes("Permission required"))
+
+    act(() => t.keys.pressKey("1"))
+    await t.settle()
+    expect(t.gw.last("approval.respond")).toBeUndefined()
+    t.destroy()
+  })
+
   test("inline prompt Esc does not arm interrupt; tab-nav still works (no backdrop)", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))


### PR DESCRIPTION
## What changed
- Expires unanswered inline prompt cards when the gateway completes the turn.
- Converts stale approval prompts into inert timeout outcome rows so they no longer keep the composer defocused or send ineffective `approval.respond` calls after the backend wait has expired.
- Leaves answered prompt outcome rows unchanged.

## Verification
- `bunx tsc --noEmit`
- `bun test test/app.test.tsx -t 'approval prompt expires|approval.request renders inline'`
- `bun test`
- `bun run build`
