### PR TITLE
fix(gateway): normalize outbound unicode

### DIFF
--- a/src/context/gateway-client.ts
+++ b/src/context/gateway-client.ts
@@ -6,6 +6,7 @@ import { homedir } from "os"
 import { resolve, delimiter } from "path"
 import { existsSync } from "fs"
 import type { GatewayEvent } from "./wire"
+import { encode } from "../utils/unicode"
 
 const LOG_MAX = 200
 const LOG_PREVIEW = 240
@@ -249,7 +250,12 @@ export class GatewayClient extends EventEmitter {
       })
 
       try {
-        writer.write(JSON.stringify({ jsonrpc: "2.0", id: rid, method, params: merged }) + "\n")
+        const frame = encode({ jsonrpc: "2.0", id: rid, method, params: merged })
+        if (frame.issues.length) {
+          const detail = frame.issues.map(x => `${x.path}:${x.count}`).join(", ")
+          this.log(`[wire] sanitized invalid unicode for ${method}: ${detail}`)
+        }
+        writer.write(frame.text + "\n")
       } catch (e) {
         clearTimeout(timeout)
         this.pending.delete(rid)

--- a/src/utils/unicode.ts
+++ b/src/utils/unicode.ts
@@ -1,0 +1,36 @@
+const BAD = /[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDFFF]/g
+
+type Issue = {
+  path: string
+  count: number
+}
+
+type Encoded = {
+  text: string
+  issues: Issue[]
+}
+
+function scalar(s: string): { text: string; count: number } {
+  let count = 0
+  const text = s.replace(BAD, m => {
+    if (m.length === 2) return m
+    count += 1
+    return "�"
+  })
+  return { text, count }
+}
+
+export function encode(v: unknown): Encoded {
+  const paths = new WeakMap<object, string>()
+  const issues: Issue[] = []
+  const text = JSON.stringify(v, function (this: unknown, key, value: unknown) {
+    const holder = this && typeof this === "object" ? paths.get(this) : undefined
+    const path = key ? `${holder ?? "$"}.${key}` : "$"
+    if (value && typeof value === "object") paths.set(value, path)
+    if (typeof value !== "string") return value
+    const next = scalar(value)
+    if (next.count > 0) issues.push({ path, count: next.count })
+    return next.text
+  }) ?? "null"
+  return { text, issues }
+}

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "fs"
 import { join, resolve } from "path"
 import { tmpdir } from "os"
-import { hermesAgentRoot, python } from "../src/context/gateway-client"
+import { GatewayClient, hermesAgentRoot, python } from "../src/context/gateway-client"
 
 const withEnv = <T>(key: string, value: string | undefined, fn: () => T): T => {
   const prev = process.env[key]
@@ -88,5 +88,42 @@ describe("python", () => {
         }
       })
     })
+  })
+})
+
+describe("GatewayClient", () => {
+  test("normalizes outbound JSON-RPC strings to Unicode scalar values", async () => {
+    const prev = Bun.spawn
+    const enc = new TextEncoder()
+    const dec = new TextDecoder()
+    let frame = ""
+    let ctrl: ReadableStreamDefaultController<Uint8Array> | null = null
+    const stdout = new ReadableStream<Uint8Array>({ start: c => { ctrl = c } })
+    const stdin = {
+      write(data: string | Uint8Array) {
+        frame += typeof data === "string" ? data : dec.decode(data)
+        const req = JSON.parse(frame.trim()) as { id: string }
+        ctrl?.enqueue(enc.encode(JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { ok: true } }) + "\n"))
+        return frame.length
+      },
+    }
+    ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = ((() => ({
+      stdin,
+      stdout,
+      stderr: null,
+      exited: new Promise<null>(() => {}),
+      exitCode: null,
+      kill() {},
+    })) as unknown) as typeof Bun.spawn
+
+    const gw = new GatewayClient()
+    try {
+      await expect(gw.request("paste.collapse", { text: "a\udc9d", nested: ["💝"] })).resolves.toEqual({ ok: true })
+      expect(JSON.parse(frame.trim()).params).toEqual({ text: "a�", nested: ["💝"] })
+      expect(gw.tail()).toContain("[wire] sanitized invalid unicode for paste.collapse: $.params.text:1")
+    } finally {
+      gw.kill()
+      ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = prev
+    }
   })
 })

--- a/test/unicode.test.ts
+++ b/test/unicode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { encode } from "../src/utils/unicode"
+
+const units = (s: string) => Array.from({ length: s.length }, (_, i) => s.charCodeAt(i).toString(16))
+
+describe("unicode JSON encoding", () => {
+  test("preserves valid astral characters", () => {
+    const out = encode({ text: "ok 💝 done" })
+    expect(out.issues).toEqual([])
+    expect(JSON.parse(out.text).text).toBe("ok 💝 done")
+  })
+
+  test("replaces lone surrogates while keeping valid pairs", () => {
+    const out = encode({ text: "a\ud83db\udc9dc💝" })
+    expect(out.issues).toEqual([{ path: "$.text", count: 2 }])
+    const text = JSON.parse(out.text).text
+    expect(text).toBe("a�b�c💝")
+    expect(units(text)).toContain("d83d")
+    expect(units(text)).toContain("dc9d")
+  })
+
+  test("reports nested param paths", () => {
+    const out = encode({ params: { text: "x\udc9d", nested: ["ok", { y: "\ud83d" }] } })
+    expect(out.issues).toEqual([
+      { path: "$.params.text", count: 1 },
+      { path: "$.params.nested.1.y", count: 1 },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
Herm now normalizes outbound JSON-RPC frames to Unicode scalar values before they cross into the Python TUI gateway. Lone UTF-16 surrogate code units are replaced with `�`, valid astral characters such as emoji are preserved, and a compact diagnostic is kept in the gateway log tail with the RPC method and JSON path that was normalized.

## Review notes
- This is intentionally at the stdio JSON-RPC serialization boundary rather than in the composer paste handler. It covers `paste.collapse`, `prompt.submit`, slash/config calls, plugin calls, and any future gateway request.
- The encoder uses `JSON.stringify` with a replacer so normal JSON behavior stays intact, including `toJSON`, omitted object `undefined`, and array nulling semantics.
- Diagnostics stay local to `GatewayClient.tail()` instead of surfacing a noisy user-facing system line.

## Verification
- `bun test test/unicode.test.ts test/gateway-client.test.ts`
- Real gateway smoke with `paste.collapse` and `\udc9d` in `params.text`, using a temporary `HERMES_HOME`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
