### PR TITLE
feat(eikon): request author-owned registry delists

### DIFF
--- a/src/app/eikon-cli.ts
+++ b/src/app/eikon-cli.ts
@@ -16,6 +16,7 @@ Usage:
   herm eikon use <name> [--json]
   herm eikon update <name> [--active-ok] [--json]
   herm eikon remove <name> [--active-ok] [--json]
+  herm eikon delist <name|id> [--json]
   herm eikon -h, --help
 `
 
@@ -31,6 +32,7 @@ type SearchRow = {
   installed: boolean
   active: boolean
   compatibility?: Record<string, unknown> | string
+  identityKey?: string
 }
 
 type InspectResult = {
@@ -58,6 +60,7 @@ export type EikonCliDeps = {
   info: (name: string) => svc.LifecycleInfo
   update: typeof svc.update
   remove: typeof svc.remove
+  delist: (target: string) => Promise<{ url: string; info: unknown }>
   list: typeof svc.list
   baked: typeof svc.baked
   has: (name: string) => boolean
@@ -116,6 +119,7 @@ function searchRow(row: market.MarketplaceRow): SearchRow {
     installed: row.installed,
     active: row.active,
     compatibility: lifecycle.compatibility,
+    identityKey: row.entry.identityKey,
   }
 }
 
@@ -131,6 +135,13 @@ const defaultDeps = (): EikonCliDeps => ({
   info: svc.lifecycle,
   update: svc.update,
   remove: svc.remove,
+  delist: async target => {
+    const state = await market.load()
+    if (state.status === "error") throw new Error(state.error ?? "marketplace failed")
+    const entry = state.service?.entry(target)
+    if (!entry || !state.service) throw new Error(`No official catalog eikon named '${target}'`)
+    return state.service.delist(entry.identityKey)
+  },
   list: svc.list,
   baked: svc.baked,
   has: name => svc.list().some(e => e.name === name),
@@ -225,6 +236,14 @@ export async function handleEikonCli(
       const eikons = await deps.search(query)
       if (p.json) return emit(io, JSON.stringify({ ok: true, query, eikons }))
       return emit(io, eikons.length ? eikons.map(e => `${e.name}\t${e.title ?? e.name}\t${e.trust}${e.active ? "\tactive" : e.installed ? "\tinstalled" : ""}`).join("\n") : "No eikons found")
+    }
+
+    if (cmd === "delist") {
+      const target = p.values[0]
+      if (!target) return emitError(io, "usage: herm eikon delist <name|id>", p.json)
+      const out = await deps.delist(target)
+      if (p.json) return emit(io, JSON.stringify({ ok: true, url: out.url, info: out.info }))
+      return emit(io, `Delist requested: ${out.url}`)
     }
 
     if (cmd === "inspect" || cmd === "peek") {

--- a/src/dialogs/eikon-marketplace-action.tsx
+++ b/src/dialogs/eikon-marketplace-action.tsx
@@ -15,7 +15,9 @@ type Props = {
 const fmt = (n?: number) => n == null ? "size unknown" : n < 1024 ? `${n} B` : n < 1024 * 1024 ? `${(n / 1024).toFixed(1)} KiB` : `${(n / 1024 / 1024).toFixed(1)} MiB`
 
 const choices = (row: MarketplaceRow, sizes?: MarketplaceSizes): Opt[] => {
-  if (row.installState === "incompatible" || row.installState === "mismatch") return []
+  if (row.installState === "incompatible" || row.installState === "mismatch") return [
+    { label: "Delist from Registry", hint: "opens an automatic GitHub delist request for the original submitter", value: "delist" },
+  ]
   if (!row.installed) return [
     { label: "Eikon only", hint: fmt(sizes?.eikon), value: "install" },
     { label: "Eikon + Source", hint: `${fmt((sizes?.eikon ?? 0) + (sizes?.source ?? 0))} · Source files needed to edit Eikon in Studio`, value: "source" },

--- a/src/dialogs/eikon-marketplace-action.tsx
+++ b/src/dialogs/eikon-marketplace-action.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../theme"
 import type { DialogContext } from "../ui/dialog"
 import type { MarketplaceRow, MarketplaceSizes } from "../service/eikon-marketplace"
 
-type Choice = "install" | "source" | "use" | "download" | "delete"
+type Choice = "install" | "source" | "use" | "download" | "delete" | "delist"
 type Opt = { label: string; hint?: string; value: Choice }
 
 type Props = {
@@ -19,11 +19,13 @@ const choices = (row: MarketplaceRow, sizes?: MarketplaceSizes): Opt[] => {
   if (!row.installed) return [
     { label: "Eikon only", hint: fmt(sizes?.eikon), value: "install" },
     { label: "Eikon + Source", hint: `${fmt((sizes?.eikon ?? 0) + (sizes?.source ?? 0))} · Source files needed to edit Eikon in Studio`, value: "source" },
+    { label: "Delist from Registry", hint: "opens an automatic GitHub delist request for the original submitter", value: "delist" },
   ]
   return [
     ...(!row.active ? [{ label: "Use", hint: "set as active avatar", value: "use" as const }] : []),
     ...(row.sourceDownloadable ? [{ label: "Download Source", hint: "needed to edit in Studio", value: "download" as const }] : []),
     ...(row.removable ? [{ label: "Delete", value: "delete" as const }] : []),
+    { label: "Delist from Registry", hint: "opens an automatic GitHub delist request for the original submitter", value: "delist" as const },
   ]
 }
 

--- a/src/service/eikon-delist.ts
+++ b/src/service/eikon-delist.ts
@@ -124,11 +124,11 @@ async function main(run: Run, repo: string) {
 }
 
 async function tree(run: Run, repo: string, sha: string) {
-  return json<Tree>(await run(["api", `repos/${repo}/git/trees/${sha}`, "-f", "recursive=1"])).tree ?? []
+  return json<Tree>(await run(["api", "-X", "GET", `repos/${repo}/git/trees/${sha}`, "-f", "recursive=1"])).tree ?? []
 }
 
 async function index(run: Run, repo: string) {
-  const raw = json<Content>(await run(["api", `repos/${repo}/contents/eikons/index.json`, "-f", "ref=main"]))
+  const raw = json<Content>(await run(["api", "-X", "GET", `repos/${repo}/contents/eikons/index.json`, "-f", "ref=main"]))
   return { sha: raw.sha, text: Buffer.from((raw.content ?? "").replace(/\s/g, ""), "base64").toString("utf8") }
 }
 
@@ -136,7 +136,7 @@ async function pr(run: Run, repo: string, user: string, branch: string, name: st
   try {
     return await run(["pr", "create", "-R", repo, "-H", `${user}:${branch}`, "-B", "main", "-t", `eikons: delist ${name}`, "-b", body])
   } catch {
-    const raw = await run(["pr", "list", "-R", repo, "--state", "open", "--head", `${user}:${branch}`, "--json", "url", "--limit", "1"])
+    const raw = await run(["api", "-X", "GET", `repos/${repo}/pulls`, "-f", "state=open", "-f", `head=${user}:${branch}`])
     const hit = json<Array<{ url?: string }>>(raw)[0]?.url
     if (hit) return hit
     throw new Error("GitHub PR creation failed")

--- a/src/service/eikon-delist.ts
+++ b/src/service/eikon-delist.ts
@@ -21,11 +21,12 @@ type Pr = {
   mergedAt?: string
   author?: { login?: string } | null
 }
-type File = { path: string }
+type File = { path?: string; filename?: string }
 type Tree = { tree?: Array<{ path?: string; type?: string; sha?: string }> }
 type Content = { content?: string; sha?: string }
 
 const REPO = process.env.EIKON_REPO ?? "liftaris/eikon"
+const HOST = "eikon.liftaris.dev"
 const enc = new TextEncoder()
 
 async function gh(args: string[], input?: string) {
@@ -57,28 +58,40 @@ function touches(entry: CatalogEntry, path: string) {
   return dirs(entry).some(dir => path.startsWith(dir))
 }
 
+export function official(entry: CatalogEntry) {
+  try {
+    const host = new URL(entry.packageUrl).hostname
+    return host === HOST && [entry.sourceKey, entry.identityKey].some(key => key?.startsWith(`registry:${HOST}:`))
+  } catch {
+    return false
+  }
+}
+
 async function user(run: Run) {
   return run(["api", "user", "-q", ".login"])
 }
 
 async function prs(entry: CatalogEntry, repo: string, run: Run) {
   const fields = "number,title,headRefName,url,mergedAt,author"
-  const first = json<Pr[]>(await run(["pr", "list", "-R", repo, "--state", "merged", "--search", `eikons: submit ${entry.name}`, "--json", fields, "--limit", "20"]))
-  if (first.length) return first
-  return json<Pr[]>(await run(["pr", "list", "-R", repo, "--state", "merged", "--json", fields, "--limit", "50"]))
+  const exact = (xs: Pr[]) => xs.filter(pr => pr.title === `eikons: submit ${entry.name}` && pr.headRefName === `submit/${entry.name}`)
+  const at = (pr: Pr) => Number.isFinite(Date.parse(pr.mergedAt ?? "")) ? Date.parse(pr.mergedAt ?? "") : 0
+  const sort = (xs: Pr[]) => xs.toSorted((a, b) => at(a) - at(b) || a.number - b.number)
+  const first = exact(json<Pr[]>(await run(["pr", "list", "-R", repo, "--state", "merged", "--search", `\"eikons: submit ${entry.name}\" in:title`, "--json", fields, "--limit", "100"])))
+  if (first.length) return sort(first)
+  return sort(exact(json<Pr[]>(await run(["pr", "list", "-R", repo, "--state", "merged", "--json", fields, "--limit", "100"]))))
 }
 
-async function files(repo: string, pr: number, run: Run) {
-  const raw = await run(["pr", "view", String(pr), "-R", repo, "--json", "files"])
-  return json<{ files?: File[] }>(raw).files ?? []
+async function files(repo: string, pr: number, run: Run): Promise<File[]> {
+  const raw = await run(["api", "--paginate", "-X", "GET", `repos/${repo}/pulls/${pr}/files`, "--jq", ".[].filename"])
+  return raw.split(/\r?\n/).filter(Boolean).map(path => ({ path }))
 }
 
 async function found(entry: CatalogEntry, repo: string, run: Run) {
   for (const pr of await prs(entry, repo, run)) {
     const title = pr.title === `eikons: submit ${entry.name}`
     const head = pr.headRefName === `submit/${entry.name}`
-    if (!title && !head) continue
-    if ((await files(repo, pr.number, run)).some(f => touches(entry, f.path))) return pr
+    if (!title || !head) continue
+    if ((await files(repo, pr.number, run)).some(f => touches(entry, f.path ?? f.filename ?? ""))) return pr
   }
   return undefined
 }
@@ -86,6 +99,7 @@ async function found(entry: CatalogEntry, repo: string, run: Run) {
 export async function info(entry: CatalogEntry, opts: Opts = {}): Promise<Info> {
   const run = opts.run ?? gh
   const repo = opts.repo ?? REPO
+  if (!official(entry)) return { eligible: false, reason: "Registry delist is only available for official Eikon catalog entries" }
   let login: string
   try { login = await user(run) }
   catch (err) { return { eligible: false, reason: err instanceof Error ? err.message : String(err) } }
@@ -129,7 +143,15 @@ async function tree(run: Run, repo: string, sha: string) {
 
 async function index(run: Run, repo: string) {
   const raw = json<Content>(await run(["api", "-X", "GET", `repos/${repo}/contents/eikons/index.json`, "-f", "ref=main"]))
-  return { sha: raw.sha, text: Buffer.from((raw.content ?? "").replace(/\s/g, ""), "base64").toString("utf8") }
+  return Buffer.from((raw.content ?? "").replace(/\s/g, ""), "base64").toString("utf8")
+}
+
+async function reset(run: Run, repo: string, name: string, sha: string) {
+  try {
+    await run(["api", "-X", "POST", `repos/${repo}/git/refs`, "-f", `ref=refs/heads/${name}`, "-f", `sha=${sha}`])
+  } catch {
+    await run(["api", "-X", "PATCH", `repos/${repo}/git/refs/heads/${name}`, "--input", "-"], JSON.stringify({ sha, force: true }))
+  }
 }
 
 async function pr(run: Run, repo: string, user: string, branch: string, name: string, body: string) {
@@ -152,10 +174,9 @@ export async function submit(entry: CatalogEntry, opts: Opts = {}): Promise<Resu
   const fork = `${own.user}/${repo.split("/")[1]}`
   const branch = `delist/${clean(entry.name)}`
   const base = await main(run, repo)
-  await run(["api", "-X", "POST", `repos/${fork}/git/refs`, "-f", `ref=refs/heads/${branch}`, "-f", `sha=${base.sha}`]).catch(() => "")
+  await reset(run, fork, branch, base.sha)
   const msg = `eikons: delist ${entry.name}`
-  const ix = await index(run, repo)
-  const next = json<Array<Record<string, unknown>>>(ix.text).filter(e => e.name !== entry.name && e.id !== entry.id)
+  const next = json<Array<Record<string, unknown>>>(await index(run, repo)).filter(e => e.name !== entry.name && e.id !== entry.id)
   await put(run, fork, branch, "eikons/index.json", `${JSON.stringify(next, null, 2)}\n`, msg)
   for (const item of await tree(run, repo, base.tree)) {
     if (!item.path || item.type !== "blob" || !item.sha || !touches(entry, item.path)) continue

--- a/src/service/eikon-delist.ts
+++ b/src/service/eikon-delist.ts
@@ -1,0 +1,169 @@
+import { Buffer } from "node:buffer"
+import type { PublicCatalogEntry as CatalogEntry } from "eikon"
+
+export type Run = (args: string[], input?: string) => Promise<string>
+export type Info = {
+  eligible: boolean
+  user?: string
+  author?: string
+  pr?: number
+  url?: string
+  reason?: string
+}
+export type Result = { url: string; info: Info }
+export type Opts = { repo?: string; run?: Run }
+
+type Pr = {
+  number: number
+  title?: string
+  headRefName?: string
+  url?: string
+  mergedAt?: string
+  author?: { login?: string } | null
+}
+type File = { path: string }
+type Tree = { tree?: Array<{ path?: string; type?: string; sha?: string }> }
+type Content = { content?: string; sha?: string }
+
+const REPO = process.env.EIKON_REPO ?? "liftaris/eikon"
+const enc = new TextEncoder()
+
+async function gh(args: string[], input?: string) {
+  const p = Bun.spawn(["gh", ...args], { stdin: input ? enc.encode(input) : undefined, stdout: "pipe", stderr: "pipe" })
+  const [out, err, code] = await Promise.all([new Response(p.stdout).text(), new Response(p.stderr).text(), p.exited])
+  if (code !== 0) throw new Error(err.trim() || out.trim() || `gh ${args[0]} failed`)
+  return out.trim()
+}
+
+function json<T>(text: string): T {
+  return JSON.parse(text) as T
+}
+
+function clean(value: string) {
+  return value.replace(/[^A-Za-z0-9_.-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "")
+}
+
+function pkg(entry: CatalogEntry) {
+  const parts = entry.id.includes("/") ? entry.id.split("/") : ["liftaris", entry.name]
+  return { ns: parts[0] || "liftaris", name: parts[1] || entry.name }
+}
+
+function dirs(entry: CatalogEntry) {
+  const p = pkg(entry)
+  return [`eikons/${entry.name}/`, `packages/${p.ns}/${p.name}/`]
+}
+
+function touches(entry: CatalogEntry, path: string) {
+  return dirs(entry).some(dir => path.startsWith(dir))
+}
+
+async function user(run: Run) {
+  return run(["api", "user", "-q", ".login"])
+}
+
+async function prs(entry: CatalogEntry, repo: string, run: Run) {
+  const fields = "number,title,headRefName,url,mergedAt,author"
+  const first = json<Pr[]>(await run(["pr", "list", "-R", repo, "--state", "merged", "--search", `eikons: submit ${entry.name}`, "--json", fields, "--limit", "20"]))
+  if (first.length) return first
+  return json<Pr[]>(await run(["pr", "list", "-R", repo, "--state", "merged", "--json", fields, "--limit", "50"]))
+}
+
+async function files(repo: string, pr: number, run: Run) {
+  const raw = await run(["pr", "view", String(pr), "-R", repo, "--json", "files"])
+  return json<{ files?: File[] }>(raw).files ?? []
+}
+
+async function found(entry: CatalogEntry, repo: string, run: Run) {
+  for (const pr of await prs(entry, repo, run)) {
+    const title = pr.title === `eikons: submit ${entry.name}`
+    const head = pr.headRefName === `submit/${entry.name}`
+    if (!title && !head) continue
+    if ((await files(repo, pr.number, run)).some(f => touches(entry, f.path))) return pr
+  }
+  return undefined
+}
+
+export async function info(entry: CatalogEntry, opts: Opts = {}): Promise<Info> {
+  const run = opts.run ?? gh
+  const repo = opts.repo ?? REPO
+  let login: string
+  try { login = await user(run) }
+  catch (err) { return { eligible: false, reason: err instanceof Error ? err.message : String(err) } }
+  const pr = await found(entry, repo, run)
+  const author = pr?.author?.login
+  if (!pr || !author) return { eligible: false, user: login, reason: "No merged GitHub submission found" }
+  if (author !== login) return { eligible: false, user: login, author, pr: pr.number, url: pr.url, reason: `Submitted by @${author}` }
+  return { eligible: true, user: login, author, pr: pr.number, url: pr.url }
+}
+
+async function exists(run: Run, repo: string, branch: string, path: string) {
+  try {
+    const raw = await run(["api", "-X", "GET", `repos/${repo}/contents/${path}`, "-f", `ref=${branch}`])
+    return json<Content>(raw).sha
+  } catch { return undefined }
+}
+
+async function put(run: Run, repo: string, branch: string, path: string, text: string, msg: string) {
+  const sha = await exists(run, repo, branch, path)
+  await run(["api", "-X", "PUT", `repos/${repo}/contents/${path}`, "--input", "-"], JSON.stringify({
+    message: msg,
+    branch,
+    content: Buffer.from(text).toString("base64"),
+    ...(sha ? { sha } : {}),
+  }))
+}
+
+async function del(run: Run, repo: string, branch: string, path: string, sha: string, msg: string) {
+  await run(["api", "-X", "DELETE", `repos/${repo}/contents/${path}`, "--input", "-"], JSON.stringify({ message: msg, branch, sha }))
+}
+
+async function main(run: Run, repo: string) {
+  const sha = await run(["api", `repos/${repo}/git/ref/heads/main`, "-q", ".object.sha"])
+  const tree = await run(["api", `repos/${repo}/git/commits/${sha}`, "-q", ".tree.sha"])
+  return { sha, tree }
+}
+
+async function tree(run: Run, repo: string, sha: string) {
+  return json<Tree>(await run(["api", `repos/${repo}/git/trees/${sha}`, "-f", "recursive=1"])).tree ?? []
+}
+
+async function index(run: Run, repo: string) {
+  const raw = json<Content>(await run(["api", `repos/${repo}/contents/eikons/index.json`, "-f", "ref=main"]))
+  return { sha: raw.sha, text: Buffer.from((raw.content ?? "").replace(/\s/g, ""), "base64").toString("utf8") }
+}
+
+async function pr(run: Run, repo: string, user: string, branch: string, name: string, body: string) {
+  try {
+    return await run(["pr", "create", "-R", repo, "-H", `${user}:${branch}`, "-B", "main", "-t", `eikons: delist ${name}`, "-b", body])
+  } catch {
+    const raw = await run(["pr", "list", "-R", repo, "--state", "open", "--head", `${user}:${branch}`, "--json", "url", "--limit", "1"])
+    const hit = json<Array<{ url?: string }>>(raw)[0]?.url
+    if (hit) return hit
+    throw new Error("GitHub PR creation failed")
+  }
+}
+
+export async function submit(entry: CatalogEntry, opts: Opts = {}): Promise<Result> {
+  const run = opts.run ?? gh
+  const repo = opts.repo ?? REPO
+  const own = await info(entry, { repo, run })
+  if (!own.eligible || !own.user) throw new Error(own.reason ?? "not authorized to delist this eikon")
+  await run(["repo", "fork", repo, "--clone=false"]).catch(() => "")
+  const fork = `${own.user}/${repo.split("/")[1]}`
+  const branch = `delist/${clean(entry.name)}`
+  const base = await main(run, repo)
+  await run(["api", "-X", "POST", `repos/${fork}/git/refs`, "-f", `ref=refs/heads/${branch}`, "-f", `sha=${base.sha}`]).catch(() => "")
+  const msg = `eikons: delist ${entry.name}`
+  const ix = await index(run, repo)
+  const next = json<Array<Record<string, unknown>>>(ix.text).filter(e => e.name !== entry.name && e.id !== entry.id)
+  await put(run, fork, branch, "eikons/index.json", `${JSON.stringify(next, null, 2)}\n`, msg)
+  for (const item of await tree(run, repo, base.tree)) {
+    if (!item.path || item.type !== "blob" || !item.sha || !touches(entry, item.path)) continue
+    const sha = await exists(run, fork, branch, item.path) ?? item.sha
+    await del(run, fork, branch, item.path, sha, msg)
+  }
+  const url = await pr(run, repo, own.user, branch, entry.name, `Requests delisting \`${entry.name}\` from the Eikon registry.`)
+  return { url, info: own }
+}
+
+export * as delistSvc from "./eikon-delist"

--- a/src/service/eikon-marketplace.ts
+++ b/src/service/eikon-marketplace.ts
@@ -4,6 +4,7 @@ import { basename, dirname, extname, join } from "node:path"
 import { downloadBytes, entries as packageEntries, type Catalog, type PublicCatalogEntry as CatalogEntry, type CatalogOptions, type DownloadOptions } from "eikon"
 import { loadCatalog, loadRuntimeArtifact, publicCatalogUrl, searchCatalog } from "eikon/catalog"
 import { eikon } from "./eikon"
+import * as delist from "./eikon-delist"
 import * as prefs from "../context/preferences"
 import { listEikons } from "../components/avatar/eikon"
 import { BUNDLED_EIKON_DIR } from "../components/avatar/bundled"
@@ -60,6 +61,8 @@ export type MarketplaceState = {
 export type MarketplaceOptions = CatalogOptions & {
   catalog?: string
   fetcher?: Fetcher
+  delistRepo?: string
+  delistRun?: delist.Run
   query?: string
   timeoutMs?: number
   previewCacheLimit?: number
@@ -406,6 +409,8 @@ export class MarketplaceService {
   private previewCacheLimit: number
   private concurrency: number
   private allowPrivate: boolean
+  private delistRepo?: string
+  private delistRun?: delist.Run
   private activeLoads = 0
   private queue: Job<string>[] = []
   private cache = new Map<string, string>()
@@ -418,6 +423,8 @@ export class MarketplaceService {
     this.previewCacheLimit = opts.previewCacheLimit ?? DEFAULT_CACHE_LIMIT
     this.concurrency = Math.max(1, Math.floor(opts.concurrency ?? 4))
     this.allowPrivate = opts.allowPrivate === true
+    this.delistRepo = opts.delistRepo
+    this.delistRun = opts.delistRun
   }
 
   rows(query = ""): MarketplaceRow[] {
@@ -471,6 +478,18 @@ export class MarketplaceService {
     const entry = this.entry(id)
     if (!entry) throw new Error(`marketplace: unknown eikon "${id}"`)
     return sizes(JSON.parse(dec.decode(await downloadBytes(entry.packageUrl, this.dl()))) as SizedPackage)
+  }
+
+  async delistInfo(id: string): Promise<delist.Info> {
+    const entry = this.entry(id)
+    if (!entry) throw new Error(`marketplace: unknown eikon "${id}"`)
+    return delist.info(entry, { repo: this.delistRepo, run: this.delistRun })
+  }
+
+  async delist(id: string): Promise<delist.Result> {
+    const entry = this.entry(id)
+    if (!entry) throw new Error(`marketplace: unknown eikon "${id}"`)
+    return delist.submit(entry, { repo: this.delistRepo, run: this.delistRun })
   }
 
   async install(id: string, opts: { media?: boolean; confirmActive?: boolean } = {}): Promise<MarketplaceInstall> {

--- a/src/service/eikon-marketplace.ts
+++ b/src/service/eikon-marketplace.ts
@@ -81,6 +81,7 @@ type Job<T> = {
 
 const DEFAULT_TIMEOUT = 5000
 const DEFAULT_CACHE_LIMIT = 24
+const OFFICIAL_CATALOG = "https://eikon.liftaris.dev/eikons"
 const dec = new TextDecoder()
 
 function hash(data: Uint8Array) {
@@ -409,6 +410,7 @@ export class MarketplaceService {
   private previewCacheLimit: number
   private concurrency: number
   private allowPrivate: boolean
+  private official: boolean
   private delistRepo?: string
   private delistRun?: delist.Run
   private activeLoads = 0
@@ -423,6 +425,7 @@ export class MarketplaceService {
     this.previewCacheLimit = opts.previewCacheLimit ?? DEFAULT_CACHE_LIMIT
     this.concurrency = Math.max(1, Math.floor(opts.concurrency ?? 4))
     this.allowPrivate = opts.allowPrivate === true
+    this.official = keyIdentity(publicCatalogUrl(opts.catalog ?? OFFICIAL_CATALOG, undefined, opts)) === keyIdentity(OFFICIAL_CATALOG)
     this.delistRepo = opts.delistRepo
     this.delistRun = opts.delistRun
   }
@@ -483,12 +486,14 @@ export class MarketplaceService {
   async delistInfo(id: string): Promise<delist.Info> {
     const entry = this.entry(id)
     if (!entry) throw new Error(`marketplace: unknown eikon "${id}"`)
+    if (!this.official) return { eligible: false, reason: "Registry delist is only available from the official Eikon catalog" }
     return delist.info(entry, { repo: this.delistRepo, run: this.delistRun })
   }
 
   async delist(id: string): Promise<delist.Result> {
     const entry = this.entry(id)
     if (!entry) throw new Error(`marketplace: unknown eikon "${id}"`)
+    if (!this.official) throw new Error("Registry delist is only available from the official Eikon catalog")
     return delist.submit(entry, { repo: this.delistRepo, run: this.delistRun })
   }
 

--- a/src/tabs/EikonMarketplace.tsx
+++ b/src/tabs/EikonMarketplace.tsx
@@ -158,6 +158,32 @@ export const EikonMarketplace = memo((props: {
     refreshMarket(svc, query)
   }, [dialog, query, refreshMarket, sel, state.rows, state.service, toast])
 
+  const delistSelected = useCallback(async (row: MarketplaceRow, svc: market.MarketplaceService) => {
+    let own: Awaited<ReturnType<typeof svc.delistInfo>>
+    try {
+      own = await svc.delistInfo(row.entry.identityKey)
+    } catch (err) {
+      toast.show({ variant: "error", title: "Delist check failed", message: err instanceof Error ? err.message : String(err), duration: 6000 })
+      return
+    }
+    if (!own.eligible) {
+      toast.show({ variant: "warning", title: "Delist unavailable", message: own.reason ?? "Only the original GitHub submitter can delist this eikon", duration: 6000 })
+      return
+    }
+    const ok = await openConfirm(dialog, {
+      title: `Delist '${row.entry.name}'?`, danger: true,
+      body: `This will open a GitHub delist request in liftaris/eikon for '${row.entry.name}'. The registry will remove it automatically after authorship is verified.`,
+      yes: "delist", no: "cancel",
+    })
+    if (!ok) return
+    try {
+      const out = await svc.delist(row.entry.identityKey)
+      toast.show({ variant: "success", title: "Delist requested", message: `${row.entry.name} will be removed automatically once GitHub verifies the request. ${out.url}`, duration: 8000 })
+    } catch (err) {
+      toast.show({ variant: "error", title: "Delist failed", message: err instanceof Error ? err.message : String(err), duration: 6000 })
+    }
+  }, [dialog, toast])
+
   const primary = useCallback((idx?: number) => {
     const row = state.rows[idx ?? sel]
     const svc = state.service
@@ -177,32 +203,7 @@ export const EikonMarketplace = memo((props: {
           return
         }
         if (pick === "delete") return removeSelected(idx)
-        if (pick === "delist") {
-          let own: Awaited<ReturnType<typeof svc.delistInfo>>
-          try {
-            own = await svc.delistInfo(row.entry.identityKey)
-          } catch (err) {
-            toast.show({ variant: "error", title: "Delist check failed", message: err instanceof Error ? err.message : String(err), duration: 6000 })
-            return
-          }
-          if (!own.eligible) {
-            toast.show({ variant: "warning", title: "Delist unavailable", message: own.reason ?? "Only the original GitHub submitter can delist this eikon", duration: 6000 })
-            return
-          }
-          const ok = await openConfirm(dialog, {
-            title: `Delist '${row.entry.name}'?`, danger: true,
-            body: `This will open a GitHub delist request for '${row.entry.name}'. The registry will remove it automatically after authorship is verified.`,
-            yes: "delist", no: "cancel",
-          })
-          if (!ok) return
-          try {
-            const out = await svc.delist(row.entry.identityKey)
-            toast.show({ variant: "success", title: "Delist requested", message: `${row.entry.name} will be removed automatically once GitHub verifies the request. ${out.url}`, duration: 8000 })
-          } catch (err) {
-            toast.show({ variant: "error", title: "Delist failed", message: err instanceof Error ? err.message : String(err), duration: 6000 })
-          }
-          return
-        }
+        if (pick === "delist") return delistSelected(row, svc)
         setInstalling(true)
         try {
           const confirm = row.installState === "active-name-conflict"
@@ -228,7 +229,7 @@ export const EikonMarketplace = memo((props: {
       }
     }
     void run()
-  }, [dialog, state.rows, state.service, sel, acting, toast, refreshMarket, query, removeSelected])
+  }, [dialog, state.rows, state.service, sel, acting, toast, refreshMarket, query, removeSelected, delistSelected])
 
   useKeyboard(key => {
     if (!props.focused || dialog.open()) return

--- a/src/tabs/EikonMarketplace.tsx
+++ b/src/tabs/EikonMarketplace.tsx
@@ -177,6 +177,26 @@ export const EikonMarketplace = memo((props: {
           return
         }
         if (pick === "delete") return removeSelected(idx)
+        if (pick === "delist") {
+          const own = await svc.delistInfo(row.entry.identityKey)
+          if (!own.eligible) {
+            toast.show({ variant: "warning", title: "Delist unavailable", message: own.reason ?? "Only the original GitHub submitter can delist this eikon", duration: 6000 })
+            return
+          }
+          const ok = await openConfirm(dialog, {
+            title: `Delist '${row.entry.name}'?`, danger: true,
+            body: `This will open a GitHub delist request for '${row.entry.name}'. The registry will remove it automatically after authorship is verified.`,
+            yes: "delist", no: "cancel",
+          })
+          if (!ok) return
+          try {
+            const out = await svc.delist(row.entry.identityKey)
+            toast.show({ variant: "success", title: "Delist requested", message: `${row.entry.name} will be removed automatically once GitHub verifies the request. ${out.url}`, duration: 8000 })
+          } catch (err) {
+            toast.show({ variant: "error", title: "Delist failed", message: err instanceof Error ? err.message : String(err), duration: 6000 })
+          }
+          return
+        }
         setInstalling(true)
         try {
           const confirm = row.installState === "active-name-conflict"

--- a/src/tabs/EikonMarketplace.tsx
+++ b/src/tabs/EikonMarketplace.tsx
@@ -178,7 +178,13 @@ export const EikonMarketplace = memo((props: {
         }
         if (pick === "delete") return removeSelected(idx)
         if (pick === "delist") {
-          const own = await svc.delistInfo(row.entry.identityKey)
+          let own: Awaited<ReturnType<typeof svc.delistInfo>>
+          try {
+            own = await svc.delistInfo(row.entry.identityKey)
+          } catch (err) {
+            toast.show({ variant: "error", title: "Delist check failed", message: err instanceof Error ? err.message : String(err), duration: 6000 })
+            return
+          }
           if (!own.eligible) {
             toast.show({ variant: "warning", title: "Delist unavailable", message: own.reason ?? "Only the original GitHub submitter can delist this eikon", duration: 6000 })
             return

--- a/test/eikon-cli.test.ts
+++ b/test/eikon-cli.test.ts
@@ -74,6 +74,7 @@ function deps(overrides: Partial<EikonCliDeps> = {}): EikonCliDeps {
     info: name => ({ ...item(name).lifecycle, active: overrides.getActive?.() === name || active === name }),
     update: async name => ({ name, sources: {}, n: 1, bytes: 42 }),
     remove: () => undefined,
+    delist: async target => ({ url: `https://github.com/liftaris/eikon/pull/${target}`, info: { eligible: true } }),
     list: () => [item()],
     baked: name => name === "ares" ? "/tmp/ares/ares.eikon" : undefined,
     has: name => name === "ares",
@@ -93,6 +94,7 @@ describe("eikon headless CLI", () => {
     expect(await handleEikonCli(["eikon", "--help"], deps(), c.io)).toBe(0)
     expect(c.stdout()).toContain("herm eikon install <name|url|dir>")
     expect(EIKON_CLI_USAGE).toContain("herm eikon use <name>")
+    expect(EIKON_CLI_USAGE).toContain("herm eikon delist <name|id>")
   })
 
   test("install passes name/media options, emits json, and can skip activation", async () => {
@@ -166,6 +168,26 @@ describe("eikon headless CLI", () => {
     const b = capture()
     expect(await handleEikonCli(["eikon", "browse", "--json"], deps(), b.io)).toBe(0)
     expect(JSON.parse(b.stdout()).eikons[0].name).toBe("ares")
+  })
+
+  test("delist requests official registry removal", async () => {
+    const calls: string[] = []
+    const c = capture()
+
+    expect(await handleEikonCli(["eikon", "delist", "ares", "--json"], deps({
+      delist: async target => { calls.push(target); return { url: "https://github.com/liftaris/eikon/pull/99", info: { eligible: true, user: "liftaris" } } },
+    }), c.io)).toBe(0)
+
+    expect(calls).toEqual(["ares"])
+    expect(JSON.parse(c.stdout())).toEqual({ ok: true, url: "https://github.com/liftaris/eikon/pull/99", info: { eligible: true, user: "liftaris" } })
+  })
+
+  test("delist requires a target", async () => {
+    const c = capture()
+
+    expect(await handleEikonCli(["eikon", "delist", "--json"], deps(), c.io)).toBe(1)
+
+    expect(JSON.parse(c.stderr())).toEqual({ ok: false, error: "usage: herm eikon delist <name|id>" })
   })
 
   test("inspect and info expose source, compatibility, trust, and state", async () => {

--- a/test/eikon-delist.test.ts
+++ b/test/eikon-delist.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test"
+import type { PublicCatalogEntry } from "eikon"
+import * as delist from "../src/service/eikon-delist"
+
+const entry = {
+  kind: "eikon.catalog.entry",
+  schemaVersion: "1.0",
+  id: "liftaris/ovo",
+  version: "1.0.0",
+  sourceKey: "registry:eikon.liftaris.dev:liftaris/ovo@1.0.0",
+  name: "ovo",
+  title: "ovo",
+  author: "kaio",
+  poster: "",
+  runtimeUrl: "https://eikon.liftaris.dev/packages/liftaris/ovo/blobs/sha256/abc",
+  packageUrl: "https://eikon.liftaris.dev/packages/liftaris/ovo/1.0.0.json",
+  compatibility: { eikon: ">=1 <2", available: true },
+  trust: {},
+  w: 48,
+  h: 24,
+  width: 48,
+  height: 24,
+  identityKey: "registry:eikon.liftaris.dev:liftaris/ovo@1.0.0",
+  raw: { name: "ovo" },
+} satisfies PublicCatalogEntry
+
+function b64(text: string) {
+  return Buffer.from(text).toString("base64")
+}
+
+function run(opts: { user?: string; submitter?: string } = {}) {
+  const calls: Array<{ args: string[]; input?: string }> = []
+  const user = opts.user ?? "liftaris"
+  const submitter = opts.submitter ?? "liftaris"
+  const fn: delist.Run = async (args, input) => {
+    calls.push({ args, input })
+    const key = args.join(" ")
+    if (key === "api user -q .login") return user
+    if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("merged"))
+      return JSON.stringify([{ number: 25, title: "eikons: submit ovo", headRefName: "submit/ovo", author: { login: submitter }, url: "https://github.com/liftaris/eikon/pull/25" }])
+    if (args[0] === "pr" && args[1] === "view" && args[2] === "25")
+      return JSON.stringify({ files: [{ path: "eikons/ovo/ovo.eikon" }, { path: "eikons/ovo/manifest.json" }, { path: "packages/liftaris/ovo/1.0.0.json" }] })
+    if (args[0] === "repo") return ""
+    if (key === "api repos/liftaris/eikon/git/ref/heads/main -q .object.sha") return "main-sha"
+    if (key === "api repos/liftaris/eikon/git/commits/main-sha -q .tree.sha") return "tree-sha"
+    if (args[0] === "api" && args[3] === "repos/liftaris/eikon/git/refs") return ""
+    if (key === "api repos/liftaris/eikon/contents/eikons/index.json -f ref=main")
+      return JSON.stringify({ sha: "index-main", content: b64(JSON.stringify([entry])) })
+    if (key === "api repos/liftaris/eikon/git/trees/tree-sha -f recursive=1")
+      return JSON.stringify({ tree: [
+        { path: "eikons/ovo/ovo.eikon", type: "blob", sha: "runtime-sha" },
+        { path: "eikons/ovo/manifest.json", type: "blob", sha: "manifest-sha" },
+        { path: "packages/liftaris/ovo/1.0.0.json", type: "blob", sha: "pkg-sha" },
+      ] })
+    if (args[0] === "api" && args[1] === "-X" && args[2] === "GET" && args[4] === "-f")
+      return JSON.stringify({ sha: `${args[3]!.split("/").pop()}-branch-sha` })
+    if (args[0] === "api" && args[1] === "-X" && (args[2] === "PUT" || args[2] === "DELETE")) return ""
+    if (args[0] === "pr" && args[1] === "create") return "https://github.com/liftaris/eikon/pull/99"
+    throw new Error(`unexpected ${key}`)
+  }
+  return { fn, calls }
+}
+
+describe("eikon delist service", () => {
+  test("author eligibility follows original merged submission PR author", async () => {
+    expect(await delist.info(entry, { run: run().fn })).toMatchObject({ eligible: true, user: "liftaris", author: "liftaris", pr: 25 })
+    expect(await delist.info(entry, { run: run({ user: "other" }).fn })).toMatchObject({ eligible: false, user: "other", author: "liftaris" })
+  })
+
+  test("submit creates a destination deletion PR", async () => {
+    const mock = run()
+    const out = await delist.submit(entry, { run: mock.fn })
+    const puts = mock.calls.filter(c => c.args[2] === "PUT")
+    const dels = mock.calls.filter(c => c.args[2] === "DELETE")
+
+    expect(out.url).toBe("https://github.com/liftaris/eikon/pull/99")
+    expect(puts).toHaveLength(1)
+    expect(JSON.parse(puts[0]!.input!).content).toBe(b64("[]\n"))
+    expect(dels.map(c => c.args[3])).toEqual([
+      "repos/liftaris/eikon/contents/eikons/ovo/ovo.eikon",
+      "repos/liftaris/eikon/contents/eikons/ovo/manifest.json",
+      "repos/liftaris/eikon/contents/packages/liftaris/ovo/1.0.0.json",
+    ])
+  })
+})

--- a/test/eikon-delist.test.ts
+++ b/test/eikon-delist.test.ts
@@ -28,7 +28,7 @@ function b64(text: string) {
   return Buffer.from(text).toString("base64")
 }
 
-function run(opts: { user?: string; submitter?: string; createFails?: boolean } = {}) {
+function run(opts: { user?: string; submitter?: string; createFails?: boolean; branchExists?: boolean } = {}) {
   const calls: Array<{ args: string[]; input?: string }> = []
   const user = opts.user ?? "liftaris"
   const submitter = opts.submitter ?? "liftaris"
@@ -37,13 +37,17 @@ function run(opts: { user?: string; submitter?: string; createFails?: boolean } 
     const key = args.join(" ")
     if (key === "api user -q .login") return user
     if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("merged"))
-      return JSON.stringify([{ number: 25, title: "eikons: submit ovo", headRefName: "submit/ovo", author: { login: submitter }, url: "https://github.com/liftaris/eikon/pull/25" }])
-    if (args[0] === "pr" && args[1] === "view" && args[2] === "25")
-      return JSON.stringify({ files: [{ path: "eikons/ovo/ovo.eikon" }, { path: "eikons/ovo/manifest.json" }, { path: "packages/liftaris/ovo/1.0.0.json" }] })
+      return JSON.stringify([{ number: 25, title: "eikons: submit ovo", headRefName: "submit/ovo", mergedAt: "2026-06-01T00:00:00Z", author: { login: submitter }, url: "https://github.com/liftaris/eikon/pull/25" }])
+    if (key === "api --paginate -X GET repos/liftaris/eikon/pulls/25/files --jq .[].filename")
+      return "eikons/ovo/ovo.eikon\neikons/ovo/manifest.json\npackages/liftaris/ovo/1.0.0.json\n"
     if (args[0] === "repo") return ""
     if (key === "api repos/liftaris/eikon/git/ref/heads/main -q .object.sha") return "main-sha"
     if (key === "api repos/liftaris/eikon/git/commits/main-sha -q .tree.sha") return "tree-sha"
-    if (args[0] === "api" && args[3] === "repos/liftaris/eikon/git/refs") return ""
+    if (args[0] === "api" && args[3] === "repos/liftaris/eikon/git/refs") {
+      if (opts.branchExists) throw new Error("exists")
+      return ""
+    }
+    if (args[0] === "api" && args[2] === "PATCH") return ""
     if (key === "api -X GET repos/liftaris/eikon/contents/eikons/index.json -f ref=main")
       return JSON.stringify({ sha: "index-main", content: b64(JSON.stringify([entry])) })
     if (key === "api -X GET repos/liftaris/eikon/git/trees/tree-sha -f recursive=1")
@@ -66,9 +70,35 @@ function run(opts: { user?: string; submitter?: string; createFails?: boolean } 
 }
 
 describe("eikon delist service", () => {
+  test("rejects non-official catalog entries before GitHub lookup", async () => {
+    const calls: string[][] = []
+    const fake = { ...entry, sourceKey: "http://localhost/eikons/ovo/", identityKey: "http://localhost/eikons/ovo/", packageUrl: "http://localhost/eikons/ovo/manifest.json" }
+    const out = await delist.info(fake, { run: async args => { calls.push(args); return "" } })
+
+    expect(out).toMatchObject({ eligible: false, reason: "Registry delist is only available for official Eikon catalog entries" })
+    expect(calls).toEqual([])
+  })
+
   test("author eligibility follows original merged submission PR author", async () => {
     expect(await delist.info(entry, { run: run().fn })).toMatchObject({ eligible: true, user: "liftaris", author: "liftaris", pr: 25 })
     expect(await delist.info(entry, { run: run({ user: "other" }).fn })).toMatchObject({ eligible: false, user: "other", author: "liftaris" })
+  })
+
+  test("submitter lookup requires exact submit PR metadata and picks the oldest match", async () => {
+    const fn: delist.Run = async args => {
+      const key = args.join(" ")
+      if (key === "api user -q .login") return "liftaris"
+      if (args[0] === "pr" && args[1] === "list") return JSON.stringify([
+        { number: 30, title: "eikons: submit ovo", headRefName: "submit/ovo", mergedAt: "2026-06-10T00:00:00Z", author: { login: "other" }, url: "new" },
+        { number: 20, title: "eikons: submit ovo", headRefName: "submit/ovo", mergedAt: "2026-06-01T00:00:00Z", author: { login: "liftaris" }, url: "old" },
+        { number: 10, title: "eikons: submit ovo", headRefName: "misc/ovo", mergedAt: "2026-05-01T00:00:00Z", author: { login: "wrong" }, url: "wrong" },
+      ])
+      if (key === "api --paginate -X GET repos/liftaris/eikon/pulls/20/files --jq .[].filename") return "eikons/ovo/manifest.json\n"
+      if (key === "api --paginate -X GET repos/liftaris/eikon/pulls/30/files --jq .[].filename") return "eikons/ovo/manifest.json\n"
+      throw new Error(`unexpected ${key}`)
+    }
+
+    expect(await delist.info(entry, { run: fn })).toMatchObject({ eligible: true, author: "liftaris", pr: 20 })
   })
 
   test("submit creates a destination deletion PR", async () => {
@@ -87,6 +117,16 @@ describe("eikon delist service", () => {
     ])
     expect(mock.calls.some(c => c.args.join(" ") === "api -X GET repos/liftaris/eikon/contents/eikons/index.json -f ref=main")).toBe(true)
     expect(mock.calls.some(c => c.args.join(" ") === "api -X GET repos/liftaris/eikon/git/trees/tree-sha -f recursive=1")).toBe(true)
+  })
+
+  test("submit resets an existing delist branch to current main before writing", async () => {
+    const mock = run({ branchExists: true })
+
+    await delist.submit(entry, { run: mock.fn })
+
+    const patch = mock.calls.find(c => c.args.join(" ") === "api -X PATCH repos/liftaris/eikon/git/refs/heads/delist/ovo --input -")
+    expect(patch).toBeDefined()
+    expect(JSON.parse(patch!.input!)).toEqual({ sha: "main-sha", force: true })
   })
 
   test("submit returns an existing delist PR when create reports one", async () => {

--- a/test/eikon-delist.test.ts
+++ b/test/eikon-delist.test.ts
@@ -28,7 +28,7 @@ function b64(text: string) {
   return Buffer.from(text).toString("base64")
 }
 
-function run(opts: { user?: string; submitter?: string } = {}) {
+function run(opts: { user?: string; submitter?: string; createFails?: boolean } = {}) {
   const calls: Array<{ args: string[]; input?: string }> = []
   const user = opts.user ?? "liftaris"
   const submitter = opts.submitter ?? "liftaris"
@@ -44,18 +44,22 @@ function run(opts: { user?: string; submitter?: string } = {}) {
     if (key === "api repos/liftaris/eikon/git/ref/heads/main -q .object.sha") return "main-sha"
     if (key === "api repos/liftaris/eikon/git/commits/main-sha -q .tree.sha") return "tree-sha"
     if (args[0] === "api" && args[3] === "repos/liftaris/eikon/git/refs") return ""
-    if (key === "api repos/liftaris/eikon/contents/eikons/index.json -f ref=main")
+    if (key === "api -X GET repos/liftaris/eikon/contents/eikons/index.json -f ref=main")
       return JSON.stringify({ sha: "index-main", content: b64(JSON.stringify([entry])) })
-    if (key === "api repos/liftaris/eikon/git/trees/tree-sha -f recursive=1")
+    if (key === "api -X GET repos/liftaris/eikon/git/trees/tree-sha -f recursive=1")
       return JSON.stringify({ tree: [
         { path: "eikons/ovo/ovo.eikon", type: "blob", sha: "runtime-sha" },
         { path: "eikons/ovo/manifest.json", type: "blob", sha: "manifest-sha" },
         { path: "packages/liftaris/ovo/1.0.0.json", type: "blob", sha: "pkg-sha" },
       ] })
+    if (key === "api -X GET repos/liftaris/eikon/pulls -f state=open -f head=liftaris:delist/ovo") return opts.createFails ? JSON.stringify([{ url: "https://github.com/liftaris/eikon/pull/98" }]) : "[]"
     if (args[0] === "api" && args[1] === "-X" && args[2] === "GET" && args[4] === "-f")
       return JSON.stringify({ sha: `${args[3]!.split("/").pop()}-branch-sha` })
     if (args[0] === "api" && args[1] === "-X" && (args[2] === "PUT" || args[2] === "DELETE")) return ""
-    if (args[0] === "pr" && args[1] === "create") return "https://github.com/liftaris/eikon/pull/99"
+    if (args[0] === "pr" && args[1] === "create") {
+      if (opts.createFails) throw new Error("already exists")
+      return "https://github.com/liftaris/eikon/pull/99"
+    }
     throw new Error(`unexpected ${key}`)
   }
   return { fn, calls }
@@ -81,5 +85,16 @@ describe("eikon delist service", () => {
       "repos/liftaris/eikon/contents/eikons/ovo/manifest.json",
       "repos/liftaris/eikon/contents/packages/liftaris/ovo/1.0.0.json",
     ])
+    expect(mock.calls.some(c => c.args.join(" ") === "api -X GET repos/liftaris/eikon/contents/eikons/index.json -f ref=main")).toBe(true)
+    expect(mock.calls.some(c => c.args.join(" ") === "api -X GET repos/liftaris/eikon/git/trees/tree-sha -f recursive=1")).toBe(true)
+  })
+
+  test("submit returns an existing delist PR when create reports one", async () => {
+    const mock = run({ createFails: true })
+
+    const out = await delist.submit(entry, { run: mock.fn })
+
+    expect(out.url).toBe("https://github.com/liftaris/eikon/pull/98")
+    expect(mock.calls.some(c => c.args.join(" ") === "api -X GET repos/liftaris/eikon/pulls -f state=open -f head=liftaris:delist/ovo")).toBe(true)
   })
 })

--- a/test/eikon-marketplace-ui.test.tsx
+++ b/test/eikon-marketplace-ui.test.tsx
@@ -35,7 +35,7 @@ const servers = new Set<ReturnType<typeof Bun.serve>>()
 const baseTestPerf = process.env.HERM_TEST_PERF
 const baseAvatarTimerStarts = globalThis.__hermAvatarTimerStarts
 
-type Route = { path: string; body: BodyInit | object | (() => Response | Promise<Response>); status?: number; headers?: HeadersInit }
+type Route = { path: string; body: BodyInit | object | ((req?: Request) => Response | Promise<Response> | BodyInit | object); status?: number; headers?: HeadersInit }
 
 function serve(routes: Route[]) {
   const srv = Bun.serve({
@@ -44,7 +44,10 @@ function serve(routes: Route[]) {
       const path = new URL(req.url).pathname
       const hit = routes.findLast(r => r.path === path)
       if (!hit) return new Response("404", { status: 404 })
-      if (typeof hit.body === "function") return hit.body()
+      if (typeof hit.body === "function") {
+        const out = hit.body(req)
+        return out instanceof Response || out instanceof Promise ? out as Response | Promise<Response> : typeof out === "object" && !(out instanceof Uint8Array) ? Response.json(out, { status: hit.status ?? 200, headers: hit.headers }) : new Response(out as BodyInit, { status: hit.status ?? 200, headers: hit.headers })
+      }
       if (typeof hit.body === "object" && !(hit.body instanceof Uint8Array))
         return Response.json(hit.body, { status: hit.status ?? 200, headers: hit.headers })
       return new Response(hit.body as BodyInit, { status: hit.status ?? 200, headers: hit.headers })
@@ -279,6 +282,27 @@ describe("EikonMarketplace tab", () => {
     await until(t, () => t.frame().includes("Catalog (6)") && t.frame().includes("ARES-IDLE"))
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Eikon only") && t.frame().includes("Delist from Registry"))
+    fx.srv.stop()
+  })
+
+  test("incompatible catalog action still includes registry delist", async () => {
+    const fx = catalog([{ path: "/eikons/index.json", body: req => {
+      const base = `${new URL(req!.url).origin}/eikons/`
+      return [
+        {
+          kind: "eikon.catalog.entry", schemaVersion: "1.0", id: "liftaris/ares", name: "ares", version: "1.0.0",
+          sourceKey: "registry:eikon.liftaris.dev:liftaris/ares@1.0.0", title: "ares", author: "Kaio", poster: "ARES-POSTER",
+          runtimeUrl: `${base}ares/ares.eikon`, packageUrl: `${base}ares/manifest.json`, description: "red warrior",
+          compatibility: { eikon: ">=1 <2", available: false, reason: "future runtime" }, trust: {},
+        },
+      ]
+    } }])
+    process.env.EIKON_URL = fx.base
+    await using t = await mountNode(group(), { width: 160, height: 48 })
+    await until(t, () => t.frame().includes("Catalog (1)") && t.frame().includes("future runtime"))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Delist from Registry"))
+    expect(t.frame()).not.toContain("Eikon only")
     fx.srv.stop()
   })
 

--- a/test/eikon-marketplace-ui.test.tsx
+++ b/test/eikon-marketplace-ui.test.tsx
@@ -272,6 +272,16 @@ describe("EikonMarketplace tab", () => {
     fx.srv.stop()
   })
 
+  test("available catalog action includes registry delist", async () => {
+    const fx = catalog()
+    process.env.EIKON_URL = fx.base
+    await using t = await mountNode(group(), { width: 160, height: 48 })
+    await until(t, () => t.frame().includes("Catalog (6)") && t.frame().includes("ARES-IDLE"))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Eikon only") && t.frame().includes("Delist from Registry"))
+    fx.srv.stop()
+  })
+
   test("slash enters search without leaving the tab", async () => {
     const fx = catalog()
     process.env.EIKON_URL = fx.base

--- a/test/eikon-marketplace.test.ts
+++ b/test/eikon-marketplace.test.ts
@@ -194,6 +194,18 @@ describe("service/eikon-marketplace", () => {
     srv.stop()
   })
 
+  test("custom catalogs cannot target official registry delist", async () => {
+    const fx = fixture()
+    const calls: string[][] = []
+    const state = await market.load({ catalog: fx.base, allowPrivate: true, delistRun: async args => { calls.push(args); return "" } })
+    const row = state.rows[0]!
+
+    await expect(state.service!.delist(row.entry.identityKey)).rejects.toThrow(/official Eikon catalog/)
+    expect(await state.service!.delistInfo(row.entry.identityKey)).toMatchObject({ eligible: false, reason: "Registry delist is only available from the official Eikon catalog" })
+    expect(calls).toEqual([])
+    fx.srv.stop()
+  })
+
   test("maps installed and active state by catalog identity before name fallback", async () => {
     const fx = fixture()
     eikon.ensure("ares")


### PR DESCRIPTION
## Summary

- Add Catalog and headless CLI paths for `Delist from Registry`.
- Check GitHub provenance before delisting: the active GitHub user must match the author of the original merged `eikons: submit <name>` PR that added the registry files.
- Open a delist PR that removes the Eikon registry files and removes the entry from `eikons/index.json`; the Eikon registry workflow handles automatic merge after validation.
- Keep local delete behavior separate from registry delist behavior.
- Harden the request path: paginated PR file scans, exact oldest submit PR matching, stale branch reset, official-catalog gating, GitHub API GET reads, existing-PR lookup via REST head filter, and UI error handling.

## Review notes

- Eikon registry auto-merge support landed in `liftaris/eikon#26`.
- Eikon workflow hardening landed in `liftaris/eikon#27`: valid delist PRs are merged only at the exact validated head SHA, and index changes must only remove the target eikon.

## Verification

- `bun test test/eikon-delist.test.ts test/eikon-marketplace.test.ts test/eikon-cli.test.ts test/eikon-marketplace-ui.test.tsx`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
