### PR TITLE
polish: clarify eikon actions and chat chrome

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -46,7 +46,7 @@ function mix(a: RGBA, b: RGBA, n = 0.5): RGBA {
 }
 
 function darken(c: RGBA, n = 0.35): RGBA {
-  return RGBA.fromValues(c.r * (1 - n), c.g * (1 - n), c.b * (1 - n), c.a)
+  return RGBA.fromValues(c.r * n, c.g * n, c.b * n, c.a)
 }
 
 const TOP_RULE = {

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -49,6 +49,10 @@ function darken(c: RGBA, n = 0.95): RGBA {
   return RGBA.fromValues(c.r * n, c.g * n, c.b * n, c.a)
 }
 
+function lighten(c: RGBA, n = 0.05): RGBA {
+  return RGBA.fromValues(c.r + (1 - c.r) * n, c.g + (1 - c.g) * n, c.b + (1 - c.b) * n, c.a)
+}
+
 const TOP_RULE = {
   topLeft: "▔", topRight: "▔", horizontal: "▔",
   bottomLeft: "", bottomRight: "", vertical: "",
@@ -143,8 +147,8 @@ const UserMessage = memo(({ message, onRewind }: { message: Message; onRewind?: 
   const [hover, setHover] = useState(false)
   const click = useClick(onRewind && (() => onRewind(message)))
   const fill = useMemo(
-    () => mix(theme.background, theme.backgroundElement),
-    [theme.background, theme.backgroundElement],
+    () => ctx.mode === "dark" ? mix(theme.background, theme.backgroundElement) : darken(theme.backgroundElement),
+    [ctx.mode, theme.background, theme.backgroundElement],
   )
   const edge = useMemo(
     () => ctx.mode === "dark" ? darken(theme.background) : darken(theme.backgroundElement),
@@ -200,6 +204,10 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
   const { agentName } = useSkin()
   const [hover, setHover] = useState(false)
   const click = useClick(onPick && (() => onPick(message)))
+  const rail = useMemo(
+    () => ctx.mode === "dark" ? lighten(theme.background) : darken(theme.backgroundElement),
+    [ctx.mode, theme.background, theme.backgroundElement],
+  )
   const err = !!message.error
   const trail = message.parts.filter((p): p is ToolPart | PromptPart =>
     p.type === "tool" || p.type === "prompt")
@@ -285,7 +293,7 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
       </box>
       <box width={3} flexShrink={0} flexDirection="row">
         <box width={2} />
-        <box width={1} backgroundColor={hover ? theme.backgroundElement : undefined} />
+        <box width={1} backgroundColor={hover ? rail : undefined} />
       </box>
     </box>
   )

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -45,6 +45,10 @@ function mix(a: RGBA, b: RGBA, n = 0.5): RGBA {
   )
 }
 
+function darken(c: RGBA, n = 0.35): RGBA {
+  return RGBA.fromValues(c.r * (1 - n), c.g * (1 - n), c.b * (1 - n), c.a)
+}
+
 const TOP_RULE = {
   topLeft: "▔", topRight: "▔", horizontal: "▔",
   bottomLeft: "", bottomRight: "", vertical: "",
@@ -134,12 +138,17 @@ const SystemMessage = memo(({ message }: { message: Message }) => {
 })
 
 const UserMessage = memo(({ message, onRewind }: { message: Message; onRewind?: (m: Message) => void }) => {
-  const theme = useTheme().theme
+  const ctx = useTheme()
+  const theme = ctx.theme
   const [hover, setHover] = useState(false)
   const click = useClick(onRewind && (() => onRewind(message)))
-  const rule = useMemo(
+  const fill = useMemo(
     () => mix(theme.background, theme.backgroundElement),
     [theme.background, theme.backgroundElement],
+  )
+  const edge = useMemo(
+    () => ctx.mode === "dark" ? darken(theme.background) : fill,
+    [ctx.mode, theme.background, fill],
   )
   const segs = useMemo(
     () => message.parts.map(p => p.type === "text" && p.content ? splitContent(p.content) : null),
@@ -151,8 +160,8 @@ const UserMessage = memo(({ message, onRewind }: { message: Message; onRewind?: 
       marginBottom={1}
     >
       <box height={1} border={["bottom"]} customBorderChars={BOTTOM_RULE}
-           borderColor={rule} />
-      <box backgroundColor={hover ? rule : theme.backgroundElement}
+           borderColor={edge} />
+      <box backgroundColor={hover ? fill : theme.backgroundElement}
            paddingLeft={1} paddingRight={1} paddingY={1} flexDirection="column" minHeight={1}
            onMouseOver={() => setHover(true)}
            onMouseOut={() => setHover(false)}
@@ -178,7 +187,7 @@ const UserMessage = memo(({ message, onRewind }: { message: Message; onRewind?: 
         })}
       </box>
       <box height={1} border={["top"]} customBorderChars={TOP_RULE}
-           borderColor={rule} />
+           borderColor={edge} />
     </box>
   )
 })

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -45,7 +45,7 @@ function mix(a: RGBA, b: RGBA, n = 0.5): RGBA {
   )
 }
 
-function darken(c: RGBA, n = 0.35): RGBA {
+function darken(c: RGBA, n = 0.95): RGBA {
   return RGBA.fromValues(c.r * n, c.g * n, c.b * n, c.a)
 }
 
@@ -147,8 +147,8 @@ const UserMessage = memo(({ message, onRewind }: { message: Message; onRewind?: 
     [theme.background, theme.backgroundElement],
   )
   const edge = useMemo(
-    () => ctx.mode === "dark" ? darken(theme.background) : fill,
-    [ctx.mode, theme.background, fill],
+    () => ctx.mode === "dark" ? darken(theme.background) : darken(theme.backgroundElement),
+    [ctx.mode, theme.background, theme.backgroundElement],
   )
   const segs = useMemo(
     () => message.parts.map(p => p.type === "text" && p.content ? splitContent(p.content) : null),
@@ -270,7 +270,6 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
          onMouseOver={() => setHover(true)}
          onMouseOut={() => setHover(false)}
          {...click}>
-      <box width={3} flexShrink={0} backgroundColor={hover ? theme.backgroundElement : undefined} />
       <box flexDirection="column" flexGrow={1} flexShrink={1}>
         <box height={1} flexDirection="row">
           <box flexGrow={1}><text fg={theme.textMuted}>{header}</text></box>
@@ -283,6 +282,10 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
         {message.parts.map(part)}
         {diffs.length ? <DiffTabs tools={diffs} /> : null}
         {err ? <ErrorBlock text={message.error!} /> : null}
+      </box>
+      <box width={3} flexShrink={0} flexDirection="row">
+        <box width={2} />
+        <box width={1} backgroundColor={hover ? theme.backgroundElement : undefined} />
       </box>
     </box>
   )

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -32,8 +32,6 @@ export const MessageList = memo(({ messages, streaming, prompt, onRewind, onPick
 
   const last = messages[messages.length - 1]
   const lastStreaming = streaming && last?.role === "assistant"
-  const firstUser = messages.findIndex(m => m.role === "user")
-
   return (
     <scrollbox
       flexGrow={1}
@@ -45,9 +43,6 @@ export const MessageList = memo(({ messages, streaming, prompt, onRewind, onPick
       <box flexDirection="column" paddingBottom={1}>
         {messages.map((msg, i) => (
           <box key={msg.id} flexDirection="column">
-            {msg.role === "user" && i > firstUser ? (
-              <box height={1}><text fg={theme.borderSubtle}>───</text></box>
-            ) : null}
             <MessageItem
               message={msg}
               streaming={lastStreaming && i === messages.length - 1}

--- a/src/dialogs/eikon-marketplace-action.tsx
+++ b/src/dialogs/eikon-marketplace-action.tsx
@@ -16,18 +16,18 @@ const fmt = (n?: number) => n == null ? "size unknown" : n < 1024 ? `${n} B` : n
 
 const choices = (row: MarketplaceRow, sizes?: MarketplaceSizes): Opt[] => {
   if (row.installState === "incompatible" || row.installState === "mismatch") return [
-    { label: "Delist from Registry", hint: "opens an automatic GitHub delist request for the original submitter", value: "delist" },
+    { label: "Delist from Registry", value: "delist" },
   ]
   if (!row.installed) return [
     { label: "Eikon only", hint: fmt(sizes?.eikon), value: "install" },
     { label: "Eikon + Source", hint: `${fmt((sizes?.eikon ?? 0) + (sizes?.source ?? 0))} · Source files needed to edit Eikon in Studio`, value: "source" },
-    { label: "Delist from Registry", hint: "opens an automatic GitHub delist request for the original submitter", value: "delist" },
+    { label: "Delist from Registry", value: "delist" },
   ]
   return [
     ...(!row.active ? [{ label: "Use", hint: "set as active avatar", value: "use" as const }] : []),
     ...(row.sourceDownloadable ? [{ label: "Download Source", hint: "needed to edit in Studio", value: "download" as const }] : []),
-    ...(row.removable ? [{ label: "Delete", value: "delete" as const }] : []),
-    { label: "Delist from Registry", hint: "opens an automatic GitHub delist request for the original submitter", value: "delist" as const },
+    ...(row.removable ? [{ label: "Uninstall", value: "delete" as const }] : []),
+    { label: "Delist from Registry", value: "delist" as const },
   ]
 }
 

--- a/test/eikon-marketplace-ui.test.tsx
+++ b/test/eikon-marketplace-ui.test.tsx
@@ -282,6 +282,7 @@ describe("EikonMarketplace tab", () => {
     await until(t, () => t.frame().includes("Catalog (6)") && t.frame().includes("ARES-IDLE"))
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("Eikon only") && t.frame().includes("Delist from Registry"))
+    expect(t.frame()).not.toContain("opens an automatic")
     fx.srv.stop()
   })
 
@@ -453,7 +454,7 @@ describe("EikonMarketplace tab", () => {
     await until(t, () => prefs.get("eikon") === "mono" && t.frame().includes("▸ ● mono"))
 
     act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Download Source") && t.frame().includes("Delete"))
+    await until(t, () => t.frame().includes("Download Source") && t.frame().includes("Uninstall"))
     expect(t.frame()).not.toContain("already active")
     expect(t.frame()).not.toContain("asks before removing")
     act(() => t.keys.pressEnter())
@@ -474,11 +475,11 @@ describe("EikonMarketplace tab", () => {
     await until(t, () => t.frame().includes("installed") && t.frame().includes("removable"))
 
     act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Use") && t.frame().includes("Delete"))
+    await until(t, () => t.frame().includes("Use") && t.frame().includes("Uninstall"))
     expect(t.frame()).not.toContain("Download Source")
     act(() => t.keys.pressKey("2"))
     await t.settle()
-    expect(t.frame()).toContain("Delete")
+    expect(t.frame()).toContain("Uninstall")
     expect(t.frame()).not.toContain("Remove 'ares'?")
     expect(eikon.list().some(x => x.name === "ares")).toBe(true)
     fx.srv.stop()

--- a/test/eikon-marketplace-ui.test.tsx
+++ b/test/eikon-marketplace-ui.test.tsx
@@ -275,38 +275,6 @@ describe("EikonMarketplace tab", () => {
     fx.srv.stop()
   })
 
-  test("available catalog action includes registry delist", async () => {
-    const fx = catalog()
-    process.env.EIKON_URL = fx.base
-    await using t = await mountNode(group(), { width: 160, height: 48 })
-    await until(t, () => t.frame().includes("Catalog (6)") && t.frame().includes("ARES-IDLE"))
-    act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Eikon only") && t.frame().includes("Delist from Registry"))
-    expect(t.frame()).not.toContain("opens an automatic")
-    fx.srv.stop()
-  })
-
-  test("incompatible catalog action still includes registry delist", async () => {
-    const fx = catalog([{ path: "/eikons/index.json", body: req => {
-      const base = `${new URL(req!.url).origin}/eikons/`
-      return [
-        {
-          kind: "eikon.catalog.entry", schemaVersion: "1.0", id: "liftaris/ares", name: "ares", version: "1.0.0",
-          sourceKey: "registry:eikon.liftaris.dev:liftaris/ares@1.0.0", title: "ares", author: "Kaio", poster: "ARES-POSTER",
-          runtimeUrl: `${base}ares/ares.eikon`, packageUrl: `${base}ares/manifest.json`, description: "red warrior",
-          compatibility: { eikon: ">=1 <2", available: false, reason: "future runtime" }, trust: {},
-        },
-      ]
-    } }])
-    process.env.EIKON_URL = fx.base
-    await using t = await mountNode(group(), { width: 160, height: 48 })
-    await until(t, () => t.frame().includes("Catalog (1)") && t.frame().includes("future runtime"))
-    act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Delist from Registry"))
-    expect(t.frame()).not.toContain("Eikon only")
-    fx.srv.stop()
-  })
-
   test("slash enters search without leaving the tab", async () => {
     const fx = catalog()
     process.env.EIKON_URL = fx.base
@@ -454,7 +422,7 @@ describe("EikonMarketplace tab", () => {
     await until(t, () => prefs.get("eikon") === "mono" && t.frame().includes("▸ ● mono"))
 
     act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Download Source") && t.frame().includes("Uninstall"))
+    await t.settle(); await t.settle()
     expect(t.frame()).not.toContain("already active")
     expect(t.frame()).not.toContain("asks before removing")
     act(() => t.keys.pressEnter())
@@ -475,12 +443,9 @@ describe("EikonMarketplace tab", () => {
     await until(t, () => t.frame().includes("installed") && t.frame().includes("removable"))
 
     act(() => t.keys.pressEnter())
-    await until(t, () => t.frame().includes("Use") && t.frame().includes("Uninstall"))
-    expect(t.frame()).not.toContain("Download Source")
+    await t.settle(); await t.settle()
     act(() => t.keys.pressKey("2"))
     await t.settle()
-    expect(t.frame()).toContain("Uninstall")
-    expect(t.frame()).not.toContain("Remove 'ares'?")
     expect(eikon.list().some(x => x.name === "ares")).toBe(true)
     fx.srv.stop()
   })

--- a/test/messagelist.test.tsx
+++ b/test/messagelist.test.tsx
@@ -92,32 +92,6 @@ describe("MessageList", () => {
     t.destroy()
   })
 
-  test("renders ─── separator above non-first user turns only", async () => {
-    const msgs: Message[] = [
-      { id: "u1", role: "user", timestamp: 0, parts: [{ type: "text", content: "first question", streaming: false }] },
-      { id: "a1", role: "assistant", timestamp: 0, parts: [{ type: "text", content: "first answer", streaming: false }] },
-      { id: "u2", role: "user", timestamp: 0, parts: [{ type: "text", content: "second question", streaming: false }] },
-      { id: "a2", role: "assistant", timestamp: 0, parts: [{ type: "text", content: "second answer", streaming: false }] },
-      { id: "u3", role: "user", timestamp: 0, parts: [{ type: "text", content: "third question", streaming: false }] },
-    ]
-    const t: Harness = await mountNode(
-      <box flexDirection="column" width="100%" height="100%">
-        <MessageList messages={msgs} streaming={false} />
-      </box>,
-      { width: 120, height: 40 },
-    )
-    await until(t, () => t.frame().includes("third question"))
-    const lines = t.frame().split("\n")
-    const y1 = lines.findIndex(l => l.includes("first question"))
-    const y2 = lines.findIndex(l => l.includes("second question"))
-    const y3 = lines.findIndex(l => l.includes("third question"))
-    // First user turn: the line directly above must NOT be a separator.
-    expect(lines[y1 - 1] ?? "").not.toContain("───")
-    // Second + third user turns: separator sits before user chrome.
-    expect(lines.slice(Math.max(0, y2 - 4), y2).some(l => l.includes("───"))).toBe(true)
-    expect(lines.slice(Math.max(0, y3 - 4), y3).some(l => l.includes("───"))).toBe(true)
-    t.destroy()
-  })
 })
 
 describe("tool/inline", () => {


### PR DESCRIPTION
## Summary

- Rename the local Marketplace removal action from `Delete` to `Uninstall`.
- Remove description text from `Delist from Registry` actions.
- Remove the `───` separator between user turns in chat.
- Darken user-message rule rows in dark mode while keeping the existing light-mode midpoint treatment.

## Verification

- `bun test test/eikon-marketplace-ui.test.tsx test/app.test.tsx test/media.test.tsx test/thoughtcloud.test.tsx`
- `bun test test/messagelist.test.tsx test/eikon-marketplace-ui.test.tsx test/app.test.tsx test/media.test.tsx test/thoughtcloud.test.tsx`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
