### PR TITLE
fix(chat): preserve queued interrupt prompts

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -58,6 +58,8 @@ import { sessionCapabilities } from "./app/sessionCapabilities"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch; keyOverrides?: Record<string, string> }
 
+const BUSY_RE = /session busy|waiting for model response/i
+
 export const App = (props: AppProps) => (
   <ThemeProvider initial={props.initialTheme}>
     <GatewayProvider client={props.gateway}>
@@ -201,6 +203,13 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [pick, setPick] = useState<Message | undefined>(undefined)
   const [skin, setSkin] = useState<SkinState>(() => deriveSkin(undefined))
   const inflight = useRef(false)
+  const hold = useRef(false)
+  const [pulse, setPulse] = useState(0)
+  const settle = useCallback(() => {
+    if (!hold.current) return
+    hold.current = false
+    setPulse(n => n + 1)
+  }, [])
   // /undo snapshots the tail it pops (Message[]) so /redo can replay
   // the head user-turn's text. Client-only; gateway session.undo is a
   // hard delete with no unrevert. Cleared on reset/session-switch.
@@ -313,19 +322,25 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
         .catch(() => setQueue(q => [...q, t]))
       return
     }
-    if (busy === "interrupt") { intr.current(); return setQueue(q => [t, ...q]) }
+    if (busy === "interrupt") {
+      hold.current = true
+      setQueue(q => [t, ...q])
+      intr.current()
+      return
+    }
     setQueue(q => [...q, t])
   }, [busy, gw, toast])
   const onAttach = useCallback((r: ImageAttachResponse) => setAttachments(a => [...a, r]), [])
 
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
-    setSid, setInfo, setReady, setTitle, setBusy, setUsage, setStatus, setSkin, setErrorPulse,
+    setSid, setInfo, setReady, setTitle, setBusy, setUsage, setStatus, setSkin, setErrorPulse, settle,
   })
   intr.current = stream.doInterrupt
 
   const reset = useCallback(() => {
     stream.interrupted.current = false
+    hold.current = false
     toast.clear("credits.depleted")
     undone.current = []
     dispatch({ kind: "reset" })
@@ -601,12 +616,31 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     const withMedia = attachments.length
       ? [...attachments.flatMap(a => a.path ? [`MEDIA:${a.path}`] : []), text].filter(Boolean).join("\n")
       : text
-    dispatch({ kind: "user", text: withMedia })
-    setAttachments([])
-    undone.current = []
-    gw.request("prompt.submit", { text }).catch(() => { inflight.current = false })
-    setTab(CHAT_TAB)
-  }, [gw, slash, attachments])
+    gw.request("prompt.submit", { text })
+      .then(() => {
+        dispatch({ kind: "user", text: withMedia })
+        setAttachments([])
+        undone.current = []
+        setTab(CHAT_TAB)
+      })
+      .catch((e: Error) => {
+        const msg = e instanceof Error ? e.message : String(e)
+        if (BUSY_RE.test(msg)) {
+          inflight.current = true
+          setQueue(q => [text, ...q])
+          setStatus("queued for next turn")
+          toast.show({ variant: "info", message: "queued for next turn" })
+          setTimeout(() => {
+            inflight.current = false
+            setPulse(n => n + 1)
+          }, 400)
+          return
+        }
+        inflight.current = false
+        dispatch({ kind: "system", text: `submit failed: ${msg}` })
+        toast.show({ variant: "error", message: msg })
+      })
+  }, [gw, slash, attachments, toast])
   sendRef.current = send
 
   // Shell mode submit — `shell.exec` is a plain subprocess (no pty,
@@ -649,12 +683,12 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // one tick. `inflight` bridges the dispatch→message.start gap.
   useEffect(() => { if (turn.streaming) inflight.current = false }, [turn.streaming])
   useEffect(() => {
-    if (!capabilities.canDrainQueue || inflight.current || queue.length === 0) return
+    if (!capabilities.canDrainQueue || inflight.current || hold.current || queue.length === 0) return
     const [head, ...rest] = queue
     inflight.current = true
     setQueue(rest)
     send(head)
-  }, [capabilities.canDrainQueue, queue, send])
+  }, [capabilities.canDrainQueue, queue, send, pulse])
 
   const dequeue = useCallback((i: number) => {
     const item = queueRef.current[i]
@@ -707,10 +741,13 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       return true
     },
     onInterrupt: stream.doInterrupt,
-    // queue.flush is just an interrupt — the drain effect auto-fires
-    // the head once turn.streaming flips false.
+    // queue.flush interrupts, then drain waits for session.info so
+    // prompt.submit does not race the gateway's still-running turn.
     queued: queue.length,
-    onFlushQueue: stream.doInterrupt,
+    onFlushQueue: () => {
+      hold.current = true
+      stream.doInterrupt()
+    },
     onQuit: () => quit(renderer, sid, caption, gw),
     onQuitArm: (label) =>
       toast.show({ variant: "info", message: `${label} again to quit` }),

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -36,6 +36,7 @@ type Ctx = {
   setStatus: (s: string) => void
   setSkin: (s: SkinState) => void
   setErrorPulse: (v: boolean) => void
+  settle: () => void
 }
 
 // Events that mutate the in-progress assistant turn. Everything else
@@ -153,6 +154,7 @@ export function useStream(c: Ctx) {
         x.setInfo(si)
         x.setReady(true)
         if (si.session_id) x.setSid(si.session_id)
+        x.settle()
         const bad = (si.mcp_servers ?? []).filter(s => !s.connected)
         if (bad.length) x.dispatch({
           kind: "system",

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1005,13 +1005,16 @@ describe("app", () => {
     expect(t.frame()).not.toContain("⏸ 2.")        // one chip left
     expect(t.gw.calls.filter(c => c.method === "prompt.submit").length).toBe(2)
 
-    // <leader>u flushes: interrupt fires, drain effect submits head on
-    // the following message.complete.
+    // <leader>u flushes: interrupt fires, then the drain waits for the
+    // gateway's post-finally session.info settle edge before submitting.
     act(() => t.keys.pressKey("x", { ctrl: true }))
     await t.settle()
     await act(async () => { await t.keys.typeText("u") })
     await until(t, () => t.gw.calls.some(c => c.method === "session.interrupt"))
     act(() => t.gw.push({ type: "message.complete", payload: { text: "r2", usage: { input: 1, output: 1, total: 2 } } }))
+    await t.settle()
+    expect(t.gw.calls.filter(c => c.method === "prompt.submit").length).toBe(2)
+    act(() => t.gw.push({ type: "session.info", payload: { model: "test-model", session_id: "test-sid", tools: {}, skills: {} } }))
     await until(t, () => t.gw.calls.filter(c => c.method === "prompt.submit").length === 3)
     expect(t.gw.last("prompt.submit")?.params.text).toBe("follow up b")
     act(() => t.gw.push({ type: "message.start" }))

--- a/test/queued-submit.test.tsx
+++ b/test/queued-submit.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until, MockGateway } from "./harness"
+
+function info() {
+  return { model: "test-model", session_id: "test-sid", tools: {}, skills: {} }
+}
+
+describe("queued prompt submit", () => {
+  test("interrupt-mode queue waits for session.info before draining", async () => {
+    const gw = new MockGateway({
+      "config.get": p => p.key === "busy" ? { value: "interrupt" } : {},
+      "session.interrupt": () => ({ status: "interrupted" }),
+      "prompt.submit": () => ({ status: "streaming" }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => gw.push({ type: "message.start" }))
+    await until(t, () => t.frame().includes("Type to queue"))
+
+    await act(async () => { await t.keys.typeText("stop l4") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("stop l4"))
+
+    expect(gw.calls.filter(c => c.method === "session.interrupt")).toHaveLength(1)
+
+    act(() => gw.push({ type: "message.complete", payload: { status: "interrupted", text: "" } }))
+    await t.settle()
+    expect(gw.calls.filter(c => c.method === "prompt.submit")).toHaveLength(0)
+
+    act(() => gw.push({ type: "session.info", payload: info() }))
+    await until(t, () => gw.calls.filter(c => c.method === "prompt.submit").length === 1)
+
+    expect(gw.last("prompt.submit")?.params).toMatchObject({
+      session_id: "test-sid",
+      text: "stop l4",
+    })
+    t.destroy()
+  })
+
+  test("session-busy submit rejection requeues and retries", async () => {
+    let tries = 0
+    const gw = new MockGateway({
+      "config.get": p => p.key === "busy" ? { value: "interrupt" } : {},
+      "session.interrupt": () => ({ status: "interrupted" }),
+      "prompt.submit": () => {
+        tries += 1
+        if (tries === 1) throw new Error("session busy")
+        return { status: "streaming" }
+      },
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => gw.push({ type: "message.start" }))
+    await until(t, () => t.frame().includes("Type to queue"))
+    await act(async () => { await t.keys.typeText("retry after settle") })
+    act(() => t.keys.pressEnter())
+
+    act(() => gw.push({ type: "message.complete", payload: { status: "interrupted", text: "" } }))
+    await t.settle()
+    expect(gw.calls.filter(c => c.method === "prompt.submit")).toHaveLength(0)
+
+    act(() => gw.push({ type: "session.info", payload: info() }))
+    await until(t, () => gw.calls.filter(c => c.method === "prompt.submit").length === 2, 2500)
+
+    expect(tries).toBe(2)
+    expect(gw.last("prompt.submit")?.params.text).toBe("retry after settle")
+    expect(t.frame()).toContain("retry after settle")
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## Summary
Queued follow-up prompts typed during interrupt-mode streaming now wait for the gateway settle signal before submitting. That prevents local-only user bubbles and keeps continuation turns from outracing the queued prompt.

## What changed
- Holds interrupt-mode queue draining until `session.info` arrives after the gateway clears the active turn.
- Treats `prompt.submit` success as the point where a user message is committed to the visible transcript.
- Requeues and retries prompts when the gateway reports `session busy` instead of dropping them silently.
- Covers the interrupt settle path and busy-retry path with focused regression tests.

## Verification
- `bun install --frozen-lockfile`
- `bun test test/queued-submit.test.tsx test/app.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
