### PR TITLE
fix: align background message rendering

### DIFF
--- a/src/app/background.tsx
+++ b/src/app/background.tsx
@@ -1,36 +1,43 @@
 // In-flight /background task ids. Registered on prompt.background,
 // unregistered on background.complete.
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+import { createContext, useCallback, useMemo, useState, type ReactNode } from "react"
 import { makeUse } from "../context/helper"
 
 type Ctx = {
   count: number
   ids: readonly string[]
-  register: (id: string) => void
+  register: (id: string, title?: string) => void
   unregister: (id: string) => void
+  label: (id: string) => string | undefined
 }
 
 const ctx = createContext<Ctx | null>(null)
 
 export const BackgroundProvider = ({ children }: { children: ReactNode }) => {
-  const [set, setSet] = useState<ReadonlySet<string>>(() => new Set())
-  const register = useCallback((id: string) => {
+  const [jobs, setJobs] = useState<ReadonlyMap<string, string>>(() => new Map())
+  const register = useCallback((id: string, title = "") => {
     if (!id) return
-    setSet(prev => prev.has(id) ? prev : new Set(prev).add(id))
+    setJobs(prev => {
+      if (prev.get(id) === title) return prev
+      const next = new Map(prev)
+      next.set(id, title)
+      return next
+    })
   }, [])
   const unregister = useCallback((id: string) => {
-    setSet(prev => {
+    setJobs(prev => {
       if (!prev.has(id)) return prev
-      const next = new Set(prev)
+      const next = new Map(prev)
       next.delete(id)
       return next
     })
   }, [])
-  const ids = useMemo(() => Array.from(set), [set])
+  const label = useCallback((id: string) => jobs.get(id)?.trim() || undefined, [jobs])
+  const ids = useMemo(() => Array.from(jobs.keys()), [jobs])
   const value = useMemo<Ctx>(
-    () => ({ count: ids.length, ids, register, unregister }),
-    [ids, register, unregister],
+    () => ({ count: ids.length, ids, register, unregister, label }),
+    [ids, register, unregister, label],
   )
   return <ctx.Provider value={value}>{children}</ctx.Provider>
 }

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -374,13 +374,18 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
         case "background":
-          if (!arg) { toast.show({ variant: "info", message: "usage: /background <prompt>" }); return }
-          gw.request<{ task_id?: string }>("prompt.background", { text: arg })
+          if (!arg) { x.dispatch({ kind: "system", text: "/background <prompt>" }); return }
+          gw.request<{ task_id?: string }>(
+            "prompt.background",
+            x.sid ? { session_id: x.sid, text: arg } : { text: arg },
+          )
             .then(r => {
-              if (r.task_id) bg.register(r.task_id)
-              toast.show(r.task_id
-                ? { variant: "success", message: `background ${r.task_id} started` }
-                : { variant: "error", message: "background start failed" })
+              if (!r.task_id) {
+                toast.show({ variant: "error", message: "background start failed" })
+                return
+              }
+              bg.register(r.task_id)
+              x.dispatch({ kind: "system", text: `bg ${r.task_id} started` })
             })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -384,7 +384,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
                 toast.show({ variant: "error", message: "background start failed" })
                 return
               }
-              bg.register(r.task_id)
+              bg.register(r.task_id, arg)
               x.dispatch({ kind: "system", text: `bg ${r.task_id} started` })
             })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))

--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -28,6 +28,7 @@ export type Action =
   | { kind: "push"; message: Message }
   | { kind: "user"; text: string }
   | { kind: "system"; text: string }
+  | { kind: "background"; id: string; title?: string; text: string }
   | { kind: "message.start" }
   | { kind: "message.delta"; chunk: string }
   | { kind: "message.complete"; text?: string; usage?: Usage }
@@ -66,6 +67,9 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
 
     case "system":
       return { ...state, messages: [...state.messages, systemMessage(sanitize(a.text))] }
+
+    case "background":
+      return { ...state, messages: [...state.messages, backgroundMessage(a.id, a.title, a.text)] }
 
     case "message.start":
       return { ...state, streaming: true, hasContent: false, toolActive: false }
@@ -211,6 +215,25 @@ function systemMessage(text: string): Message {
   return {
     id: mid(), role: "system",
     parts: [{ type: "text", content: text, streaming: false }],
+    timestamp: Date.now() / 1000,
+  }
+}
+
+function clip(text: string, max: number): string {
+  return text.length <= max ? text : text.slice(0, max - 1) + "…"
+}
+
+function label(text: string | undefined, max: number): string {
+  return clip(sanitize(text).replace(/\s+/g, " ").trim(), max)
+}
+
+function backgroundMessage(id: string, title: string | undefined, text: string): Message {
+  const tid = label(id, 32) || "?"
+  const name = label(title, 80)
+  return {
+    id: mid(), role: "assistant",
+    speaker: `[bg ${tid}]${name ? ` ${name}` : ""}`,
+    parts: [{ type: "text", content: sanitize(text), streaming: false }],
     timestamp: Date.now() / 1000,
   }
 }

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -10,7 +10,7 @@ import { useGateway, useGatewayEvent } from "../context/gateway"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 import { openAlert } from "../dialogs/alert"
-import { formatProcessNotification, mapEvent } from "../context/events"
+import { mapEvent } from "../context/events"
 import { deriveSkin, type SkinState } from "../context/skin"
 import { useBackground } from "./background"
 import type { Action } from "./turnReducer"
@@ -79,35 +79,11 @@ export function useStream(c: Ctx) {
   // action flushes synchronously first so part ordering is preserved.
   const deltas = useRef({ text: "", think: "", timer: null as ReturnType<typeof setTimeout> | null })
 
-  // Process notification batching: status.update/kind=process events
-  // accumulate over a 500ms window and dispatch as one combined system
-  // message. Prevents TUI lag when many background processes finish
-  // in rapid succession (each one otherwise triggers a full React
-  // re-render of the Chat transcript).
-  const procs = useRef<{ texts: string[]; timer: ReturnType<typeof setTimeout> | null }>(
-    { texts: [], timer: null },
-  )
-
   const flush = useCallback(() => {
     const d = deltas.current
     if (d.timer) { clearTimeout(d.timer); d.timer = null }
     if (d.think) { ctx.current.dispatch({ kind: "thinking", text: d.think, final: false }); d.think = "" }
     if (d.text) { ctx.current.dispatch({ kind: "message.delta", chunk: d.text }); d.text = "" }
-  }, [])
-
-  // Flush accumulated process notifications as one combined system msg.
-  const flushProcs = useCallback(() => {
-    const n = procs.current
-    if (n.timer) { clearTimeout(n.timer); n.timer = null }
-    if (!n.texts.length) return
-    const batch = n.texts.splice(0)
-    const lines = batch.map(t => `  ${formatProcessNotification(t)}`)
-    ctx.current.dispatch({
-      kind: "system",
-      text: batch.length === 1
-        ? `◆ background ${lines[0].trim()}`
-        : `◆ ${batch.length} background notifications\n${lines.join("\n")}`,
-    })
   }, [])
 
   const sync = useCallback((ms = 0) => {
@@ -128,8 +104,12 @@ export function useStream(c: Ctx) {
   const handle = useCallback((ev: GatewayEvent) => {
     const x = ctx.current
     if (ev.type === "gateway.ready") info.current = false
-    const shared = ev.type === "background.complete" ||
-      (ev.type === "status.update" && ev.payload?.kind === "process")
+    if (ev.type === "background.complete" && ev.session_id && x.sidRef.current
+        && ev.session_id !== x.sidRef.current) {
+      bg.unregister(ev.payload.task_id)
+      return
+    }
+    const shared = ev.type === "background.complete" && !ev.session_id
     if (ev.session_id && x.sidRef.current && ev.session_id !== x.sidRef.current && !ev.type.startsWith("gateway.") && !shared) return
     // The agent's stream-retry loop (run_agent._call) classifies the
     // force-closed httpx socket from an interrupt as a transient drop
@@ -175,13 +155,7 @@ export function useStream(c: Ctx) {
       },
       onBackground: (tid, text) => {
         bg.unregister(tid)
-        const head = text.split("\n")[0].slice(0, 80)
-        x.dispatch({ kind: "system", text: `◷ background task ${tid} complete — ${head}` })
-        toast.show({
-          variant: "info", title: "Background task complete", message: head,
-          duration: 8000,
-          action: { label: "view", run: () => openAlert(dialog, `Background task ${tid}`, text) },
-        })
+        x.dispatch({ kind: "system", text: `[bg ${tid}] ${text}` })
       },
       onBtw: (text) => {
         const head = text.split("\n")[0].slice(0, 80)
@@ -194,12 +168,6 @@ export function useStream(c: Ctx) {
       onStatus: (text) => x.setStatus(text),
       onApprovalRemembered: () => {
         void gw.request("approval.respond", { choice: "always" }).catch(() => {})
-      },
-      onProcessNotification: (text) => {
-        const n = procs.current
-        n.texts.push(text)
-        if (n.timer) clearTimeout(n.timer)
-        n.timer = setTimeout(flushProcs, 500)
       },
       onSkin: (s) => x.setSkin(deriveSkin(s)),
       notices: toast,

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -154,8 +154,9 @@ export function useStream(c: Ctx) {
         TITLE_DELAYS.forEach(sync)
       },
       onBackground: (tid, text) => {
+        const title = bg.label(tid)
         bg.unregister(tid)
-        x.dispatch({ kind: "system", text: `[bg ${tid}] ${text}` })
+        x.dispatch({ kind: "background", id: tid, title, text })
       },
       onBtw: (text) => {
         const head = text.split("\n")[0].slice(0, 80)
@@ -193,7 +194,7 @@ export function useStream(c: Ctx) {
     flush()
     if (action.kind === "error") x.setErrorPulse(true)
     x.dispatch(action)
-  }, [gw, dialog, toast, flush])
+  }, [gw, dialog, toast, flush, bg])
 
   useGatewayEvent(handle)
 

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -79,37 +79,6 @@ function useClick(fn?: () => void) {
   }
 }
 
-/** Themed vertical bar next to the body. `side` picks left or right. */
-const Gutter = memo(({ color, glyph = "│", side = "left", children }: {
-  color: RGBA
-  glyph?: string
-  side?: "left" | "right"
-  children: React.ReactNode
-}) => {
-  const bar = (
-    <box
-      width={2}
-      flexShrink={0}
-      border={[side]}
-      borderColor={color}
-      customBorderChars={{
-        topLeft: glyph, bottomLeft: glyph, vertical: glyph,
-        topRight: glyph, bottomRight: glyph, horizontal: "",
-        topT: "", bottomT: "", leftT: "", rightT: "", cross: "",
-      }}
-    />
-  )
-  return (
-    <box flexDirection="row">
-      {side === "left" ? bar : null}
-      <box flexDirection="column" flexGrow={1} flexShrink={1}>
-        {children}
-      </box>
-      {side === "right" ? bar : null}
-    </box>
-  )
-})
-
 export type PromptWire = {
   /** Ref to the single pending prompt card, for key routing. */
   ref: RefObject<PromptCardHandle | null>
@@ -131,12 +100,8 @@ export const MessageItem = memo(({ message, streaming, prompt, onRewind, onPick 
 const SystemMessage = memo(({ message }: { message: Message }) => {
   const theme = useTheme().theme
   return (
-    <box marginBottom={1}>
-      <Gutter color={theme.textMuted} glyph="·">
-        <box minHeight={1}>
-          <text fg={theme.textMuted} wrapMode="word">{extract(message)}</text>
-        </box>
-      </Gutter>
+    <box marginBottom={1} minHeight={1}>
+      <text fg={theme.textMuted} wrapMode="word">{extract(message)}</text>
     </box>
   )
 })
@@ -223,7 +188,7 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
   )
 
   const header = [
-    agentName,
+    message.speaker ?? agentName,
     message.usage ? `${tokens(message.usage.input)}→${tokens(message.usage.output)} tok` : null,
     message.duration ? duration(message.duration) : null,
   ].filter(Boolean).join(" · ")

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -23,8 +23,6 @@ export type Side = {
   onVoiceStatus?: (state: string) => void
   /** voice.transcript event — transcribed text from a completed voice capture. */
   onVoiceTranscript?: (text: string, noSpeechLimit: boolean) => void
-  /** status.update with kind=process — debounced client-side to prevent TUI lag. */
-  onProcessNotification?: (text: string) => void
   notices?: ToastContext
 }
 
@@ -222,17 +220,14 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
     case "status.update": {
       const kind = ev.payload?.kind
       const text = ev.payload?.text ?? ""
+      if (kind === "process") {
+        side.onStatus?.(formatProcessNotification(text))
+        return null
+      }
       side.onStatus?.(text)
       // Generic "status" is cosmetic; lifecycle/error/warn carry real
       // signal (retries, fallbacks, auth failures) and must persist.
       if (!kind || kind === "status") return null
-      // process: route through debounced accumulator instead of dispatching
-      // directly — prevents TUI lag when many terminal(background=true)
-      // processes finish in rapid succession.
-      if (kind === "process") {
-        side.onProcessNotification?.(text)
-        return null
-      }
       return { kind: "system", text }
     }
 

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -76,6 +76,7 @@ export type Message = {
   role: "user" | "assistant" | "system"
   parts: Part[]
   timestamp: number
+  speaker?: string
   model?: string
   duration?: number
   usage?: Usage

--- a/test/background.test.tsx
+++ b/test/background.test.tsx
@@ -3,16 +3,17 @@ import { act } from "react"
 import { mount, until, MockGateway } from "./harness"
 
 describe("background/btw completion", () => {
-  test("background.complete → stock TUI transcript line", async () => {
+  test("background.complete → assistant-style transcript message", async () => {
     const t = await mount({ width: 140, height: 40 })
     await until(t, () => t.frame().includes("Ready"))
 
     const body = ["summary line", ...Array.from({ length: 5 }, (_, i) => `detail ${i}`)].join("\n")
     act(() => t.gw.push({ type: "background.complete", payload: { task_id: "bg-1", text: body } }))
-    await t.settle()
+    await until(t, () => t.frame().includes("summary line"), 3000)
 
     const f = t.frame()
-    expect(f).toContain("[bg bg-1] summary line")
+    expect(f).toContain("[bg bg-1]")
+    expect(f).toContain("summary line")
     expect(f).toContain("detail 4")
     expect(f).not.toContain("Background task complete")
     expect(f).not.toContain("view")
@@ -29,7 +30,7 @@ describe("background/btw completion", () => {
     t.destroy()
   })
 
-  test("/background register → stock TUI start line + composer badge; completion unregisters", async () => {
+  test("/background register → start line + titled assistant completion", async () => {
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),
       "prompt.background": () => ({ task_id: "bg-42" }),
@@ -43,10 +44,14 @@ describe("background/btw completion", () => {
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("▶ 1"))
     expect(t.frame()).toContain("bg bg-42 started")
+    expect(t.frame()).not.toContain("· bg bg-42 started")
     expect(t.gw.last("prompt.background")?.params).toMatchObject({ session_id: "test-sid", text: "do the thing" })
 
     act(() => t.gw.push({ type: "background.complete", payload: { task_id: "bg-42", text: "done" } }))
-    await until(t, () => !t.frame().includes("▶ 1"))
+    await until(t, () => t.frame().includes("done"), 3000)
+    expect(t.frame()).not.toContain("▶ 1")
+    expect(t.frame()).toContain("[bg bg-42] do the thing")
+    expect(t.frame()).toContain("done")
     t.destroy()
   })
 

--- a/test/background.test.tsx
+++ b/test/background.test.tsx
@@ -3,7 +3,7 @@ import { act } from "react"
 import { mount, until, MockGateway } from "./harness"
 
 describe("background/btw completion", () => {
-  test("background.complete → transcript marker + toast with view action → alert dialog", async () => {
+  test("background.complete → stock TUI transcript line", async () => {
     const t = await mount({ width: 140, height: 40 })
     await until(t, () => t.frame().includes("Ready"))
 
@@ -12,25 +12,10 @@ describe("background/btw completion", () => {
     await t.settle()
 
     const f = t.frame()
-    expect(f).toContain("◷ background task bg-1 complete — summary line")
-    expect(f).toContain("Background task complete")
-    expect(f).toContain("view")
-
-    // click the toast action
-    const rows = f.split("\n")
-    const y = rows.findIndex(l => l.includes("view"))
-    const x = rows[y].indexOf("view")
-    await act(async () => { await t.mouse.pressDown(x, y) })
-    await until(t, () => t.frame().includes("◈ Background task bg-1"))
-
-    const d = t.frame()
-    expect(d).toContain("summary line")
-    expect(d).toContain("detail 4")
-    expect(d).toContain("Esc close · C copy")
-
-    act(() => t.keys.pressEscape())
-    await t.settle()
-    expect(t.frame()).not.toContain("◈ Background task bg-1")
+    expect(f).toContain("[bg bg-1] summary line")
+    expect(f).toContain("detail 4")
+    expect(f).not.toContain("Background task complete")
+    expect(f).not.toContain("view")
     t.destroy()
   })
 
@@ -44,7 +29,7 @@ describe("background/btw completion", () => {
     t.destroy()
   })
 
-  test("/background register → composer badge; background.complete → unregister", async () => {
+  test("/background register → stock TUI start line + composer badge; completion unregisters", async () => {
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),
       "prompt.background": () => ({ task_id: "bg-42" }),
@@ -57,6 +42,8 @@ describe("background/btw completion", () => {
     await act(async () => { await t.keys.typeText("/background do the thing") })
     act(() => t.keys.pressEnter())
     await until(t, () => t.frame().includes("▶ 1"))
+    expect(t.frame()).toContain("bg bg-42 started")
+    expect(t.gw.last("prompt.background")?.params).toMatchObject({ session_id: "test-sid", text: "do the thing" })
 
     act(() => t.gw.push({ type: "background.complete", payload: { task_id: "bg-42", text: "done" } }))
     await until(t, () => !t.frame().includes("▶ 1"))

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -90,19 +90,11 @@ describe("mapEvent", () => {
     expect(b.action).toEqual({ kind: "system", text: "HTTP 404" })
   })
 
-  test("status.update kind=process routes to debounced side callback", () => {
+  test("status.update kind=process is transient status only", () => {
     const text = "[IMPORTANT: Background process proc_abc completed (exit code 0).\nCommand: bun test\nOutput:\n…long stdout…]"
     const done = map({ type: "status.update", payload: { kind: "process", text } })
     expect(done.action).toBeNull()
-    expect(done.calls.status).toEqual([text])
-
-    const calls: string[] = []
-    const routed = map(
-      { type: "status.update", payload: { kind: "process", text } },
-      { onProcessNotification: t => calls.push(t) },
-    )
-    expect(routed.action).toBeNull()
-    expect(calls).toEqual([text])
+    expect(done.calls.status).toEqual(["proc_abc exited 0 · bun test"])
   })
 
   test("notification events route to keyed notice controller", () => {

--- a/test/live-session-events.test.tsx
+++ b/test/live-session-events.test.tsx
@@ -32,24 +32,53 @@ describe("live session event routing", () => {
     t.destroy()
   })
 
-  test("surfaces sibling process notifications while stream events stay scoped", async () => {
+  test("ignores sibling process notifications while stream events stay scoped", async () => {
     const gw = new MockGateway({
       "session.resume": p => ({ session_id: p.session_id, messages: [] }),
     })
     const t = await mount({ gw, launch: { mode: "resume", sid: "sid-b", splash: false } })
     await until(t, () => t.frame().includes("Ready"))
 
-    act(() => t.gw.push({
-      type: "status.update",
-      session_id: "sid-a",
-      payload: {
-        kind: "process",
-        text: "Background process proc_watch completed (exit code 0).\nCommand: watch-kanban",
-      },
-    }))
-    await until(t, () => t.frame().includes("proc_watch exited 0"))
+    act(() => {
+      t.gw.push({ type: "message.start", session_id: "sid-b" })
+      t.gw.push({ type: "message.delta", session_id: "sid-b", payload: { text: "B is streaming" } })
+      t.gw.push({
+        type: "status.update",
+        session_id: "sid-a",
+        payload: {
+          kind: "process",
+          text: "Background process proc_watch completed (exit code 0).\nCommand: watch-kanban",
+        },
+      })
+    })
+    await until(t, () => t.frame().includes("B is streaming"))
 
-    expect(t.frame()).toContain("watch-kanban")
+    expect(t.frame()).not.toContain("proc_watch")
+    expect(t.frame()).not.toContain("watch-kanban")
+    t.destroy()
+  })
+
+  test("sibling background completion clears badge without writing into active transcript", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),
+      "prompt.background": () => ({ task_id: "bg-42" }),
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "sid-b", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/background do the thing") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("▶ 1"))
+
+    act(() => t.gw.push({
+      type: "background.complete",
+      session_id: "sid-a",
+      payload: { task_id: "bg-42", text: "done elsewhere" },
+    }))
+    await until(t, () => !t.frame().includes("▶ 1"))
+
+    expect(t.frame()).not.toContain("[bg bg-42] done elsewhere")
     t.destroy()
   })
 })

--- a/test/live-session-events.test.tsx
+++ b/test/live-session-events.test.tsx
@@ -78,7 +78,7 @@ describe("live session event routing", () => {
     }))
     await until(t, () => !t.frame().includes("▶ 1"))
 
-    expect(t.frame()).not.toContain("[bg bg-42] done elsewhere")
+    expect(t.frame()).not.toContain("done elsewhere")
     t.destroy()
   })
 })


### PR DESCRIPTION
## Summary

Background prompt output now lands in the transcript with normal assistant-message chrome. The accepted job still writes `bg <task_id> started`, while the completion renders under a background-specific header such as `[bg bg-42] summarize the nightly report`.

Terminal background-process notifications now stay as transient status text while the gateway delivers the follow-up turn. Events from sibling sessions no longer pollute the active transcript, while matching running badges still clear when those background tasks complete.

## Screenshot

![Background message transcript](https://files.catbox.moe/magbr5.png)

## Verification

- `bun test test/background.test.tsx test/live-session-events.test.tsx test/gatewayEvents.test.ts test/app.test.tsx test/composer-background-fragment.test.tsx`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
