### PR TITLE
docs(eikon): update shipped skill guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,42 +98,48 @@ discover, inspect, install, use, update, and remove.
 
 In Herm:
 
-- Open Eikon → Marketplace, or run `/marketplace`, to browse shared catalog
+- Open Eikon → Catalog, or run `/catalog`, to browse shared catalog
   entries.
 - Preview rows before installing. Trust is shown as `Verified`, `Unverified`,
   or `Mismatch` beside source and compatibility state.
 - Install adds the eikon to your local library without activating it.
 - Use selects an installed eikon as the active avatar.
+- Installing over the currently active eikon name also requires confirmation or
+  `--active-ok` because it replaces the active avatar's backing package.
 - Update or remove an active eikon only after confirming that the active
   avatar's backing package will change or be cleared.
 
 From the shell:
 
 ```bash
-herm eikon search [query]
-herm eikon inspect <name|github.com/user/repo/eikon-name|dir>
-herm eikon install <name|github.com/user/repo/eikon-name|dir>
-herm eikon use <name>
-herm eikon info <name>
-herm eikon update <name> --active-ok
-herm eikon remove <name> --active-ok
+herm eikon search [query] [--json]
+herm eikon browse [query] [--json]
+herm eikon inspect <name|url|dir> [--json]
+herm eikon install <name|url|dir> [--name N] [--no-source] [--active-ok] [--json]
+herm eikon list [--json]
+herm eikon use <name> [--json]
+herm eikon info <name> [--json]
+herm eikon update <name> [--active-ok] [--json]
+herm eikon remove <name> [--active-ok] [--json]
+herm eikon delist <name|id> [--json]
 ```
 
 `install` never activates. `use` is the activation action. JSON output is
 available for automation with `--json`.
 
-Default Marketplace installs fetch built package artifacts referenced by the
+Default Catalog installs fetch built package artifacts referenced by the
 catalog, not creator repositories. Direct GitHub installs are for sharing
 outside the default catalog and support both single-package repos and
 multi-eikon catalog repos addressed as `github.com/user/repo/eikon-name`.
 Private GitHub repos use normal git authentication.
 
 Creators can share Eikons through normal GitHub repositories. For official
-registry listing, use Eikon → Studio/Gallery → submit after baking. Herm previews
-the exact public bundle, asks for title/author/description/glyph, and either
-creates a GitHub PR through local `gh` auth or gives a browser/manual PR
-fallback with copyable bundle and PR text. Direct-install repos can still be
-prepared with upstream `eikon pack`, `eikon index`, and `eikon manifest`.
+registry listing, press `u` in Studio or use Library's Share to catalog action
+after baking. Herm previews metadata, the prepared public bundle, and the GitHub
+PR target; with local `gh` auth it creates the PR, otherwise it shows manual PR
+steps with the prepared bundle path and compare URL. Direct-install repos can
+still be prepared with upstream `eikon pack`, `eikon index`, and
+`eikon manifest`.
 `eikon publish` remains the lower-level GitHub PR contribution helper for the
 configured/default catalog repo; it is not a hosted marketplace account, upload,
 dashboard, or moderation flow.
@@ -141,7 +147,7 @@ dashboard, or moderation flow.
 Use `eikon.liftaris.dev` as a discovery gallery only; it previews catalog
 entries and gives copyable Herm install instructions.
 
-Herm owns native Marketplace behavior. The eikon repo owns the registry,
+Herm owns native Catalog behavior. The eikon repo owns the registry,
 browser mirror, shared catalog/player exports, install resolver, and publish
 preflight. Herm imports public eikon package exports rather than browser mirror
 internals or unexported source paths.

--- a/assets/skills/eikon-create/SKILL.md
+++ b/assets/skills/eikon-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eikon-create
-description: Interactively generate source images (and optionally short videos) for a herm eikon avatar, iterate on them with the user, and land them under ~/.hermes/eikons/<name>/source/ so the Eikon Studio tab can tune and bake them. This is the agent-driven counterpart to Studio's one-shot Generate dialog.
-tags: [eikon, avatar, image-gen, herm]
+description: Use when generating or adopting source images/videos for a Herm eikon so Eikon Studio can tune, bake, and optionally share it.
+tags: [eikon, avatar, image-gen, video-gen, herm]
 related_skills: [eikon]
 ---
 
@@ -9,49 +9,52 @@ related_skills: [eikon]
 
 You are producing **source files**, not the packed `.eikon`. Studio owns
 crop, tone (contrast/invert/flip), rasterizer choice, and baking. Your
-deliverable is one or more images/videos under
+deliverable is one or more images/videos under the active Hermes profile:
 
     ~/.hermes/eikons/<name>/source/
 
-named so Studio resolves them: `base.*` for the default pose, `<state>.*`
-for per-state overrides (`idle listening thinking speaking working
-error`). Extensions: `png jpg jpeg webp gif bmp mp4 webm mov mkv`.
+Studio resolves `base.*` for the default source and `<state>.*` for
+per-state overrides (`idle listening thinking speaking working error`).
+Direct `source/` discovery supports `png jpg jpeg webp gif bmp mp4 webm mov
+mkv`; Studio's Local file picker currently accepts `png jpg jpeg webp gif mp4
+webm mov`, so copy `bmp`/`mkv` into `source/` manually if needed.
+
 Studio bakes with **Ctrl+S** without activation; **Ctrl+U** bakes and uses the
 eikon as the active avatar.
 
 ## What survives rasterization
 
-Output is 48×24, one theme color, braille/block glyphs. The one-line
-brief (say once, don't repeat):
+Output is 48×24, one theme color, braille/block glyphs. The one-line brief
+(say once, don't repeat):
 
-> 48×24, one color. Best results: light subject on black background,
-> high contrast, strong silhouette.
+> 48×24, one color. Best results: light subject on black background, high
+> contrast, strong silhouette.
 
-Outline carries everything — facial detail, fine texture, and tonal
-gradients mostly vanish.
+Outline carries everything — facial detail, fine texture, and tonal gradients
+mostly vanish.
 
 ## What Studio fixes for you (don't regenerate for these)
 
 Studio adjusts these live on any source without a new generation:
 
-- **Aspect / framing** — Studio crops to a square window; zoom + pan
-  pick which square. A 16:9 or portrait source is fine.
-- **Contrast** — slider, mean-centered. Flat or over-bright sources
-  are usually salvageable.
-- **Invert** — light↔dark swap. A dark-subject-on-light source works
-  with invert off.
+- **Aspect / framing** — Studio crops to a square window; zoom + pan pick
+  which square. A 16:9 or portrait source is fine.
+- **Contrast** — slider, mean-centered. Flat or over-bright sources are
+  usually salvageable.
+- **Invert** — light↔dark swap. A dark-subject-on-light source works with
+  invert off.
 - **Flip** — horizontal/vertical mirror.
 
-So: regenerate for **subject, pose, silhouette, background clutter**.
-Don't regenerate for **crop, exposure, polarity, orientation**.
+So: regenerate for **subject, pose, silhouette, background clutter**. Don't
+regenerate for **crop, exposure, polarity, orientation**.
 
 ## Flow
 
 ### 0. Name
 
-If the user passed an argument (`/eikon-create <name>`), slug it
-(lowercase, `[^a-z0-9-]` → `-`, collapse runs, trim). Otherwise ask
-once. Make the folder immediately so Studio's Open picker lists it:
+If the user passed an argument (`/eikon-create <name>`), slug it (lowercase,
+`[^a-z0-9-]` → `-`, collapse runs, trim). Otherwise ask once. Make the folder
+immediately so Studio's picker lists it:
 
 ```bash
 n="<slug>"; mkdir -p "${HERMES_HOME:-$HOME/.hermes}/eikons/$n/source"
@@ -59,52 +62,67 @@ n="<slug>"; mkdir -p "${HERMES_HOME:-$HOME/.hermes}/eikons/$n/source"
 
 ### 1. Subject
 
-Ask what the eikon is. One line is enough. If they drop an image
-instead of describing one, skip to §3 adopt-only.
+Ask what the eikon is. One line is enough. If they drop an image instead of
+describing one, skip to §3 adopt-only.
 
 ### 2. Generate base
 
-Call `image_generate` with the subject on line 1 and the fixed suffix
-on line 2 — same suffix Studio seeds:
+Call `image_generate` with the subject on line 1 and Studio's fixed style hint
+on line 2:
 
-```
+```text
 <subject>, close-up portrait emphasizing the face/head, looking slightly left, stark black and white, bold silhouette, simple uncluttered shape
 high contrast, light subject on dark, black background
 ```
 
-Keep this general: replace `face/head` with the subject's most readable
-feature if it is not a character or creature. Prefer square if the tool
-takes `aspect_ratio`; if it doesn't, don't worry — Studio crops. Show
-the result inline with `![base](<path>)`
-and a 48-wide terminal preview:
+Keep this general: replace `face/head` with the subject's most readable feature
+if it is not a character or creature. Prefer `aspect_ratio="square"` if the
+tool takes it; if it doesn't, don't worry — Studio crops.
+
+After every candidate, adopt it into `source/base.<ext>` before handoff or
+iteration. Show the result inline with `![base](<path>)` and a 48-wide terminal
+preview:
 
 ```bash
 chafa --size=48x24 --symbols=braille --colors=none --format=symbols --stretch "<path>" 2>/dev/null || true
 ```
 
-Ask: **keep, regenerate, or adjust?** On adjust, fold their note into
-the subject line (leave the suffix alone). Loop. **Always overwrite the
-same `<state>.<ext>` in `source/` on every iteration** — Studio reads
-that path live, so a new candidate that lives only in cache is invisible
-to the user. If two rounds fail on background clutter, silently append
-`, isolated on pure black, no floor, no environment` and try again.
+Ask: **keep, regenerate, or adjust?** On adjust, fold their note into the
+subject line and leave the style hint alone. If two rounds fail on background
+clutter, silently append `, isolated on pure black, no floor, no environment`
+and try again.
+
+Overwrite the same role file (`base.<ext>` for the default source,
+`<state>.<ext>` for overrides) so candidates do not drift across filenames. If
+Studio is already open after an external write, tell the user to press reload
+(`r`) or reopen the eikon; dirty drafts must be saved or reverted before reload.
+A candidate left only in temp/cache or in an unselected filename is invisible.
 
 ### 3. Adopt
 
+Use this for generated files, downloaded URLs, or a user-supplied local path.
+Set `role=<state>` for per-state overrides; default is `base`.
+
 ```bash
+role="${role:-base}"
 src="<path-or-downloaded-tmp>"
-dst="${HERMES_HOME:-$HOME/.hermes}/eikons/$n/source/base.${src##*.}"
+base="${src##*/}"
+ext="${base##*.}"
+[ "$ext" = "$base" ] && ext="png"
+ext=".${ext,,}"
+case "$ext" in .png|.jpg|.jpeg|.webp|.gif|.bmp|.mp4|.webm|.mov|.mkv) ;; *) ext=".png" ;; esac
+dst="${HERMES_HOME:-$HOME/.hermes}/eikons/$n/source/$role$ext"
 cp "$src" "$dst" && ls -l "$dst"
 ```
 
-URL return → `curl -fsSL -o /tmp/<n>-base.png "<url>"` first. Ambiguous
-extension → `.png`.
+URL return → download to `/tmp/<n>-<role>.<ext>` first, preserving the media
+extension when known. Ambiguous image URL → `.png`; ambiguous video URL → `.mp4`.
 
 ### 4. Per-state sources (optional)
 
-Base covers all six states by default. If the user wants distinct
-ones, repeat §2–3 per state, saving as `<state>.<ext>`. Nudge the
-subject line with pose intent:
+Base covers all six states by default. If the user wants distinct ones, repeat
+§2–3 per state, saving as `<state>.<ext>`. Nudge the subject line with pose
+intent:
 
 | state | pose nudge |
 |---|---|
@@ -116,24 +134,39 @@ subject line with pose intent:
 
 ### 5. Video (optional, only if asked)
 
-Use `video_generate` if available. What matters for an eikon source:
+Use `video_generate` if available. Studio's Generate video row appears only
+when the installed Hermes Agent video backend passes its requirement check; this
+skill may also use any available agent `video_generate` tool. If video generation
+is unavailable, adopt a local file or URL result instead.
 
-- **Duration** — 2–4 s is the useful range. Longer just inflates the
-  bake. If the provider picks duration itself, accept whatever lands.
-- **Aspect** — prefer 1:1 if the provider exposes it; otherwise any,
-  Studio crops.
-- **Resolution** — low is fine; the target is 48×24. Don't ask for
-  HD if the provider lets you pick.
-- **Start/end frame** — if the provider accepts a start (and/or end)
-  image, pass `base.*` so the clip anchors on the still pose and
-  loops cleanly. If it only takes text, that's fine — Studio plays
-  whatever frames it gets.
-- **Loop** — nice-to-have, not required. If the provider has a loop
-  or seamless flag, set it; if not, don't chase it with prompting.
+Before prompting motion for a character/creature, establish a one-line persona:
+temperament, bearing, and what an "idle" moment means for this subject. It keeps
+motion specific instead of generic breathing/bobbing.
 
-Providers vary in which of these knobs exist. **Pass what the tool
-accepts, skip what it doesn't, and don't apologize for the gaps.**
-None of them block a usable eikon.
+Motion discipline: animate only what the user asked for. Do not add ambient
+breathing, swaying, shimmer, cloth ripple, or body motion unless requested;
+small artifacts become obvious at 48×24. Prefer one deliberate motion plus one
+blink over many tiny movements. Put unwanted motion in the negative prompt or
+prompt body when the provider supports it.
+
+What matters for an eikon video source:
+
+- **Duration** — 1–4 s; Studio defaults to 2 s. Longer usually inflates the
+  bake without improving readability.
+- **Aspect** — prefer 1:1 if accepted; otherwise use an accepted aspect and let
+  Studio crop.
+- **Resolution** — low is fine; the target is 48×24. Don't ask for HD.
+- **Start image** — if the tool accepts it, pass `base.*` / the effective idle
+  source as `image_url` so frame 0 anchors on the still pose. Studio's current
+  bridge does not provide an end-frame handoff; skip unsupported knobs.
+- **Loop** — useful but not required. If the provider has loop/seamless flags,
+  set them; otherwise do not chase a perfect loop by prompting.
+- **Model tier** — if a lite/fast tier warps the subject, switch to a better
+  tier if the tool exposes `model=`. Don't burn iterations fighting artifacts a
+  tier bump fixes.
+
+Providers vary. **Pass what the tool accepts, skip what it doesn't, and don't
+apologize for the gaps.** None of them block a usable eikon.
 
 Adopt as `<state>.mp4` (or `base.mp4` for an animated idle).
 
@@ -141,20 +174,19 @@ Adopt as `<state>.mp4` (or `base.mp4` for an animated idle).
 
 Once source files are in place:
 
-> Open the **Eikon** tab → `eikon` row → **<name>**. Tune zoom /
-> contrast / invert / symbols there, then **Ctrl+S** to bake or **Ctrl+U**
-> to bake and use. For official registry sharing, press `u` in Studio or
-> `s` in Gallery after baking; Herm previews the public bundle and GitHub PR
-> target before anything is submitted.
+> Open **Eikon → Studio** → `eikon` row → **<name>**. Tune zoom / contrast /
+> invert / symbols there, then **Ctrl+S** to bake or **Ctrl+U** to bake and use.
+> After a saved bake, press `u` in Studio for the Submit eikon dialog or `s` in
+> **Library** for Share to catalog; Herm previews the bundle and GitHub PR target
+> before submission.
 
 Stop there. Studio writes `<name>.eikon` and `studio.json`.
 
 ## Don'ts
 
 - Don't write `.eikon` or `studio.json`.
-- Don't pick contrast, invert, zoom, or rasterizer values — name the
-  knob, the user turns it in Studio.
+- Don't pick contrast, invert, zoom, or rasterizer values — name the knob, the
+  user turns it in Studio.
 - Don't regenerate for things Studio can fix (see table above).
-- Don't enumerate provider capabilities to the user; just use what's
-  there.
+- Don't enumerate provider capabilities to the user; just use what's there.
 - Don't repeat the 48×24 brief.

--- a/assets/skills/eikon/SKILL.md
+++ b/assets/skills/eikon/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: eikon
-description: Guide the user through making or editing a herm sidebar avatar (eikon) using herm's built-in Eikon Studio tab. The agent's role is advisory (what makes a good source, which knob to reach for); source generation is /eikon-create and all rasterize/bake happens in-app.
+description: Use when helping a user create, edit, install, activate, update, remove, or share a Herm eikon through the built-in Eikon tab or the `herm eikon` CLI.
+tags: [eikon, avatar, herm]
 related_skills: [eikon-create]
 ---
 
-# Building an eikon in herm
+# Building and managing eikons in Herm
 
-An eikon is a 48×24 monochrome text avatar. It lives on disk as:
+An eikon is a 48×24 monochrome text avatar. It lives in the active
+Hermes profile, normally:
 
     ~/.hermes/eikons/<name>/
       <name>.eikon      packed NDJSON — written by Studio on Ctrl+S / Ctrl+U
@@ -17,72 +19,99 @@ You do **not** write `.eikon` or `studio.json`. Studio does.
 
 ## Where the user does the work
 
-Herm's built-in **Eikon** tab (Gallery / Studio / Marketplace). Tell the user:
-"open the Eikon tab" or "Ctrl+K → Eikon". In Studio:
+Herm's built-in **Eikon** tab has **Library / Catalog / Studio**:
 
-- `eikon` row → pick / New…
-- `source` row → Local file… / Generate image… / Generate video…
+- **Library** — local and bundled eikons; use, edit, update, share, delete,
+  and New/install entry points.
+- **Catalog** — shared catalog; install runtime-only, install with source,
+  use installed eikons, download source, uninstall, or delist when eligible.
+- **Studio** — edit an existing local/source draft eikon and bake it.
+
+Tell the user: "open the Eikon tab"; `/library`, `/catalog`, and `/studio`
+jump directly to the Eikon sub-tabs. In Studio:
+
+- `eikon` row → pick an eikon, `+ New…`, or `+ Install…`
+- `source` row → local/downloaded source; Generate rows appear only when the
+  corresponding Hermes generation backend is configured
 - `input` section → contrast / invert / flip (pixel-domain, shared)
-- `<rasterizer>` section → symbols / fill / dither (glyph-domain)
-- Preview pane → wheel pans, Ctrl+wheel zooms, Shift+wheel pans X
+- `<rasterizer>` section → rasterizer-specific glyph knobs, e.g. chafa
+  symbols/fill/dither or native symbols
+- Preview pane → wheel pans Y, Shift+wheel pans X, Ctrl+wheel zooms; drag the
+  pan bars to scrub pan
 - **Ctrl+S** bakes all six states without changing the active avatar
 - **Ctrl+U** bakes all six states and uses it as the active avatar
-- `u` from Studio or `s` from Gallery opens the official-registry submit flow
+- `u` in Studio opens the Submit eikon dialog; `s` in Library opens Share to
+  catalog for local unpublished eikons
 
 ## What makes a good source
 
-One line, once: **48×24, one color. Light subject on black, high
-contrast, strong silhouette.** Fine detail disappears; outline is
-everything.
+One line, once: **48×24, one color. Light subject on black, high contrast,
+strong silhouette.** Fine detail disappears; outline is everything.
 
 ## When to do what
 
 | user says | you do |
 |---|---|
 | "make me an eikon of X" | Load `eikon-create` and follow it. |
-| drops an image path | `cp` it to `~/.hermes/eikons/<name>/source/base.<ext>` → "Eikon tab, pick <name>". |
-| "edit my <name> eikon" | "Eikon tab → `eikon` row → <name>." |
-| "install/shared marketplace eikon" | "Eikon tab → Marketplace", or `/marketplace`. Install, then Use when ready. |
-| "install from GitHub" | "Eikon tab → New… → inspect/install", or `herm eikon install github.com/user/repo/eikon-name`. |
+| drops an image path | Copy it to `${HERMES_HOME:-$HOME/.hermes}/eikons/<name>/source/base.<ext>` or use Library → New… → local file, then Studio → `eikon` row → `<name>`. |
+| "edit my <name> eikon" | "Eikon → Studio → `eikon` row → `<name>`." |
+| "install/shared catalog eikon" | "Eikon → Catalog" or `/catalog`. Choose Eikon only or Eikon + Source, then Use when ready. |
+| "install from GitHub / URL / dir" | "Studio → `eikon` row → `+ Install…`", "Library → New… → inspect/install", or `herm eikon install <name|url|dir>`. |
 | "too dark / washed out" | "invert toggle, then contrast slider — under `input`." |
-| "off-center / too small" | "Ctrl+wheel to zoom, wheel/drag to pan on the preview." |
-| "make it move" | `eikon-create` §5 (video), or Studio's `source` → Generate video…. |
-| "publish/share my eikon" | "Eikon tab → Studio/Gallery → submit. Review the bundle, metadata, and GitHub PR target before continuing." |
+| "off-center / too small" | "Ctrl+wheel zooms; wheel/Shift+wheel pans; drag pan bars for precise pan." |
+| "make it move" | `eikon-create` §5 (video), or Studio's `source` row → Generate video… if available. |
+| "publish/share my eikon" | "After baking, press `u` in Studio or `s` in Library. Review metadata, bundle, and GitHub PR target before submitting." |
+| "remove from official catalog" | Use Catalog → Delist from Registry when eligible, or `herm eikon delist <name|id>`. |
 
 ## Install and manage shared eikons
 
-For catalog eikons, use **Eikon → Marketplace**. Rows show source,
-compatibility, and trust (`Verified`, `Unverified`, or `Mismatch`).
-Marketplace installs fetch built package artifacts and do not clone creator
-repos.
+For catalog eikons, use **Eikon → Catalog**. Rows show source,
+compatibility, trust (`Verified`, `Unverified`, or `Mismatch`), digest,
+and installed/active state. Catalog installs fetch built package artifacts;
+they do not clone creator repos.
+
+Default install is **Eikon only**: runtime package, no activation, no editable
+source. Choose **Eikon + Source**, or later **Download Source**, when the user
+wants to edit it in Studio.
 
 For direct sharing, use `github.com/user/repo/eikon-name` for a multi-eikon
-GitHub catalog repo, `github.com/user/repo` for a single-package repo, or a
-local package directory. Private GitHub repos use normal git authentication.
+GitHub catalog repo, `github.com/user/repo` for a single-package repo, a git or
+HTTP URL, or a local package directory. Private GitHub repos use normal git
+authentication.
 
 The local lifecycle is explicit:
 
 ```bash
-herm eikon search [query]
-herm eikon inspect <name|github.com/user/repo/eikon-name|dir>
-herm eikon install <name|github.com/user/repo/eikon-name|dir>
-herm eikon use <name>
-herm eikon info <name>
-herm eikon update <name> --active-ok
-herm eikon remove <name> --active-ok
+herm eikon search [query] [--json]
+herm eikon browse [query] [--json]
+herm eikon inspect <name|url|dir> [--json]
+herm eikon install <name|url|dir> [--name N] [--no-source] [--active-ok] [--json]
+herm eikon list [--json]
+herm eikon use <name> [--json]
+herm eikon info <name> [--json]
+herm eikon update <name> [--active-ok] [--json]
+herm eikon remove <name> [--active-ok] [--json]
+herm eikon delist <name|id> [--json]
 ```
 
-`install` never activates. `use` activates. Updating or removing the active
-eikon requires explicit acknowledgement because it changes or clears the active
-avatar.
+`install` does not activate. If the installed name is currently active,
+installing replaces the active avatar's backing package and requires
+`--active-ok`. `use` activates. Updating or removing the active eikon also
+requires `--active-ok`.
 
 Creators share through normal GitHub repositories. For official registry
-listing, use Gallery/Studio submit after baking: Herm previews the public
-bundle, asks for title/author/description/glyph, and creates or guides a
-GitHub PR to the shared registry. Use upstream `eikon pack`, `eikon index`,
-and `eikon manifest` for direct-install repos. `eikon publish` is the lower-
-level GitHub PR contribution helper for the configured/default catalog repo,
-not a hosted marketplace account or upload flow.
+listing, use `u` in Studio or Library → Share to catalog after baking: Herm
+runs registry preflight, asks for title/author/description/glyph, previews the
+public bundle, then creates a GitHub PR through local `gh` auth or gives manual
+PR instructions.
+Use upstream `eikon pack`, `eikon index`, and `eikon manifest` for
+direct-install repos. `eikon publish` is the lower-level GitHub PR contribution
+helper for the configured/default catalog repo, not a hosted account, upload,
+dashboard, or moderation flow.
+
+Browser catalog surfaces such as `eikon.liftaris.dev` are discovery-only: they
+preview catalog entries and give copyable `herm eikon install …` instructions.
+Do not imply a browser click installs, activates, authenticates, or mutates Herm.
 
 ## Quick poster
 
@@ -92,10 +121,14 @@ To show a candidate in chat without Studio:
 chafa --size=48x24 --symbols=braille --colors=none --format=symbols --stretch "<path>"
 ```
 
-Preview-only; Studio's output will differ (it tone-maps first).
+Preview-only; Studio's output will differ because it tone-maps first.
 
 ## Don'ts
 
 - Don't hand-write `.eikon` NDJSON.
 - Don't pick knob values for the user. Name the knob.
 - Don't repeat the 48×24 brief.
+- Don't say install activates. Install only writes the local package; Use
+  activates.
+- Don't describe hosted marketplace accounts, upload tokens, dashboards, or
+  browser-native install flows for the v1 registry.


### PR DESCRIPTION
## Provenance

This aligns Herm's shipped Eikon guidance with the current Library / Catalog / Studio lifecycle, current `herm eikon` CLI surface, and current official registry submit flow.

## What changed

- Updated the bundled `eikon` skill to teach the current local Library, shared Catalog, and Studio editing workflow instead of retired Gallery / Marketplace routes.
- Updated `eikon-create` so agents adopt source files with supported media extensions, handle Studio reload caveats, and describe current image/video generation handoff accurately.
- Brought README's Eikon lifecycle section in line with the shipped skills, including `/catalog`, active-package install acknowledgement, current CLI commands, and Studio submit vs Library Share wording.

## Review notes

- Install still does not activate. `use`, Studio `Ctrl+U`, or an explicit Catalog use action activates an eikon.
- Existing profile-installed skill copies are not overwritten by Herm's bundled-skill sync. This PR updates the shipped assets used for fresh installs/new profiles and future copied bundles.
- Browser catalog surfaces remain discovery-only; native install/use behavior stays in Herm or the CLI.

## Verification

- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bunx tsc --noEmit`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun run build`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun test test/eikon-cli.test.ts test/eikon-studio.test.tsx test/eikon-marketplace-ui.test.tsx test/eikon-submit.test.tsx test/eikon-delist.test.ts test/eikon-marketplace.test.ts test/eikon-gen.test.ts test/eikon-service.test.ts test/bundled-skills.test.ts test/eikon-gallery-button.test.tsx`
- `PATH=/home/kaio/.bun/bin:$PATH /home/kaio/.bun/bin/bun run test`
- Frontmatter/final-newline check for both shipped skills
- Stale-term check for current-facing `/marketplace`, Gallery, Marketplace, `Ctrl+K → Eikon`, and obsolete generation wording
- `git diff --check -- README.md assets/skills/eikon/SKILL.md assets/skills/eikon-create/SKILL.md`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a docs and shipped-skill guidance change with no runtime behavior, deployment, data, or service impact.
