### PR TITLE
fix: pass Python source root to gateway child

### DIFF
--- a/src/context/gateway-client.ts
+++ b/src/context/gateway-client.ts
@@ -145,6 +145,7 @@ export class GatewayClient extends EventEmitter {
     if (!env.TERMINAL_CWD) env.TERMINAL_CWD = cwd
     const pp = env.PYTHONPATH?.trim()
     env.PYTHONPATH = pp ? `${root}${delimiter}${pp}` : root
+    env.HERMES_PYTHON_SRC_ROOT = root
 
     // Reset state
     this.ok = false

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "fs"
-import { join, resolve } from "path"
+import { delimiter, join, resolve } from "path"
 import { tmpdir } from "os"
 import { GatewayClient, hermesAgentRoot, python } from "../src/context/gateway-client"
 
@@ -92,6 +92,65 @@ describe("python", () => {
 })
 
 describe("GatewayClient", () => {
+  test("passes Python source root to gateway child env", () => {
+    const prev = Bun.spawn
+    const root = tmp()
+    const cwd = tmp()
+    const py = resolve(root, "bin", "python")
+    let opts: { cwd?: string, env?: Record<string, string> } | undefined
+    ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = (((cmd: string[], cfg: { cwd?: string, env?: Record<string, string> }) => {
+      opts = cfg as typeof opts
+      expect(cmd).toEqual([py, "-u", "-m", "tui_gateway.entry"])
+      return {
+        stdin: { write() { return 0 } },
+        stdout: null,
+        stderr: null,
+        exited: Promise.resolve(null),
+        exitCode: null,
+        kill() {},
+      }
+    }) as unknown) as typeof Bun.spawn
+
+    const env = {
+      root: process.env.HERMES_AGENT_ROOT,
+      py: process.env.HERMES_PYTHON,
+      cwd: process.env.HERMES_CWD,
+      term: process.env.TERMINAL_CWD,
+      path: process.env.PYTHONPATH,
+    }
+    process.env.HERMES_AGENT_ROOT = root
+    process.env.HERMES_PYTHON = py
+    process.env.HERMES_CWD = cwd
+    delete process.env.TERMINAL_CWD
+    process.env.PYTHONPATH = "tail"
+
+    const gw = new GatewayClient()
+    try {
+      gw.start()
+      expect(opts?.cwd).toBe(cwd)
+      expect(opts?.env?.HERMES_AGENT_ROOT).toBe(root)
+      expect(opts?.env?.HERMES_PYTHON).toBe(py)
+      expect(opts?.env?.TERMINAL_CWD).toBe(cwd)
+      expect(opts?.env?.PYTHONPATH).toBe(`${root}${delimiter}tail`)
+      expect(opts?.env?.HERMES_PYTHON_SRC_ROOT).toBe(root)
+    } finally {
+      gw.kill()
+      ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = prev
+      if (env.root === undefined) delete process.env.HERMES_AGENT_ROOT
+      else process.env.HERMES_AGENT_ROOT = env.root
+      if (env.py === undefined) delete process.env.HERMES_PYTHON
+      else process.env.HERMES_PYTHON = env.py
+      if (env.cwd === undefined) delete process.env.HERMES_CWD
+      else process.env.HERMES_CWD = env.cwd
+      if (env.term === undefined) delete process.env.TERMINAL_CWD
+      else process.env.TERMINAL_CWD = env.term
+      if (env.path === undefined) delete process.env.PYTHONPATH
+      else process.env.PYTHONPATH = env.path
+      rmSync(root, { recursive: true, force: true })
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
   test("normalizes outbound JSON-RPC strings to Unicode scalar values", async () => {
     const prev = Bun.spawn
     const enc = new TextEncoder()


### PR DESCRIPTION
## Summary
- Adds HERMES_PYTHON_SRC_ROOT to the gateway child process environment using the same root as PYTHONPATH.
- Covers the spawn env seam with a focused GatewayClient test that preserves cwd, HERMES_AGENT_ROOT, HERMES_PYTHON, TERMINAL_CWD, and PYTHONPATH behavior.

## Test Plan
- bun test test/gateway-client.test.ts
- bunx tsc --noEmit
- bun run build
- bun run test