### PR TITLE
fix: hide unknown splash behind count

### DIFF
--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -203,7 +203,7 @@ export type SessionInfo = {
   mcp_servers?: McpServer[]
   /** hermes-agent version string (e.g. "1.14.2-dev+abc123") */
   release_date?: string
-  /** commits behind origin/main; null = unknown, 0 = up to date */
+  /** commits behind origin/main; null = unknown, negative = update available with unknown count */
   update_behind?: number | null
   /** platform-appropriate update invocation */
   update_command?: string

--- a/src/ui/Splash.tsx
+++ b/src/ui/Splash.tsx
@@ -63,10 +63,11 @@ export function Splash(p: SplashProps) {
   const [tip, setTip] = useState(() => randomTip())
 
   const behind = p.info?.behind
+  const count = behind == null || behind < 0 ? null : behind === 0 ? "up to date" : `${behind} behind`
   const sub = [
     `v${VERSION}`,
     p.info ? `hermes ${p.info.agentVersion ?? "?"}` : "…",
-    behind == null ? null : behind === 0 ? "up to date" : `${behind} behind`,
+    count,
     p.info?.model,
   ].filter(Boolean).join("  ·  ")
 

--- a/test/splash.test.tsx
+++ b/test/splash.test.tsx
@@ -35,6 +35,38 @@ describe("splash (herm-tji.2)", () => {
     t.destroy()
   })
 
+  test("upstream no-count sentinel is not shown as a negative behind count", async () => {
+    seed()
+    const t = await mount({
+      launch: { mode: "new", splash: true },
+      handlers: { "session.create": () => ({ session_id: "test-sid", info: { update_behind: -1 } }) },
+    })
+    await until(t, () => splashUp(t.frame()))
+    expect(t.frame()).not.toContain("-1 behind")
+    expect(t.frame()).not.toContain("-1 commits behind")
+    t.destroy()
+  })
+
+  test("zero and positive behind counts stay visible", async () => {
+    seed()
+    const t = await mount({
+      launch: { mode: "new", splash: true },
+      handlers: { "session.create": () => ({ session_id: "test-sid", info: { update_behind: 0 } }) },
+    })
+    await until(t, () => t.frame().includes("up to date"))
+    expect(t.frame()).toContain("up to date")
+    t.destroy()
+
+    seed()
+    const u = await mount({
+      launch: { mode: "new", splash: true },
+      handlers: { "session.create": () => ({ session_id: "test-sid", info: { update_behind: 3 } }) },
+    })
+    await until(u, () => u.frame().includes("3 behind"))
+    expect(u.frame()).toContain("3 behind")
+    u.destroy()
+  })
+
   test("tip pinned at bottom of inner window; click cycles", async () => {
     seed()
     const t = await mount({ launch: { mode: "new", splash: true } })


### PR DESCRIPTION
## Summary
- hides unknown upstream update sentinels from the splash status line instead of rendering negative behind counts
- keeps explicit `0` and positive behind counts visible
- documents the negative-count sentinel and adds splash regression coverage

## Test Plan
- `bun test test/splash.test.tsx`
- `bun test test/splash-art.test.ts`
- `bunx tsc --noEmit`
- `bun run typecheck`
- `bun test`
