### PR TITLE
feat: surface verification status

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -56,6 +56,7 @@ import { useVoice } from "./voice/useVoice"
 import { VoiceIndicator } from "./voice/Indicator"
 import { sessionCapabilities } from "./app/sessionCapabilities"
 import { useGitBranch } from "./utils/git"
+import { useVerification } from "./app/verification"
 
 type AppProps = { initialTheme?: string; gateway?: Gateway; launch?: Launch; keyOverrides?: Record<string, string> }
 
@@ -855,6 +856,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const inputFocused = focusRegion === "input" && !prompt
   const sidebarVisible = dims.width >= (tab === CHAT_TAB ? 120 : 140) && !hideSidebar
   const branch = useGitBranch(info?.cwd)
+  const vf = useVerification(sid, info?.cwd)
   const hidden = !sidebarVisible ? hiddenSidebar({
     info, usage, profile: activeProfileName(), title: caption, branch,
   }) : undefined
@@ -886,6 +888,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming}
                 status={status}
                 model={info?.model}
+                verification={vf}
                 hidden={hidden}
                 escHint={escHint}
                 queue={queue}

--- a/src/app/verification.ts
+++ b/src/app/verification.ts
@@ -42,10 +42,23 @@ export type VerificationModel = {
   tone: "muted" | "warn" | "ok" | "err"
 }
 
+function evidence(v: unknown): string | undefined {
+  if (typeof v === "string") return v.trim() || undefined
+  if (!v || typeof v !== "object" || Array.isArray(v)) return undefined
+  const rec = v as Record<string, unknown>
+  return ["command", "canonical_command", "message", "summary", "kind", "scope"]
+    .map(key => {
+      const val = rec[key]
+      if (typeof val !== "string") return false
+      return val.trim() && `${key}: ${val.trim()}`
+    })
+    .find(Boolean) || undefined
+}
+
 export function model(v: VerificationState | null | undefined): VerificationModel | null {
   if (!v) return null
   const paths = v.changed_paths?.filter(Boolean) ?? []
-  const evidence = v.evidence?.trim()
+  const detail = evidence(v.evidence)
   const stale = v.status === "stale" && paths.length > 0
     ? `changed: ${paths.slice(0, 3).join(", ")}${paths.length > 3 ? ` +${paths.length - 3}` : ""}`
     : undefined
@@ -53,7 +66,7 @@ export function model(v: VerificationState | null | undefined): VerificationMode
     status: v.status,
     glyph: GLYPHS[v.status],
     label: LABELS[v.status],
-    detail: stale ?? evidence ?? LABELS[v.status],
+    detail: stale ?? detail ?? LABELS[v.status],
     tone: TONES[v.status],
   }
 }

--- a/src/app/verification.ts
+++ b/src/app/verification.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useGateway, useGatewayEvent } from "../context/gateway"
+import type { GatewayEvent, VerificationStatusRequest, VerificationStatusResponse, VerificationState, VerificationStatus } from "../context/wire"
+
+const MUTATES = new Set([
+  "patch",
+  "write_file",
+  "terminal",
+  "execute_code",
+  "image_generate",
+])
+
+const LABELS: Record<VerificationStatus, string> = {
+  not_applicable: "verify n/a",
+  unverified: "verify unverified",
+  passed: "verify passed",
+  failed: "verify failed",
+  stale: "verify stale",
+}
+
+const GLYPHS: Record<VerificationStatus, string> = {
+  not_applicable: "○",
+  unverified: "◇",
+  passed: "✓",
+  failed: "×",
+  stale: "△",
+}
+
+const TONES: Record<VerificationStatus, VerificationModel["tone"]> = {
+  not_applicable: "muted",
+  unverified: "warn",
+  passed: "ok",
+  failed: "err",
+  stale: "warn",
+}
+
+export type VerificationModel = {
+  status: VerificationStatus
+  glyph: string
+  label: string
+  detail: string
+  tone: "muted" | "warn" | "ok" | "err"
+}
+
+export function model(v: VerificationState | null | undefined): VerificationModel | null {
+  if (!v) return null
+  const paths = v.changed_paths?.filter(Boolean) ?? []
+  const evidence = v.evidence?.trim()
+  const stale = v.status === "stale" && paths.length > 0
+    ? `changed: ${paths.slice(0, 3).join(", ")}${paths.length > 3 ? ` +${paths.length - 3}` : ""}`
+    : undefined
+  return {
+    status: v.status,
+    glyph: GLYPHS[v.status],
+    label: LABELS[v.status],
+    detail: stale ?? evidence ?? LABELS[v.status],
+    tone: TONES[v.status],
+  }
+}
+
+function mutates(ev: GatewayEvent): boolean {
+  if (ev.type !== "tool.complete") return false
+  const name = ev.payload.name?.trim()
+  if (!name) return Boolean(ev.payload.inline_diff)
+  return MUTATES.has(name) || Boolean(ev.payload.inline_diff)
+}
+
+export function useVerification(sid: string, cwd?: string): VerificationModel | null {
+  const gw = useGateway()
+  const [state, setState] = useState<VerificationState | null>(null)
+  const disabled = useRef(false)
+  const seq = useRef(0)
+  const sidRef = useRef(sid); sidRef.current = sid
+  const cwdRef = useRef(cwd); cwdRef.current = cwd
+
+  const refresh = useCallback(() => {
+    if (disabled.current || !sidRef.current || !cwdRef.current) {
+      setState(null)
+      return
+    }
+    const n = ++seq.current
+    const params: VerificationStatusRequest = {
+      session_id: sidRef.current,
+      cwd: cwdRef.current,
+    }
+    gw.request<VerificationStatusResponse>("verification.status", params).then(r => {
+      if (n === seq.current) setState(r.verification ?? null)
+    }).catch(() => {
+      disabled.current = true
+      setState(null)
+    })
+  }, [gw])
+
+  useEffect(() => {
+    disabled.current = false
+    refresh()
+  }, [sid, cwd, refresh])
+
+  useGatewayEvent(ev => {
+    if (ev.session_id && sidRef.current && ev.session_id !== sidRef.current) return
+    if (ev.type === "message.complete" || mutates(ev)) refresh()
+  })
+
+  return useMemo(() => model(state), [state])
+}
+
+export * as verification from "./verification"

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -17,6 +17,7 @@ import { acceptCompletion, useCompletion } from "../../app/useCompletion"
 import { frecency } from "../../app/frecency"
 import { useInputHistory, type HistEntry } from "../../app/useInputHistory"
 import { useBackground } from "../../app/background"
+import type { VerificationModel } from "../../app/verification"
 import { PartsBuffer, styles as partStyles, type Part, type FilePart } from "../../app/parts"
 import { SlashPopover } from "./SlashPopover"
 import { AtRefPopover } from "./AtRefPopover"
@@ -58,6 +59,7 @@ type Props = {
   streaming: boolean
   status?: string
   model?: string
+  verification?: VerificationModel | null
   /** Set for ~5s after the first Esc of the interrupt double-tap. */
   escHint?: boolean
   queue?: ReadonlyArray<string>
@@ -397,6 +399,11 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     : props.streaming ? (props.status || "Generating...")
     : "Ready"
   const dot = props.ready ? (props.streaming ? theme.warning : theme.success) : theme.error
+  const vf = props.verification
+  const vfFg = vf?.tone === "ok" ? theme.success
+    : vf?.tone === "err" ? theme.error
+    : vf?.tone === "warn" ? theme.warning
+    : theme.textMuted
 
   // Logical-line row count (wrap-induced growth ignored; yoga sizes the
   // textarea, this only positions the absolute popover above the border).
@@ -558,6 +565,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
         ) : null}
         {bg.count > 0 ? <text fg={theme.text}>▶ {bg.count}  </text> : null}
         {bits.length > 0 ? <text fg={theme.textMuted}>{trunc(bits.join(" · "), 56)}  </text> : null}
+        {vf ? <text fg={vfFg}>{vf.glyph} {trunc(vf.detail, 42)}  </text> : null}
         {props.model ? <text fg={theme.textMuted}>{props.model}</text> : null}
       </box>
     </box>

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -110,7 +110,7 @@ export type VerificationStatus = "not_applicable" | "unverified" | "passed" | "f
 
 export type VerificationState = {
   status: VerificationStatus
-  evidence?: string
+  evidence?: unknown
   root?: string
   session_id?: string
   changed_paths?: string[]

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -106,6 +106,26 @@ export type DelegationStatus = {
   max_concurrent_children: number
 }
 
+export type VerificationStatus = "not_applicable" | "unverified" | "passed" | "failed" | "stale"
+
+export type VerificationState = {
+  status: VerificationStatus
+  evidence?: string
+  root?: string
+  session_id?: string
+  changed_paths?: string[]
+}
+
+export type VerificationStatusRequest = {
+  session_id?: string
+  session_key?: string
+  cwd: string
+}
+
+export type VerificationStatusResponse = {
+  verification?: VerificationState
+}
+
 // spawn_tree.list index entries + spawn_tree.load payload
 export type SpawnTreeEntry = {
   path: string

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -61,6 +61,7 @@ export class MockGateway extends EventEmitter implements Gateway {
     this.on$("session.history", () => ({ count: 0, messages: [] }))
     this.on$("session.save", () => ({ file: "/tmp/conv.json" }))
     this.on$("session.usage", () => ({}))
+    this.on$("verification.status", () => ({}))
     this.on$("commands.catalog", () => ({ pairs: [] }))
     this.on$("cron.manage", () => ({ jobs: [] }))
     this.on$("toolsets.list", () => ({ toolsets: [] }))

--- a/test/verification.test.ts
+++ b/test/verification.test.ts
@@ -26,4 +26,27 @@ describe("verification render model", () => {
 
     expect(model(state)?.detail).toBe("changed: src/app.tsx, src/app/verification.ts, test/verification.test.ts +1")
   })
+
+  test("summarizes object evidence", () => {
+    const state: VerificationState = {
+      status: "passed",
+      evidence: {
+        command: "bun test",
+        status: "passed",
+      },
+    }
+
+    expect(model(state)?.detail).toBe("command: bun test")
+  })
+
+  test("falls back for stale object evidence without changed paths", () => {
+    const state: VerificationState = {
+      status: "stale",
+      evidence: {
+        status: "stale",
+      },
+    }
+
+    expect(model(state)?.detail).toBe("verify stale")
+  })
 })

--- a/test/verification.test.ts
+++ b/test/verification.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { model } from "../src/app/verification"
+import type { VerificationStatus, VerificationState } from "../src/context/wire"
+
+const statuses: VerificationStatus[] = ["not_applicable", "unverified", "passed", "failed", "stale"]
+
+describe("verification render model", () => {
+  test("maps every upstream status distinctly", () => {
+    const rows = statuses.map(status => model({ status, evidence: `${status} evidence` }))
+
+    expect(rows.map(r => r?.status)).toEqual(statuses)
+    expect(new Set(rows.map(r => r?.glyph)).size).toBe(statuses.length)
+    expect(new Set(rows.map(r => r?.label)).size).toBe(statuses.length)
+    expect(rows.map(r => r?.detail)).toEqual(statuses.map(status => `${status} evidence`))
+    expect(rows.find(r => r?.status === "passed")?.tone).toBe("ok")
+    expect(rows.find(r => r?.status === "failed")?.tone).toBe("err")
+    expect(rows.find(r => r?.status === "not_applicable")?.tone).toBe("muted")
+  })
+
+  test("shows stale changed paths before evidence", () => {
+    const state: VerificationState = {
+      status: "stale",
+      evidence: "old pass no longer covers the tree",
+      changed_paths: ["src/app.tsx", "src/app/verification.ts", "test/verification.test.ts", "README.md"],
+    }
+
+    expect(model(state)?.detail).toBe("changed: src/app.tsx, src/app/verification.ts, test/verification.test.ts +1")
+  })
+})


### PR DESCRIPTION
## Summary
- add typed verification.status request/response shapes and active-session polling
- refresh passive verification state after message completion, session/cwd changes, and file-mutating tool completions
- render compact verification indicators in the composer footer, including stale changed paths

## Test Plan
- bun test test/verification.test.ts test/live-session-events.test.tsx test/yolo-status.test.tsx
- bunx tsc --noEmit
- bun run test
- bun run build