### PR TITLE
feat: handle live session title events

### DIFF
--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -12,6 +12,7 @@ import { useToast } from "../ui/toast"
 import { openAlert } from "../dialogs/alert"
 import { mapEvent } from "../context/events"
 import { deriveSkin, type SkinState } from "../context/skin"
+import { home } from "../home"
 import { useBackground } from "./background"
 import type { Action } from "./turnReducer"
 import type { useSession } from "./useSession"
@@ -101,6 +102,12 @@ export function useStream(c: Ctx) {
     timers.current.push(id)
   }, [gw])
 
+  const retitle = useCallback((sid?: string, title?: string) => {
+    if (!sid || title === undefined) return
+    if (sid === ctx.current.sidRef.current) ctx.current.setTitle(title)
+    home.update("recentSessions", rows => rows.map(r => r.id === sid ? { ...r, title } : r))
+  }, [])
+
   const handle = useCallback((ev: GatewayEvent) => {
     const x = ctx.current
     if (ev.type === "gateway.ready") info.current = false
@@ -167,6 +174,7 @@ export function useStream(c: Ctx) {
         })
       },
       onStatus: (text) => x.setStatus(text),
+      onSessionTitle: retitle,
       onApprovalRemembered: () => {
         void gw.request("approval.respond", { choice: "always" }).catch(() => {})
       },
@@ -194,7 +202,7 @@ export function useStream(c: Ctx) {
     flush()
     if (action.kind === "error") x.setErrorPulse(true)
     x.dispatch(action)
-  }, [gw, dialog, toast, flush, bg])
+  }, [gw, dialog, toast, flush, bg, retitle])
 
   useGatewayEvent(handle)
 

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -17,6 +17,7 @@ export type Side = {
   onBackground?: (task_id: string, text: string) => void
   onBtw?: (text: string) => void
   onStatus?: (text: string) => void
+  onSessionTitle?: (sid?: string, title?: string) => void
   onSkin?: (skin: GatewaySkin | null | undefined) => void
   onApprovalRemembered?: () => void
   /** voice.status event — gateway VAD loop state change (listening/transcribing/idle). */
@@ -55,6 +56,10 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       if (si.credential_warning) side.onStatus?.(si.credential_warning)
       return { kind: "system", text: label }
     }
+
+    case "session.title":
+      side.onSessionTitle?.(ev.payload.session_id, ev.payload.title)
+      return null
 
     case "message.start":
       perf.count("stream:start")

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -23,6 +23,7 @@ export type GatewayEvent = ({
   | { type: "gateway.start_timeout"; payload?: { cwd?: string; python?: string } }
   | { type: "gateway.protocol_error"; payload?: { preview?: string } }
   | { type: "session.info"; payload: SessionInfo }
+  | { type: "session.title"; payload: { session_id?: string; title?: string } }
   | { type: "skin.changed"; payload?: GatewaySkin }
   | { type: "message.start"; payload?: undefined }
   | { type: "message.delta"; payload?: { text?: string; rendered?: string } }

--- a/src/home/store.ts
+++ b/src/home/store.ts
@@ -214,6 +214,13 @@ export class HomeStore {
     for (const dep of DEPENDENTS.get(k) ?? []) this.invalidate(dep)
   }
 
+  update<K extends SliceKey>(k: K, fn: (v: HomeState[K]) => HomeState[K]): void {
+    if (!(k in this.data)) return
+    this.data[k] = fn(this.data[k] as HomeState[K])
+    this.notify(k)
+    for (const dep of DEPENDENTS.get(k) ?? []) this.invalidate(dep)
+  }
+
   /** Dispose all watchers and timers. Tests must call this. */
   close(): void {
     for (const ws of this.watchers.values()) for (const w of ws) w.close()

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -9,7 +9,7 @@ import { io as dbio } from "../io"
 import type {
   SessionListItem, SessionListResponse, SessionActiveItem, SessionActiveListResponse,
 } from "../context/wire"
-import { useGateway } from "../context/gateway"
+import { useGateway, useGatewayEvent } from "../context/gateway"
 import { useTheme } from "../theme"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
@@ -654,6 +654,19 @@ export const Sessions = memo((props: Props) => {
   const pick = <T,>(m: Map<string, T>, s: SessionActiveItem) =>
     m.get(s.id) ?? m.get(s.session_key ?? "")
 
+  const patchTitle = useCallback((id?: string, title?: string) => {
+    if (!id || title === undefined) return
+    home.update("recentSessions", rows => rows.map(r => r.id === id ? { ...r, title } : r))
+    setRows(prev => prev.map(row => row.id === id ? { ...row, title, detail: row.detail ? { ...row.detail, title } : row.detail } : row))
+    setLiveRows(prev => prev.map(row => row.id === id || row.live?.session_key === id
+      ? { ...row, title, live: row.live ? { ...row.live, title } : row.live }
+      : row))
+  }, [])
+
+  useGatewayEvent(ev => {
+    if (ev.type === "session.title") patchTitle(ev.payload.session_id, ev.payload.title)
+  })
+
   // Two-stage paint. io.list is off-thread, so the mount frame commits
   // (spinner / cached rows) before it resolves; the RPC is slower still.
   // Kids (subagents per parent) fill in after the list — the tree
@@ -851,15 +864,12 @@ export const Sessions = memo((props: Props) => {
         home.invalidate("recentSessions")
         // Patch in place so the row updates without a full RPC reload
         // (session.list is the slow path). reload still happens next r.
-        setRows(prev => prev.map(row => ids.includes(row.id) ? { ...row, title } : row))
-        setLiveRows(prev => prev.map(row => row.id === r.id
-          ? { ...row, title, live: row.live ? { ...row.live, title } : row.live }
-          : row))
+        ids.forEach(id => patchTitle(id, title))
         toast.show({ variant: "success", message: "Renamed" })
       })
       .catch((e: Error) =>
         toast.show({ variant: "error", message: `Rename failed: ${e.message}` }))
-  }, [gw, dialog, toast, sel])
+  }, [gw, dialog, toast, sel, patchTitle])
 
   const toggle = useCallback(() => {
     const v = visible[sel]

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -34,6 +34,16 @@ describe("mapEvent", () => {
     expect(r.calls.status).toEqual(["no key"])
   })
 
+  test("session.title is side-effect only", () => {
+    const got: unknown[] = []
+    const r = map({
+      type: "session.title",
+      payload: { session_id: "sid-a", title: "Auto Title" },
+    }, { onSessionTitle: (...a) => got.push(a) })
+    expect(r.action).toBeNull()
+    expect(got).toEqual([["sid-a", "Auto Title"]])
+  })
+
   test("message.delta empty → null", () => {
     expect(map({ type: "message.delta", payload: { text: "" } }).action).toBeNull()
     expect(map({ type: "message.delta", payload: { text: "x" } }).action)

--- a/test/live-session-events.test.tsx
+++ b/test/live-session-events.test.tsx
@@ -81,4 +81,41 @@ describe("live session event routing", () => {
     expect(t.frame()).not.toContain("done elsewhere")
     t.destroy()
   })
+
+  test("session.title updates active title without transcript noise", async () => {
+    const gw = new MockGateway({
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "sid-b", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.gw.push({
+      type: "session.title",
+      payload: { session_id: "sid-b", title: "Generated B" },
+    }))
+    await until(t, () => /Title\s+Generated B/.test(t.frame()))
+
+    expect(t.frame()).not.toContain("session.title")
+    t.destroy()
+  })
+
+  test("session.title ignores missing and inactive payloads", async () => {
+    const gw = new MockGateway({
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "sid-b", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => {
+      t.gw.push({ type: "session.title", payload: { title: "No ID" } })
+      t.gw.push({ type: "session.title", payload: { session_id: "sid-b" } })
+      t.gw.push({ type: "session.title", payload: { session_id: "sid-a", title: "Wrong Session" } })
+    })
+    await t.settle()
+
+    expect(t.frame()).not.toContain("No ID")
+    expect(t.frame()).not.toContain("Wrong Session")
+    expect(t.frame()).toMatch(/Title\s+—/)
+    t.destroy()
+  })
 })

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -157,6 +157,29 @@ describe("Sessions tab", () => {
     t.destroy()
   })
 
+  test("session.title event patches the matching sidebar row", async () => {
+    const gw = new MockGateway({
+      "session.active_list": () => ({ sessions: [
+        { id: "live-past", session_key: "past", title: "Past Root", preview: "hello", message_count: 2, started_at: 1700000000, status: "idle" },
+      ]}),
+      "session.list": () => ({ sessions: [
+        { id: "past", title: "Past Root", preview: "hello", message_count: 2, started_at: 1700000000, source: "tui" },
+      ]}),
+    })
+    const disk = [detail({ id: "past", sessionSource: "tui", title: "Past Root", message_count: 2, started_at: 1700000000 })]
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, list: () => disk }} currentId="live-past" />, { gw, width: 120 })
+    await until(t, () => t.frame().includes("Sessions (1)") && t.frame().includes("Past Root"))
+
+    act(() => gw.push({
+      type: "session.title",
+      payload: { session_id: "live-past", title: "Generated Active" },
+    }))
+    await until(t, () => t.frame().includes("Generated Active"))
+
+    expect(t.frame()).not.toContain("Past Root")
+    t.destroy()
+  })
+
   test("lists from session.list RPC and switches on Enter", async () => {
     const gw = new MockGateway({ "session.list": () => ({ sessions: ROWS }) })
     let switched = ""


### PR DESCRIPTION
## Summary
- type and map the upstream session.title push event without transcript output
- update the active session title live when the event matches the current session
- patch Sessions tab/live rows and the recentSessions home cache by session id
- keep existing session.title polling fallback for gateways that do not emit the event

## Verification
- bun test test/gatewayEvents.test.ts test/live-session-events.test.tsx test/sessions.test.tsx
- bunx tsc --noEmit
- bun run build
- bun run test