### PR TITLE
feat: add model options refresh action

### DIFF
--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -30,6 +30,8 @@ type SaveKeyResponse = {
   warning?: string
 }
 
+const REFRESH = "__refresh__"
+
 const configured = (p: ModelOptionProvider) => (p.models?.length ?? 0) > 0
 
 const setupDescription = (p: ModelOptionProvider): string | undefined => {
@@ -67,11 +69,22 @@ const ModelPickerDialog = (props: Props) => {
   const [setupProvider, setSetupProvider] = useState<ModelOptionProvider | null>(null)
   const [global, setGlobal] = useState(false)
 
-  const refresh = useCallback(() => props.gw.request<ModelOptionsResponse>("model.options")
-    .then(setData)
-    .catch(() => setData({ providers: [] })), [props.gw])
+  const load = useCallback((force = false) => props.gw.request<ModelOptionsResponse>("model.options", force ? { refresh: true } : {})
+    .then(r => {
+      setData(d => force || !d ? r : d)
+      return r
+    })
+    .catch(() => {
+      const r = { providers: [] }
+      setData(r)
+      return r
+    }), [props.gw])
 
-  useEffect(() => { void refresh() }, [refresh])
+  const refresh = useCallback(() => {
+    void load(true)
+  }, [load])
+
+  useEffect(() => { void load() }, [load])
 
   const apply = useCallback((model: string, prov: string) => {
     if (props.onApply) return void props.onApply(prov, model)
@@ -91,8 +104,8 @@ const ModelPickerDialog = (props: Props) => {
     try {
       const r = await props.gw.request<SaveKeyResponse>("model.save_key", { slug: p.slug, api_key: key })
       if (r.warning) toast.show({ variant: "warning", message: r.warning })
-      const next = r.provider ?? (await props.gw.request<ModelOptionsResponse>("model.options"))
-        .providers?.find(pp => pp.slug === p.slug)
+      const opts = r.provider ? undefined : await load(true)
+      const next = r.provider ?? opts?.providers?.find(pp => pp.slug === p.slug)
       if (!next) {
         toast.show({ variant: "warning", message: "Provider saved; refresh model options to continue" })
         return
@@ -109,7 +122,7 @@ const ModelPickerDialog = (props: Props) => {
     } catch (e) {
       toast.show({ variant: "error", message: e instanceof Error ? e.message : String(e) })
     }
-  }, [props.gw, toast])
+  }, [props.gw, load, toast])
 
   const setup = useCallback((p: ModelOptionProvider) => {
     const msg = setupDescription(p)
@@ -122,21 +135,26 @@ const ModelPickerDialog = (props: Props) => {
   }, [toast])
 
   const onKey = useCallback((k: { name: string }) => {
+    if (k.name === "f5") { refresh(); return true }
     if (k.name === "tab" && !props.onApply) { setGlobal(g => !g); return true }
     if (k.name === "left" && step !== "provider") { setStep("provider"); return true }
     return false
-  }, [step, props.onApply])
+  }, [step, props.onApply, refresh])
 
   const footer = props.onApply
-    ? <text fg={theme.textMuted}>{step === "model" ? "←: providers" : " "}</text>
+    ? <box height={1} onMouseDown={refresh}>
+      <text fg={theme.textMuted}>{step === "model" ? "F5/Refresh row/click: reload · ←: providers" : "F5/Refresh row/click: reload"}</text>
+    </box>
     : (
-      <text fg={theme.textMuted}>
-        <span>Scope: </span>
-        <span fg={global ? theme.warning : theme.accent}>
-          {global ? "global (persists to config)" : "this session"}
-        </span>
-        <span> · Tab: toggle{step === "model" ? " · ←: providers" : ""}</span>
-      </text>
+      <box height={1} onMouseDown={refresh}>
+        <text fg={theme.textMuted}>
+          <span>Scope: </span>
+          <span fg={global ? theme.warning : theme.accent}>
+            {global ? "global (persists to config)" : "this session"}
+          </span>
+          <span> · F5/Refresh row/click: reload · Tab: toggle{step === "model" ? " · ←: providers" : ""}</span>
+        </text>
+      </box>
     )
 
   if (!data) return <box width={50} padding={1}><text>Loading models…</text></box>
@@ -148,21 +166,25 @@ const ModelPickerDialog = (props: Props) => {
   />
 
   if (step === "provider") {
-    const options: SelectOption[] = (data.providers ?? [])
-      .toSorted((a, b) => Number(Boolean(b.is_current)) - Number(Boolean(a.is_current)))
-      .map(p => ({
-        title: p.name,
-        value: p.slug,
-        description: providerDescription(p),
-        hint: providerHint(p),
-        category: p.is_current ? "Current" : p.authenticated === false ? "Setup required" : "Available",
-      }))
+    const options: SelectOption[] = [
+      ...(data.providers ?? [])
+        .toSorted((a, b) => Number(Boolean(b.is_current)) - Number(Boolean(a.is_current)))
+        .map(p => ({
+          title: p.name,
+          value: p.slug,
+          description: providerDescription(p),
+          hint: providerHint(p),
+          category: p.is_current ? "Current" : p.authenticated === false ? "Setup required" : "Available",
+        })),
+      { title: "Refresh model options", value: REFRESH, description: "force reload from gateway", hint: undefined, category: "Actions" },
+    ]
     return (
       <DialogSelect
         title={props.title ?? "Switch Provider"}
         options={options}
         current={data.provider}
         onSelect={(o) => {
+          if (o.value === REFRESH) return refresh()
           const p = data.providers?.find(pp => pp.slug === o.value)
           if (p?.authenticated === false || (p && !configured(p))) return void setup(p)
           setProvider(o.value)
@@ -176,18 +198,21 @@ const ModelPickerDialog = (props: Props) => {
   }
 
   const p = data.providers?.find(pp => pp.slug === provider)
-  const options: SelectOption[] = (p?.models ?? []).map(m => {
-    const caps = p?.capabilities?.[m]
-    const badges = [
-      caps?.fast ? "fast" : "",
-      caps?.reasoning ? "reasoning" : "",
-    ].filter(Boolean)
-    return {
-      title: m,
-      value: m,
-      hint: badges.length > 0 ? badges.join(" · ") : undefined,
-    }
-  })
+  const options: SelectOption[] = [
+    ...(p?.models ?? []).map(m => {
+      const caps = p?.capabilities?.[m]
+      const badges = [
+        caps?.fast ? "fast" : "",
+        caps?.reasoning ? "reasoning" : "",
+      ].filter(Boolean)
+      return {
+        title: m,
+        value: m,
+        hint: badges.length > 0 ? badges.join(" · ") : undefined,
+      }
+    }),
+    { title: "Refresh model options", value: REFRESH, description: "force reload from gateway", hint: undefined, category: "Actions" },
+  ]
 
   return (
     <DialogSelect
@@ -195,6 +220,7 @@ const ModelPickerDialog = (props: Props) => {
       options={options}
       current={provider === data.provider ? data.model : undefined}
       onSelect={(o) => {
+        if (o.value === REFRESH) return refresh()
         if (provider) apply(o.value, provider)
         dialog.clear()
       }}

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -162,6 +162,72 @@ describe("model-picker", () => {
     t.destroy()
   })
 
+  test("refresh key forces model.options refresh and applies returned providers", async () => {
+    const opts = {
+      provider: "moa",
+      model: "moa/fast",
+      providers: [
+        { slug: "moa", name: "Mixture of Agents", is_current: true, total_models: 1, models: ["moa/fast"] },
+        ...OPTIONS.providers,
+      ],
+    }
+    const calls: Array<Record<string, unknown>> = []
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": (p) => {
+          calls.push(p)
+          return p.refresh ? opts : { providers: [] }
+        },
+      },
+    })
+    await until(t, () => t.frame().includes("Refresh model options"))
+    expect(t.frame()).toContain("Refresh model options")
+
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => t.frame().includes("Mixture of Agents"))
+
+    expect(calls).toEqual([{}, { refresh: true }])
+    expect(t.frame()).toContain("Mixture of Agents")
+    t.destroy()
+  })
+
+  test("save-key fallback refreshes model options before warning", async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": (p) => {
+          calls.push(p)
+          return {
+            providers: [
+              { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
+              {
+                slug: "anthropic",
+                name: "Anthropic",
+                total_models: calls.length > 1 ? 1 : 0,
+                models: calls.length > 1 ? ["claude-sonnet"] : [],
+                authenticated: calls.length > 1,
+                auth_type: "api_key",
+                key_env: "ANTHROPIC_API_KEY",
+                warning: calls.length > 1 ? undefined : "paste ANTHROPIC_API_KEY to activate",
+              },
+            ],
+          }
+        },
+        "model.save_key": () => ({}),
+      },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => t.frame().includes("Paste ANTHROPIC_API_KEY"))
+    await act(async () => { await t.keys.typeText("sk-test") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("claude-sonnet"))
+
+    expect(calls).toEqual([{}, { refresh: true }])
+    t.destroy()
+  })
+
   test("non-api-key unauthenticated providers warn without model.save_key", async () => {
     const saves: Array<Record<string, unknown>> = []
     const t = await mountNode(<Open />, {


### PR DESCRIPTION
## Summary
- adds an explicit model picker refresh action row plus F5/click footer affordance
- calls model.options with { refresh: true } for manual refreshes and save-key fallback refreshes
- keeps MoA rendering generic through returned provider/model rows

## Test Plan
- bun test test/model-picker.test.tsx
- bun test
- bunx tsc --noEmit
- bun run build

MoA observation: no MoA-specific UI handling was needed; the test verifies a returned MoA virtual provider renders through existing provider rows.