### PR TITLE
feat: support kanban project-linked tasks

### DIFF
--- a/src/dialogs/new-task.tsx
+++ b/src/dialogs/new-task.tsx
@@ -2,7 +2,7 @@
 //
 // Layout: a vertical form. Fields top-to-bottom: Title (input), Body
 // (textarea), Assignee / Priority / Triage always visible; Tenant /
-// Workspace / Max runtime / Skills live under a collapsed "More"
+// Project / Workspace / Max runtime / Skills live under a collapsed "More"
 // section ('m' toggles).
 //
 // Navigation:
@@ -57,6 +57,7 @@ export type Draft = {
   parent: string | null
   triage: boolean
   tenant: string | null
+  project: string | null
   workspace: Workspace
   maxRuntime: string | null
   skills: string[]
@@ -78,10 +79,10 @@ export function openCreateTask(
 // Visible-field identifiers. "More" is the collapsible header row.
 type Field =
   | "title" | "body" | "assignee" | "priority" | "triage"
-  | "more" | "tenant" | "workspace" | "maxRuntime" | "skills"
+  | "more" | "tenant" | "project" | "workspace" | "maxRuntime" | "skills"
 
 const CORE: Field[] = ["title", "body", "assignee", "priority", "triage", "more"]
-const MORE: Field[] = ["tenant", "workspace", "maxRuntime", "skills"]
+const MORE: Field[] = ["tenant", "project", "workspace", "maxRuntime", "skills"]
 
 // Fields that open a picker on Space.
 const SELECTY: ReadonlySet<Field> = new Set(["assignee", "priority", "workspace"])
@@ -129,6 +130,7 @@ const Form = (p: {
   const [priority, setPriority] = useState(0)
   const [triage, setTriage] = useState(false)
   const [tenant, setTenant] = useState("")
+  const [project, setProject] = useState("")
   const [workspace, setWorkspace] = useState<Workspace>({ kind: "scratch" })
   const [maxRuntime, setMaxRuntime] = useState("")
 
@@ -190,6 +192,7 @@ const Form = (p: {
       parent: p.parent?.id ?? null,
       triage,
       tenant: tenant.trim() || null,
+      project: project.trim() || null,
       workspace,
       maxRuntime: maxRuntime.trim() || null,
       skills,
@@ -542,12 +545,13 @@ const Form = (p: {
         </box>
         {!more ? (
           <box flexGrow={1} height={1} overflow="hidden">
-            <text fg={theme.textMuted}>tenant · workspace · runtime · skills</text>
+            <text fg={theme.textMuted}>tenant · project · workspace · runtime · skills</text>
           </box>
         ) : null}
       </box>
 
       {more ? textRow("tenant", "Tenant", tenant, setTenant, "namespace (optional)") : null}
+      {more ? textRow("project", "Project", project, setProject, "id/slug (optional)") : null}
       {more ? valRow("workspace", "Workspace", wsLabel(workspace), "Space pick ▾") : null}
       {more ? textRow("maxRuntime", "Runtime", maxRuntime, setMaxRuntime, "e.g. 30m, 2h, 1800 (optional)") : null}
       {more ? skillsRows() : null}

--- a/src/service/hermes-kanban.ts
+++ b/src/service/hermes-kanban.ts
@@ -52,6 +52,7 @@ export type Task = {
   created_at: number; updated_at: number; completed_at: number | null
   result: string | null; error: string | null
   tenant: string | null; pid: number | null
+  project_id: string | null
   workspace_kind: string | null; workspace_path: string | null
   branch_name: string | null
   skills: string[]
@@ -474,6 +475,7 @@ const selectCol = (have: Set<string>, name: string, alias?: string): string => {
 const taskColumns = (have: Set<string>): string => [
   "id", "title", selectCol(have, "body"), selectCol(have, "assignee"),
   "status", "priority", selectCol(have, "tenant"),
+  selectCol(have, "project_id"),
   selectCol(have, "created_at"), selectCol(have, "completed_at"),
   selectCol(have, "result"), selectCol(have, "last_spawn_error"),
   selectCol(have, "worker_pid"),
@@ -506,6 +508,7 @@ const toTask = (r: Record<string, unknown>): Task => ({
   result: (r.result as string) ?? null,
   error: (r.last_spawn_error as string) ?? null,
   tenant: (r.tenant as string) ?? null,
+  project_id: (r.project_id as string) ?? null,
   pid: (r.worker_pid as number) ?? null,
   workspace_kind: (r.workspace_kind as string) ?? null,
   workspace_path: (r.workspace_path as string) ?? null,

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -442,6 +442,14 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] 
                 </box>
               </box>
             : null}
+          {d.project_id
+            ? <box height={1} flexDirection="row" paddingLeft={1}>
+                <box width={10} flexShrink={0}><text fg={theme.textMuted}>Project</text></box>
+                <box flexGrow={1} minWidth={0} overflow="hidden">
+                  <text fg={theme.textMuted}>{d.project_id}</text>
+                </box>
+              </box>
+            : null}
           {d.workspace_kind
             ? <box height={1} flexDirection="row" paddingLeft={1}>
                 <box width={10} flexShrink={0}><text fg={theme.textMuted}>Workspace</text></box>
@@ -903,6 +911,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
         d.parent ? `--parent ${q(d.parent)}` : "",
         d.triage ? "--triage" : "",
         d.tenant ? `--tenant ${q(d.tenant)}` : "",
+        d.project ? `--project ${q(d.project)}` : "",
         ws,
         d.maxRuntime ? `--max-runtime ${q(d.maxRuntime)}` : "",
         ...d.skills.map(s => `--skill ${q(s)}`),

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -766,8 +766,9 @@ describe("Kanban tab", () => {
     await until(t, () => /▸ More/.test(t.frame()))
     await act(async () => { await t.keys.typeText(" ") })   // expand
     await until(t, () => /Workspace/.test(t.frame()))
-    // more→tenant→workspace
+    // more→tenant→project→workspace
     act(() => t.keys.pressArrow("down")); await t.settle() // tenant
+    act(() => t.keys.pressArrow("down")); await t.settle() // project
     act(() => t.keys.pressArrow("down")); await t.settle() // workspace
     await until(t, () => /▸ Workspace/.test(t.frame()))
     await act(async () => { await t.keys.typeText(" ") })   // open workspace picker
@@ -784,6 +785,31 @@ describe("Kanban tab", () => {
     act(() => t.keys.pressEnter({ ctrl: true }))
     await until(t, () => cmds.length === 1)
     expect(cmds[0]).toBe("hermes kanban --board default create 'in a dir' --workspace dir:/tmp/work")
+    t.destroy()
+  })
+
+  test("create form: Project field feeds --project", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "tp", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    await until(t, () => t.frame().includes("Kanban · 3 boards"))
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("New Task"))
+    await act(async () => { await t.keys.typeText("linked task") })
+    await t.settle()
+    for (let i = 0; i < 5; i++) { act(() => t.keys.pressArrow("down")); await t.settle() }
+    await act(async () => { await t.keys.typeText(" ") })
+    await until(t, () => /Project/.test(t.frame()))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    await until(t, () => /▸ Project/.test(t.frame()))
+    await act(async () => { await t.keys.typeText("herm") })
+    await t.settle()
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => cmds.length === 1)
+    expect(cmds[0]).toBe("hermes kanban --board default create 'linked task' --project herm")
     t.destroy()
   })
 
@@ -837,6 +863,7 @@ describe("Kanban tab", () => {
     await act(async () => { await t.keys.typeText(" ") })   // expand
     await until(t, () => /Workspace/.test(t.frame()))
     act(() => t.keys.pressArrow("down")); await t.settle() // tenant
+    act(() => t.keys.pressArrow("down")); await t.settle() // project
     act(() => t.keys.pressArrow("down")); await t.settle() // workspace
     await act(async () => { await t.keys.typeText(" ") })   // open workspace picker
     await until(t, () => /isolated temp dir under the board root/.test(t.frame()))
@@ -1627,26 +1654,27 @@ describe("scheduled status + new fields parity", () => {
     const db = new Database(hermesPath("kanban/boards/sched/kanban.db"), { create: true })
     schema(db)
     db.run("ALTER TABLE tasks ADD COLUMN branch_name TEXT")
+    db.run("ALTER TABLE tasks ADD COLUMN project_id TEXT")
     db.run("ALTER TABLE tasks ADD COLUMN model_override TEXT")
     db.run("ALTER TABLE tasks ADD COLUMN session_id TEXT")
     db.run("ALTER TABLE tasks ADD COLUMN last_heartbeat_at INTEGER")
     const ins = db.prepare(
       `INSERT INTO tasks (id, title, status, priority, created_at,
          started_at, workspace_kind, workspace_path, branch_name,
-         model_override, session_id, last_heartbeat_at, worker_pid)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         project_id, model_override, session_id, last_heartbeat_at, worker_pid)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     // sch1: parked in scheduled, full set of new fields.
     ins.run("sch1", "delayed follow-up", "scheduled", 4, now - 300,
       null, "worktree", "/tmp/wt/sch1", "feat/delayed",
-      "anthropic/claude-sonnet-4", "sess-abc123", null, null)
+      "herm", "anthropic/claude-sonnet-4", "sess-abc123", null, null)
     // sch2: running with model + heartbeat.
     ins.run("sch2", "model-pinned worker", "running", 3, now - 60,
       now - 60, null, null, null,
-      "openrouter/qwen3-coder", null, now - 45, 9999)
+      null, "openrouter/qwen3-coder", null, now - 45, 9999)
     // sch3: plain ready task, exercises null-column fallback.
     ins.run("sch3", "vanilla", "ready", 1, now - 30,
-      null, null, null, null, null, null, null, null)
+      null, null, null, null, null, null, null, null, null)
     db.close()
     resetKanban()
   })
@@ -1661,6 +1689,7 @@ describe("scheduled status + new fields parity", () => {
     const row = b.get("scheduled")?.[0]
     expect(row?.id).toBe("sch1")
     expect(row?.branch_name).toBe("feat/delayed")
+    expect(row?.project_id).toBe("herm")
     expect(row?.model_override).toBe("anthropic/claude-sonnet-4")
     expect(row?.session_id).toBe("sess-abc123")
     expect(row?.workspace_kind).toBe("worktree")
@@ -1675,12 +1704,13 @@ describe("scheduled status + new fields parity", () => {
     // Schema-tolerance: vanilla task has all new fields null.
     const ready = b.get("ready")?.find(t => t.id === "sch3")
     expect(ready?.branch_name).toBeNull()
+    expect(ready?.project_id).toBeNull()
     expect(ready?.model_override).toBeNull()
     expect(ready?.session_id).toBeNull()
     expect(ready?.last_heartbeat_at).toBeNull()
   })
 
-  test("detail pane renders Branch / Model / Session for scheduled task", async () => {
+  test("detail pane renders Project / Branch / Model / Session for scheduled task", async () => {
     const t = await mountNode(<Kanban focused />, { width: 200, height: 60 })
     try {
       await until(t, () => /▾\s+sched/.test(t.frame()))
@@ -1698,6 +1728,7 @@ describe("scheduled status + new fields parity", () => {
       act(() => t.keys.pressEnter())
       await until(t, () => /Title\s+delayed follow-up/.test(t.frame()))
       const f = t.frame()
+      expect(f).toMatch(/Project\s+herm/)
       expect(f).toMatch(/Branch\s+feat\/delayed/)
       expect(f).toMatch(/Model\s+anthropic\/claude-sonnet-4/)
       expect(f).toMatch(/Session\s+sess-abc123/)

--- a/test/new-task-skills.test.tsx
+++ b/test/new-task-skills.test.tsx
@@ -40,6 +40,7 @@ async function walkToSkills(t: Awaited<ReturnType<typeof mountNode>>) {
   await act(async () => { await t.keys.typeText(" ") })
   await until(t, () => /More ▾/.test(t.frame()))
   await tab(); await until(t, () => /▸ Tenant/.test(t.frame()))
+  await tab(); await until(t, () => /▸ Project/.test(t.frame()))
   await tab(); await until(t, () => /▸ Workspace/.test(t.frame()))
   await tab(); await until(t, () => /▸ Runtime/.test(t.frame()))
   await tab(); await until(t, () => /▸ Skills/.test(t.frame()))


### PR DESCRIPTION
## Summary
- read optional Kanban task project_id without breaking older board schemas
- show Project in task details when present
- add Project to the create-task More section and pass --project only when set

## Test Plan
- bun test test/kanban.test.tsx test/new-task-skills.test.tsx
- bunx tsc --noEmit
- bun run test
- bun run build
