### PR TITLE
feat: show idle subagent resume hint

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -886,6 +886,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming}
                 status={status}
                 model={info?.model}
+                subagents={usage?.active_subagents ?? info?.usage?.active_subagents}
                 hidden={hidden}
                 escHint={escHint}
                 queue={queue}

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -132,6 +132,7 @@ export function useStream(c: Ctx) {
       },
       onSessionInfo: (si) => {
         x.setInfo(si)
+        if (si.usage) x.setUsage(si.usage)
         x.setReady(true)
         if (si.session_id) x.setSid(si.session_id)
         x.settle()

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -58,6 +58,7 @@ type Props = {
   streaming: boolean
   status?: string
   model?: string
+  subagents?: number
   /** Set for ~5s after the first Esc of the interrupt double-tap. */
   escHint?: boolean
   queue?: ReadonlyArray<string>
@@ -397,6 +398,10 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     : props.streaming ? (props.status || "Generating...")
     : "Ready"
   const dot = props.ready ? (props.streaming ? theme.warning : theme.success) : theme.error
+  const subagents = typeof props.subagents === "number" ? props.subagents : 0
+  const resume = subagents > 0 && !props.streaming
+    ? subagents === 1 ? "↩ resumes when subagent finishes" : `↩ resumes when ${subagents} subagents finish`
+    : undefined
 
   // Logical-line row count (wrap-induced growth ignored; yoga sizes the
   // textarea, this only positions the absolute popover above the border).
@@ -557,6 +562,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
           <text fg={theme.textMuted}>{keys.print("queue.flush")} to send queued now  </text>
         ) : null}
         {bg.count > 0 ? <text fg={theme.text}>▶ {bg.count}  </text> : null}
+        {resume ? <text fg={theme.textMuted}>{resume}  </text> : null}
         {bits.length > 0 ? <text fg={theme.textMuted}>{trunc(bits.join(" · "), 56)}  </text> : null}
         {props.model ? <text fg={theme.textMuted}>{props.model}</text> : null}
       </box>

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -283,6 +283,7 @@ export type SessionUsageResponse = {
   cache_read?: number
   cache_write?: number
   reasoning?: number
+  active_subagents?: number
   cost_usd?: number
   cost_status?: "estimated" | "exact"
   context_used?: number

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -62,6 +62,7 @@ export type Usage = {
   input: number
   output: number
   total: number
+  active_subagents?: number
   // Context-compression fields — populated when the agent has a
   // ContextCompressor attached (default). Absent on sessions without
   // compression, so consumers must guard with `typeof x === "number"`.

--- a/test/composer-background-fragment.test.tsx
+++ b/test/composer-background-fragment.test.tsx
@@ -8,7 +8,12 @@ const noop = () => {}
 
 // Surface the bg API next to the Composer so the test can register/unregister
 // without reaching into provider internals.
-const Host = ({ grab, composerRef }: { grab: (api: ReturnType<typeof useBackground>) => void; composerRef: React.Ref<ComposerHandle> }) => {
+const Host = ({ grab, composerRef, subagents = 0, streaming = false }: {
+  grab: (api: ReturnType<typeof useBackground>) => void
+  composerRef: React.Ref<ComposerHandle>
+  subagents?: number
+  streaming?: boolean
+}) => {
   const api = useBackground()
   grab(api)
   return (
@@ -17,7 +22,8 @@ const Host = ({ grab, composerRef }: { grab: (api: ReturnType<typeof useBackgrou
       focused
       canSubmitPrompt={true}
       ready
-      streaming={false}
+      streaming={streaming}
+      subagents={subagents}
       cmds={[]}
       model="test-model"
       onSend={noop}
@@ -26,12 +32,12 @@ const Host = ({ grab, composerRef }: { grab: (api: ReturnType<typeof useBackgrou
   )
 }
 
-const mountComposer = async () => {
+const mountComposer = async (opts: { subagents?: number; streaming?: boolean } = {}) => {
   const ref = createRef<ComposerHandle>()
   let api: ReturnType<typeof useBackground> | undefined
   const t = await mountNode(
     <BackgroundProvider>
-      <Host grab={a => { api = a }} composerRef={ref} />
+      <Host grab={a => { api = a }} composerRef={ref} subagents={opts.subagents} streaming={opts.streaming} />
     </BackgroundProvider>,
     { width: 80, height: 8 },
   )
@@ -69,6 +75,30 @@ describe("Composer background fragment", () => {
     await until(t, () => t.frame().includes("▶ 1"))
     act(() => { get().unregister("a") })
     await until(t, () => !t.frame().includes("▶"))
+    t.destroy()
+  })
+
+  test("shows idle subagent auto-resume hint", async () => {
+    const { t } = await mountComposer({ subagents: 1 })
+    expect(t.frame()).toContain("↩ resumes when subagent finishes")
+    t.destroy()
+  })
+
+  test("pluralizes idle subagent auto-resume hint", async () => {
+    const { t } = await mountComposer({ subagents: 3 })
+    expect(t.frame()).toContain("↩ resumes when 3 subagents finish")
+    t.destroy()
+  })
+
+  test("hides subagent auto-resume hint while streaming", async () => {
+    const { t } = await mountComposer({ subagents: 2, streaming: true })
+    expect(t.frame()).not.toContain("resumes when")
+    t.destroy()
+  })
+
+  test("hides subagent auto-resume hint when count is zero", async () => {
+    const { t } = await mountComposer({ subagents: 0 })
+    expect(t.frame()).not.toContain("resumes when")
     t.destroy()
   })
 })

--- a/test/subagent-resume-hint.test.tsx
+++ b/test/subagent-resume-hint.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, until } from "./harness"
+
+describe("subagent resume hint", () => {
+  test("session info usage shows idle auto-resume hint", async () => {
+    const t = await mount({ handlers: {
+      "session.create": () => ({
+        session_id: "test-sid",
+        info: {
+          model: "test-model",
+          session_id: "test-sid",
+          tools: {},
+          skills: {},
+          usage: { input: 0, output: 0, total: 0, active_subagents: 1 },
+        },
+      }),
+    } })
+
+    await until(t, () => t.frame().includes("↩ resumes when subagent finishes"))
+    t.destroy()
+  })
+
+  test("hides idle auto-resume hint for zero and undefined counts", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+    expect(t.frame()).not.toContain("resumes when")
+
+    act(() => t.gw.push({
+      type: "session.info",
+      payload: {
+        model: "test-model",
+        session_id: "test-sid",
+        tools: {},
+        skills: {},
+        usage: { input: 0, output: 0, total: 0, active_subagents: 0 },
+      },
+    }))
+    await until(t, () => t.frame().includes("Ready"))
+    expect(t.frame()).not.toContain("resumes when")
+    t.destroy()
+  })
+
+  test("pluralizes idle auto-resume hint from live session info", async () => {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+
+    act(() => t.gw.push({
+      type: "session.info",
+      payload: {
+        model: "test-model",
+        session_id: "test-sid",
+        tools: {},
+        skills: {},
+        usage: { input: 0, output: 0, total: 0, active_subagents: 3 },
+      },
+    }))
+    await until(t, () => t.frame().includes("↩ resumes when 3 subagents finish"))
+    t.destroy()
+  })
+
+  test("hides auto-resume hint while streaming", async () => {
+    const t = await mount({ handlers: {
+      "session.create": () => ({
+        session_id: "test-sid",
+        info: {
+          model: "test-model",
+          session_id: "test-sid",
+          tools: {},
+          skills: {},
+          usage: { input: 0, output: 0, total: 0, active_subagents: 2 },
+        },
+      }),
+    } })
+    await until(t, () => t.frame().includes("↩ resumes when 2 subagents finish"))
+
+    act(() => t.gw.push({ type: "message.start", session_id: "test-sid" }))
+    await until(t, () => !t.frame().includes("resumes when") && !t.frame().includes("Ready"))
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `active_subagents` to Herm usage wire types and refreshes live usage from `session.info` events.
- Shows a compact idle composer-footer hint when active subagents remain in flight: `↩ resumes when subagent finishes` / `↩ resumes when N subagents finish`.
- Hides the hint for zero/undefined counts and while a turn is streaming.

## Verification
- `bun test test/subagent-resume-hint.test.tsx test/composer-background-fragment.test.tsx`
- `bunx tsc --noEmit`
- `bun run test`
- `bun run build`

## Notes
- Build initially failed because the isolated worktree did not have `node_modules`; symlinked the ignored primary checkout `node_modules` into the worktree, then build passed.
