### PR TITLE
feat: surface typed kanban block state

### DIFF
--- a/src/service/hermes-kanban.ts
+++ b/src/service/hermes-kanban.ts
@@ -60,7 +60,11 @@ export type Task = {
   model_override: string | null
   session_id: string | null
   last_heartbeat_at: number | null
+  block_kind: BlockKind | null
+  block_recurrences: number
 }
+
+export type BlockKind = "dependency" | "needs_input" | "capability" | "transient"
 
 export type Run = {
   id: number; profile: string | null
@@ -483,8 +487,14 @@ const taskColumns = (have: Set<string>): string => [
   selectCol(have, "max_retries"),
   selectCol(have, "model_override"), selectCol(have, "session_id"),
   selectCol(have, "last_heartbeat_at"),
+  selectCol(have, "block_kind"), selectCol(have, "block_recurrences"),
   `${AT} AS updated_at`,
 ].join(", ")
+
+const BLOCK_KINDS = new Set<BlockKind>(["dependency", "needs_input", "capability", "transient"])
+
+const parseKind = (raw: unknown): BlockKind | null =>
+  typeof raw === "string" && BLOCK_KINDS.has(raw as BlockKind) ? raw as BlockKind : null
 
 const parseSkills = (raw: unknown): string[] => {
   if (typeof raw !== "string" || !raw) return []
@@ -516,6 +526,8 @@ const toTask = (r: Record<string, unknown>): Task => ({
   model_override: (r.model_override as string) ?? null,
   session_id: (r.session_id as string) ?? null,
   last_heartbeat_at: (r.last_heartbeat_at as number) ?? null,
+  block_kind: parseKind(r.block_kind),
+  block_recurrences: Math.max(0, Number(r.block_recurrences) || 0),
 })
 
 const toRun = (r: Record<string, unknown>): Run => ({

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -5,7 +5,7 @@ import {
   boardStateOf, detailOf, tailLogOf, assignees, q, STATUSES,
   currentBoard, listBoards, resetKanban, patchTask,
   parseDiagnostics, maxSeverity, sortDiags,
-  type Task, type Status, type Detail, type Board,
+  type Task, type Status, type Detail, type Board, type BlockKind,
   type Diag, type Severity, type BoardError,
 } from "../service/hermes-kanban"
 import { useKeys } from "../keys"
@@ -183,11 +183,42 @@ type SevTheme = { warning: import("@opentui/core").RGBA; error: import("@opentui
 const sevColor = (sev: Severity, theme: SevTheme) =>
   sev === "warning" ? theme.warning : theme.error
 
+const KIND: Record<BlockKind, string> = {
+  dependency: "dependency-wait",
+  needs_input: "needs-input",
+  capability: "capability",
+  transient: "transient",
+}
+const MARK: Record<BlockKind, string> = {
+  dependency: "dep",
+  needs_input: "input",
+  capability: "cap",
+  transient: "tmp",
+}
+
+const blockText = (t: Pick<Task, "block_kind" | "block_recurrences">): string => {
+  const kind = t.block_kind ? KIND[t.block_kind] : ""
+  const loop = t.block_recurrences > 1 ? `loop×${t.block_recurrences}` : ""
+  if (kind && loop) return `${kind} · ${loop}`
+  return kind || loop
+}
+
+const cardMark = (t: Pick<Task, "block_kind" | "block_recurrences">): string => {
+  if (t.block_kind) return `[${MARK[t.block_kind]}${t.block_recurrences > 1 ? `×${t.block_recurrences}` : ""}]`
+  return t.block_recurrences > 1 ? `[loop×${t.block_recurrences}]` : ""
+}
+
+const statusText = (t: Task): string => {
+  const block = blockText(t)
+  return block ? `${t.status} · ${block}` : t.status
+}
+
 const Card = memo((p: {
   id: string; t: Task; on: boolean; hov: boolean; sev: Severity | null
   onHover: () => void; onPick: () => void
 }) => {
   const theme = useTheme().theme
+  const mark = cardMark(p.t)
   return (
     <box id={p.id} height={2} flexDirection="row" paddingLeft={1}
          border={RULE} borderStyle="single" borderColor={theme.borderSubtle}
@@ -195,6 +226,7 @@ const Card = memo((p: {
          onMouseDown={p.onPick}
          onMouseMove={p.onHover}>
       <Ticker active={p.on || p.hov} fg={p.on ? theme.accent : theme.text}>
+        {mark ? <><span fg={theme.warning}>{mark}</span>{" "}</> : null}
         {p.sev
           ? <><span fg={sevColor(p.sev, theme)}>{SEV_GLYPH[p.sev]}</span>{" "}</>
           : null}
@@ -410,7 +442,7 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] 
       <box height={1}>
         <text>
           <span fg={theme.primary}><strong>{d.id}</strong></span>
-          <span fg={theme.textMuted}>{`  ·  ${p.pane.slug}  ·  ${d.status}  ·  ${ago(d.updated_at)}`}</span>
+          <span fg={theme.textMuted}>{`  ·  ${p.pane.slug}  ·  ${statusText(d)}  ·  ${ago(d.updated_at)}`}</span>
         </text>
       </box>
       <scrollbox scrollY flexGrow={1}>
@@ -430,7 +462,7 @@ const SidePane = memo((p: { pane: Pane; on: boolean; sel: number; diags: Diag[] 
             p.on && cur === "assignee" ? "Enter pick" : undefined)}
           {srow("priority", "Priority", d.priority ? `P${d.priority}` : "—",
             p.on && cur === "priority" ? "Enter select" : undefined)}
-          {srow("status", "Status", d.status,
+          {srow("status", "Status", statusText(d),
             p.on && cur === "status" ? "Enter change" : undefined)}
           {srow("parents", "Parents", d.parents.length ? d.parents.join(", ") : "—",
             p.on && cur === "parents" ? "Enter add/remove" : undefined)}
@@ -1084,6 +1116,30 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     })
   }, [dialog, sh, toast])
 
+  const block = useCallback((t: Task) => {
+    const opts: Array<{ title: string; value: string; description?: string }> = [
+      { title: "generic", value: "", description: "legacy block without --kind" },
+      { title: "needs input", value: "needs_input", description: "human answer required" },
+      { title: "dependency", value: "dependency", description: "wait in todo until parents finish" },
+      { title: "capability", value: "capability", description: "missing tool, credential, or profile capability" },
+      { title: "transient", value: "transient", description: "temporary/flaky condition" },
+    ]
+    dialog.replace(
+      <DialogSelect title={`Block kind for ${t.id}`} options={opts}
+        current={t.block_kind ?? ""} filterable={false}
+        onSelect={async o => {
+          dialog.clear()
+          const r = await openTextPrompt(dialog, {
+            title: `Block ${t.id}`, label: "Reason (optional, posted as comment)",
+          })
+          const arg = r ? ` ${q(r)}` : ""
+          const kind = o.value ? ` --kind ${q(o.value)}` : ""
+          void sh(`block ${q(t.id)}${arg}${kind}`,
+            o.value === "dependency" ? `Dependency-wait ${t.id}` : `Blocked ${t.id}`)
+        }} />,
+    )
+  }, [dialog, sh])
+
   const editStatus = useCallback((t: Task) => {
     // Only expose transitions the CLI has verbs for. 'unblock' covers
     // both blocked (human-waiting) and scheduled (time-waiting) per
@@ -1093,7 +1149,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
     if (t.status !== "done") opts.push({ title: "done", value: "complete",
       description: "mark complete (prompts for result)" })
     if (t.status !== "blocked") opts.push({ title: "blocked", value: "block",
-      description: "mark blocked (prompts for reason)" })
+      description: "mark blocked (choose kind, prompts for reason)" })
     if (t.status !== "scheduled") opts.push({ title: "scheduled", value: "schedule",
       description: "park until externally unblocked (prompts for reason)" })
     if (t.status === "blocked" || t.status === "scheduled")
@@ -1114,14 +1170,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
             void sh(`complete ${q(t.id)}${flag}`, `Completed ${t.id}`)
             return
           }
-          if (o.value === "block") {
-            const r = await openTextPrompt(dialog, {
-              title: `Block ${t.id}`, label: "Reason (optional, posted as comment)",
-            })
-            const arg = r ? ` ${q(r)}` : ""
-            void sh(`block ${q(t.id)}${arg}`, `Blocked ${t.id}`)
-            return
-          }
+          if (o.value === "block") return block(t)
           if (o.value === "schedule") {
             const r = await openTextPrompt(dialog, {
               title: `Schedule ${t.id}`, label: "Reason (optional, posted as comment)",
@@ -1135,7 +1184,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
           if (o.value === "archive") return void archive(t)
         }} />,
     )
-  }, [dialog, sh, archive])
+  }, [dialog, sh, archive, block])
 
   const editParents = useCallback((t: Task) => {
     // Parents live on Detail, not Task; look up the current pane

--- a/src/tabs/Kanban.tsx
+++ b/src/tabs/Kanban.tsx
@@ -59,6 +59,7 @@ import type { Source } from "../service/hermes-home"
 
 type Sh = { stdout: string; stderr: string; code: number }
 type Tier = "head" | "filter" | "grid" | "pane"
+type BlockSupport = "unknown" | "yes" | "no"
 
 // Column scrollbars hidden — the column border + ↑↓ are enough
 // signal at kanban card density; the bar steals a col per status.
@@ -211,6 +212,16 @@ const cardMark = (t: Pick<Task, "block_kind" | "block_recurrences">): string => 
 const statusText = (t: Task): string => {
   const block = blockText(t)
   return block ? `${t.status} · ${block}` : t.status
+}
+
+const supportsKind = (r: Sh): boolean =>
+  r.code === 0 && /--kind\b/.test(r.stdout)
+
+const unsupportedKind = (r: Sh): boolean => {
+  const s = `${r.stderr}\n${r.stdout}`.toLowerCase()
+  return r.code !== 0 && s.includes("--kind")
+    && (s.includes("unrecognized") || s.includes("no such option")
+      || s.includes("unknown option") || s.includes("invalid option"))
 }
 
 const Card = memo((p: {
@@ -721,6 +732,7 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   const [chip, setChip] = useState(0)
   const [paneSel, setPaneSel] = useState(0)
   const [pane, setPane] = useState<Pane | null>(null)
+  const [blocks, setBlocks] = useState<Map<string, BlockSupport>>(() => new Map())
 
   const outer = useRef<ScrollBoxRenderable | null>(null)
 
@@ -839,6 +851,43 @@ export const Kanban = memo((props: { focused?: boolean }) => {
       return r.stdout
     }).catch((e: Error) => void toast.show({ variant: "error", message: trunc(e.message, 120) })),
   [gw, toast, load, at])
+
+  const blockSupport = useCallback(async (s: string): Promise<BlockSupport> => {
+    const cur = blocks.get(s)
+    if (cur === "yes" || cur === "no") return cur
+    const next = await gw.request<Sh>("shell.exec", { command: `hermes kanban --board ${q(s)} block --help` })
+      .then(r => supportsKind(r) ? "yes" as const : "no" as const)
+      .catch(() => "no" as const)
+    setBlocks(m => {
+      const out = new Map(m)
+      out.set(s, next)
+      return out
+    })
+    return next
+  }, [blocks, gw])
+
+  const runBlock = useCallback((t: Task, reason: string | null, kind: string) => {
+    const slug = live.current.at
+    const arg = reason ? ` ${q(reason)}` : ""
+    const suffix = kind ? ` --kind ${q(kind)}` : ""
+    const ok = kind === "dependency" ? `Dependency-wait ${t.id}` : `Blocked ${t.id}`
+    return gw.request<Sh>("shell.exec", { command: `hermes kanban --board ${q(slug)} block ${q(t.id)}${arg}${suffix}` })
+      .then(r => {
+        if (unsupportedKind(r) && kind) {
+          setBlocks(m => {
+            const out = new Map(m)
+            out.set(slug, "no")
+            return out
+          })
+          throw new Error("active Hermes CLI does not support typed block kinds; choose generic block")
+        }
+        if (r.code !== 0) throw new Error((r.stderr || r.stdout || `exit ${r.code}`).trim())
+        toast.show({ variant: "success", message: ok })
+        resetKanban()
+        load()
+        return r.stdout
+      }).catch((e: Error) => void toast.show({ variant: "error", message: trunc(e.message, 120) }))
+  }, [gw, toast, load])
 
   // Direct bun:sqlite patch — title/body/priority only. Mirrors
   // dashboard PATCH /tasks/:id. Refreshes on success (no shell round-trip).
@@ -1117,28 +1166,33 @@ export const Kanban = memo((props: { focused?: boolean }) => {
   }, [dialog, sh, toast])
 
   const block = useCallback((t: Task) => {
-    const opts: Array<{ title: string; value: string; description?: string }> = [
-      { title: "generic", value: "", description: "legacy block without --kind" },
-      { title: "needs input", value: "needs_input", description: "human answer required" },
-      { title: "dependency", value: "dependency", description: "wait in todo until parents finish" },
-      { title: "capability", value: "capability", description: "missing tool, credential, or profile capability" },
-      { title: "transient", value: "transient", description: "temporary/flaky condition" },
-    ]
-    dialog.replace(
-      <DialogSelect title={`Block kind for ${t.id}`} options={opts}
-        current={t.block_kind ?? ""} filterable={false}
-        onSelect={async o => {
-          dialog.clear()
-          const r = await openTextPrompt(dialog, {
-            title: `Block ${t.id}`, label: "Reason (optional, posted as comment)",
-          })
-          const arg = r ? ` ${q(r)}` : ""
-          const kind = o.value ? ` --kind ${q(o.value)}` : ""
-          void sh(`block ${q(t.id)}${arg}${kind}`,
-            o.value === "dependency" ? `Dependency-wait ${t.id}` : `Blocked ${t.id}`)
-        }} />,
-    )
-  }, [dialog, sh])
+    void blockSupport(live.current.at).then(support => {
+      if (support === "no") {
+        return openTextPrompt(dialog, {
+          title: `Block ${t.id}`,
+          label: "Reason (optional; generic block — active CLI has no --kind)",
+        }).then(r => { if (r !== null) void runBlock(t, r, "") })
+      }
+      const opts: Array<{ title: string; value: string; description?: string }> = [
+        { title: "generic", value: "", description: "legacy block without --kind" },
+        { title: "needs input", value: "needs_input", description: "human answer required" },
+        { title: "dependency", value: "dependency", description: "wait in todo until parents finish" },
+        { title: "capability", value: "capability", description: "missing tool, credential, or profile capability" },
+        { title: "transient", value: "transient", description: "temporary/flaky condition" },
+      ]
+      dialog.replace(
+        <DialogSelect title={`Block kind for ${t.id}`} options={opts}
+          current={t.block_kind ?? ""} filterable={false}
+          onSelect={async o => {
+            dialog.clear()
+            const r = await openTextPrompt(dialog, {
+              title: `Block ${t.id}`, label: "Reason (optional, posted as comment)",
+            })
+            if (r !== null) void runBlock(t, r, o.value)
+          }} />,
+      )
+    })
+  }, [dialog, blockSupport, runBlock])
 
   const editStatus = useCallback((t: Task) => {
     // Only expose transitions the CLI has verbs for. 'unblock' covers

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -548,10 +548,16 @@ describe("Kanban tab", () => {
     t.destroy()
   })
 
-  test("status editor block path passes typed --kind", async () => {
+  test("status editor uses typed --kind when active CLI supports it", async () => {
     const cmds: string[] = []
     const gw = new MockGateway({
-      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
+      "shell.exec": p => {
+        const cmd = p.command as string
+        if (/\bdiagnostics\b/.test(cmd)) return { stdout: "", stderr: "", code: 0 }
+        cmds.push(cmd)
+        if (/\bblock --help$/.test(cmd)) return { stdout: "usage: hermes kanban block [--kind KIND]", stderr: "", code: 0 }
+        return { stdout: "", stderr: "", code: 0 }
+      },
     })
     const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
     try {
@@ -571,12 +577,95 @@ describe("Kanban tab", () => {
       act(() => t.keys.pressArrow("down")); await t.settle()
       act(() => t.keys.pressEnter())
       await until(t, () => t.frame().includes("Block kind for t1"))
+      act(() => t.keys.pressArrow("down")); await t.settle()
       act(() => t.keys.pressEnter())
       await until(t, () => t.frame().includes("Block t1"))
       await act(async () => { await t.keys.typeText("need answer") })
       act(() => t.keys.pressEnter())
-      await until(t, () => cmds.length === 1)
-      expect(cmds[0]).toBe("hermes kanban --board default block t1 'need answer' --kind needs_input")
+      await until(t, () => cmds.length === 2)
+      expect(cmds[0]).toBe("hermes kanban --board default block --help")
+      expect(cmds[1]).toBe("hermes kanban --board default block t1 'need answer' --kind needs_input")
+    } finally {
+      t.destroy()
+    }
+  })
+
+  test("status editor falls back to generic block when active CLI lacks --kind", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => {
+        const cmd = p.command as string
+        if (/\bdiagnostics\b/.test(cmd)) return { stdout: "", stderr: "", code: 0 }
+        cmds.push(cmd)
+        if (/\bblock --help$/.test(cmd)) return { stdout: "usage: hermes kanban block task_id [reason ...] [--ids IDS]", stderr: "", code: 0 }
+        return { stdout: "", stderr: "", code: 0 }
+      },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    try {
+      await until(t, () => t.frame().includes("Kanban · 3 boards"))
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => /Status\s+ready/.test(t.frame()))
+      act(() => t.keys.pressTab()); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("Status for t1"))
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("generic block"))
+      await act(async () => { await t.keys.typeText("need answer") })
+      act(() => t.keys.pressEnter())
+      await until(t, () => cmds.length === 2)
+      expect(cmds[0]).toBe("hermes kanban --board default block --help")
+      expect(cmds[1]).toBe("hermes kanban --board default block t1 'need answer'")
+    } finally {
+      t.destroy()
+    }
+  })
+
+  test("status editor sends dependency kind when active CLI supports typed blocks", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => {
+        const cmd = p.command as string
+        if (/\bdiagnostics\b/.test(cmd)) return { stdout: "", stderr: "", code: 0 }
+        cmds.push(cmd)
+        if (/\bblock --help$/.test(cmd)) return { stdout: "usage: hermes kanban block [--kind KIND]", stderr: "", code: 0 }
+        return { stdout: "", stderr: "", code: 0 }
+      },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    try {
+      await until(t, () => t.frame().includes("Kanban · 3 boards"))
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => /Status\s+ready/.test(t.frame()))
+      act(() => t.keys.pressTab()); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("Status for t1"))
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("Block kind for t1"))
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("Block t1"))
+      await act(async () => { await t.keys.typeText("waiting on t3") })
+      act(() => t.keys.pressEnter())
+      await until(t, () => cmds.length === 2)
+      expect(cmds[1]).toBe("hermes kanban --board default block t1 'waiting on t3' --kind dependency")
     } finally {
       t.destroy()
     }

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -19,6 +19,7 @@ const schema = (db: Database) => {
   db.run(`CREATE TABLE IF NOT EXISTS tasks (
     id TEXT PRIMARY KEY, title TEXT, body TEXT, assignee TEXT,
     status TEXT, priority INTEGER DEFAULT 0, tenant TEXT,
+    block_kind TEXT, block_recurrences INTEGER DEFAULT 0,
     created_at INTEGER, started_at INTEGER, completed_at INTEGER,
     result TEXT, last_spawn_error TEXT, worker_pid INTEGER,
     workspace_kind TEXT, workspace_path TEXT,
@@ -47,9 +48,14 @@ const schema = (db: Database) => {
 
 
 const cleanupHazardBoards = () => {
-  for (const slug of ["bad", "missing", "quarantined", "ui_bad", "unreadable"])
+  for (const slug of ["bad", "missing", "old", "quarantined", "ui_bad", "unreadable"])
     rmSync(hermesPath(`kanban/boards/${slug}`), { recursive: true, force: true })
   rmSync(hermesPath("kanban.db.corrupt.20260527_010204.bak"), { force: true })
+  try {
+    const db = new Database(hermesPath("kanban.db"))
+    db.run("UPDATE tasks SET block_kind = NULL, block_recurrences = 0")
+    db.close()
+  } catch {}
   resetKanban()
 }
 
@@ -136,6 +142,33 @@ describe("hermes-kanban readers", () => {
     expect(boardOf("atm10").get("ready")?.[0]?.id).toBe("m1")
     expect(boardOf("default").get("ready")?.[0]?.id).toBe("t1")
     expect([...boardOf("zeta").values()].every(v => v.length === 0)).toBe(true)
+  })
+
+  test("boardOf() reads typed block state when present and tolerates old schema", () => {
+    const db = new Database(hermesPath("kanban.db"))
+    db.run("UPDATE tasks SET block_kind = 'needs_input', block_recurrences = 2 WHERE id = 't5'")
+    db.close()
+    resetKanban()
+
+    const blocked = boardOf("default").get("blocked")?.find(t => t.id === "t5")
+    expect(blocked?.block_kind).toBe("needs_input")
+    expect(blocked?.block_recurrences).toBe(2)
+
+    mkdirSync(hermesPath("kanban/boards/old"), { recursive: true })
+    const old = new Database(hermesPath("kanban/boards/old/kanban.db"), { create: true })
+    old.run(`CREATE TABLE tasks (
+      id TEXT PRIMARY KEY, title TEXT, body TEXT, assignee TEXT,
+      status TEXT, priority INTEGER DEFAULT 0, created_at INTEGER,
+      started_at INTEGER, completed_at INTEGER
+    )`)
+    old.run("INSERT INTO tasks (id, title, status, priority, created_at) VALUES ('old1', 'legacy board', 'ready', 1, ?)", [now])
+    old.close()
+    resetKanban()
+
+    const legacy = boardOf("old").get("ready")?.[0]
+    expect(legacy?.id).toBe("old1")
+    expect(legacy?.block_kind).toBeNull()
+    expect(legacy?.block_recurrences).toBe(0)
   })
 
 
@@ -513,6 +546,40 @@ describe("Kanban tab", () => {
     expect(cmds[0]).toBe("hermes kanban --board default comment t5 'use user_id' --author user")
     expect(cmds[1]).toBe("hermes kanban --board default unblock t5")
     t.destroy()
+  })
+
+  test("status editor block path passes typed --kind", async () => {
+    const cmds: string[] = []
+    const gw = new MockGateway({
+      "shell.exec": p => { if (!/\bdiagnostics\b/.test(p.command as string)) cmds.push(p.command as string); return { stdout: "", stderr: "", code: 0 } },
+    })
+    const t = await mountNode(<Kanban focused />, { gw, width: 180, height: 44 })
+    try {
+      await until(t, () => t.frame().includes("Kanban · 3 boards"))
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => /Status\s+ready/.test(t.frame()))
+      act(() => t.keys.pressTab()); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("Status for t1"))
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("Block kind for t1"))
+      act(() => t.keys.pressEnter())
+      await until(t, () => t.frame().includes("Block t1"))
+      await act(async () => { await t.keys.typeText("need answer") })
+      act(() => t.keys.pressEnter())
+      await until(t, () => cmds.length === 1)
+      expect(cmds[0]).toBe("hermes kanban --board default block t1 'need answer' --kind needs_input")
+    } finally {
+      t.destroy()
+    }
   })
 
   test("d → confirm → archive", async () => {
@@ -1701,6 +1768,31 @@ describe("scheduled status + new fields parity", () => {
       expect(f).toMatch(/Branch\s+feat\/delayed/)
       expect(f).toMatch(/Model\s+anthropic\/claude-sonnet-4/)
       expect(f).toMatch(/Session\s+sess-abc123/)
+    } finally {
+      t.destroy()
+    }
+  })
+
+  test("typed dependency and recurrence state render on cards and detail pane", async () => {
+    const db = new Database(hermesPath("kanban/boards/sched/kanban.db"))
+    db.run("UPDATE tasks SET block_kind = 'dependency', block_recurrences = 1 WHERE id = 'sch1'")
+    db.run("UPDATE tasks SET block_kind = 'capability', block_recurrences = 3 WHERE id = 'sch3'")
+    db.close()
+    resetKanban()
+
+    const t = await mountNode(<Kanban focused />, { width: 210, height: 60 })
+    try {
+      await until(t, () => /\[dep\]\s+delayed follow-up/.test(t.frame()))
+      expect(t.frame()).toMatch(/\[cap×3\]\s+vanilla/)
+      act(() => t.keys.pressTab()); await t.settle()
+      act(() => t.keys.pressTab()); await t.settle()
+      act(() => t.keys.pressTab()); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("down")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressArrow("right")); await t.settle()
+      act(() => t.keys.pressEnter())
+      await until(t, () => /Status\s+scheduled · dependency-wait/.test(t.frame()))
     } finally {
       t.destroy()
     }


### PR DESCRIPTION
## Summary
- read optional `tasks.block_kind` / `tasks.block_recurrences` in Herm's Kanban SQLite path while preserving old-schema boards
- surface typed block state on cards and detail/status rows, including dependency-wait and recurrence loop markers
- add a block-kind picker so status changes can call `hermes kanban block ... --kind needs_input|dependency|capability|transient` while keeping generic blocks available

## Verification
- `bun test test/kanban.test.tsx`
- `bunx tsc --noEmit`
- `bun run test`
- `bun run build` (after symlinking worktree `node_modules` to the main checkout's install)
