### PR TITLE
fix: allow cancelling turns before stream start

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -97,7 +97,10 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [ready, setReady] = useState(false)
   const [sid, setSid] = useState("")
   const sidRef = useRef(sid); sidRef.current = sid
-  const capabilities = sessionCapabilities({ sid, ready, streaming: turn.streaming })
+  const [starting, setStarting] = useState(false)
+  const startRef = useRef(starting); startRef.current = starting
+  const active = turn.streaming || starting
+  const capabilities = sessionCapabilities({ sid, ready, streaming: active })
   const [tab, setTab] = useState(CHAT_TAB)
   // Sub-tab per group — Chat has none, so key 0 is unused.
   // Defensive clamp lives inside each group (SessionsGroup/Automation/
@@ -248,7 +251,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     ? "error"
     : turn.toolActive ? "working"
     : turn.streaming && turn.hasContent ? "speaking"
-    : turn.streaming ? "thinking"
+    : active ? "thinking"
     : composing ? "listening"
     : "idle"
 
@@ -335,9 +338,13 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
-    setSid, setInfo, setReady, setTitle, setBusy, setUsage, setStatus, setSkin, setErrorPulse, settle,
+    setSid, setInfo, setReady, setTitle, setBusy, setStarting, setUsage, setStatus, setSkin, setErrorPulse, settle,
   })
-  intr.current = stream.doInterrupt
+  const interrupt = useCallback(() => {
+    if (startRef.current && !turnRef.current.streaming) hold.current = true
+    stream.doInterrupt()
+  }, [stream.doInterrupt])
+  intr.current = interrupt
 
   const reset = useCallback(() => {
     stream.interrupted.current = false
@@ -347,6 +354,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     dispatch({ kind: "reset" })
     setUsage(undefined)
     setReady(false)
+    setStarting(false)
     setStatus("")
     setTitle("")
     setAttachments([])
@@ -617,9 +625,13 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     const withMedia = attachments.length
       ? [...attachments.flatMap(a => a.path ? [`MEDIA:${a.path}`] : []), text].filter(Boolean).join("\n")
       : text
-    gw.request("prompt.submit", { text })
-      .then(() => {
+    gw.request<{ status?: string }>("prompt.submit", { text })
+      .then(r => {
         dispatch({ kind: "user", text: withMedia })
+        if (r.status === "streaming" && !turnRef.current.streaming) {
+          setStarting(true)
+          setStatus("starting agent…")
+        }
         setAttachments([])
         undone.current = []
         setTab(CHAT_TAB)
@@ -638,6 +650,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           return
         }
         inflight.current = false
+        setStarting(false)
         dispatch({ kind: "system", text: `submit failed: ${msg}` })
         toast.show({ variant: "error", message: msg })
       })
@@ -728,6 +741,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     subCount, cycleSub,
     focusRegion, setFocusRegion,
     streaming: turn.streaming,
+    starting,
     dialogOpen: dialog.open,
     composer,
     // Route keys to the pending inline prompt card before anything
@@ -741,13 +755,13 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setSplash(false); summoned.current = false
       return true
     },
-    onInterrupt: stream.doInterrupt,
+    onInterrupt: interrupt,
     // queue.flush interrupts, then drain waits for session.info so
     // prompt.submit does not race the gateway's still-running turn.
     queued: queue.length,
     onFlushQueue: () => {
       hold.current = true
-      stream.doInterrupt()
+      interrupt()
     },
     onQuit: () => quit(renderer, sid, caption, gw),
     onQuitArm: (label) =>
@@ -791,11 +805,11 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     onVoiceRecord: () => voice.record(sidRef.current),
   })
   useBridge({
-    tab, ready, streaming: turn.streaming, messages: turn.messages, sid, focusRegion,
+    tab, ready, streaming: active, messages: turn.messages, sid, focusRegion,
     setTab, setFocusRegion, dispatch, composer,
   })
 
-  const contentFocused = focusRegion === "content" && !turn.streaming
+  const contentFocused = focusRegion === "content" && !active
   // At most one pending prompt (gateway blocks on the answer). The
   // card mounts inside MessageList; key routing and composer-defocus
   // live here because the shell owns both. `prompt` is computed above
@@ -883,7 +897,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
               <VoiceIndicator voice={voice.state} keyLabel={voice.keyLabel} />
               <Composer
                 ref={composer}
-                focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming}
+                focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={active}
+                starting={starting}
                 status={status}
                 model={info?.model}
                 hidden={hidden}
@@ -905,7 +920,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
             <Profiler id="sidebar" onRender={perf.onRender}>
               <Sidebar agentState={agentState} info={info} usage={usage} eikon={eikon} profile={activeProfileName()}
                        title={caption}
-                       cloud={tab === 0 && cloud} pulse={turn.streaming}
+                       cloud={tab === 0 && cloud} pulse={active}
                        onAvatar={onAvatar} onAvatarHold={onAvatarHold} />
             </Profiler>
           ) : null}
@@ -913,7 +928,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
         {plugins.has("app_bottom") ? (
           <box height={1} flexShrink={0} paddingX={1} overflow="hidden">
             <plugins.Slot name="app_bottom" mode="single_winner"
-                          sid={sid} tab={tab} streaming={turn.streaming} />
+                          sid={sid} tab={tab} streaming={active} />
           </box>
         ) : null}
       </box>

--- a/src/app/useAppKeys.ts
+++ b/src/app/useAppKeys.ts
@@ -44,6 +44,7 @@ type Opts = {
   focusRegion: Region
   setFocusRegion: (r: Region | ((r: Region) => Region)) => void
   streaming: boolean
+  starting: boolean
   dialogOpen: () => boolean
   composer: RefObject<ComposerHandle | null>
   /** Offer the key to a pending inline prompt card. Return true to
@@ -207,7 +208,7 @@ export function useAppKeys(o: Opts) {
     // Only meaningful mid-stream with something queued; otherwise fall
     // through (leader was already consumed, so no stray "u" reaches the
     // textarea).
-    if (keys.match("queue.flush", key) && o.streaming && o.queued > 0) {
+    if (keys.match("queue.flush", key) && (o.streaming || o.starting) && o.queued > 0) {
       o.onFlushQueue()
       key.stopPropagation()
       return
@@ -315,8 +316,8 @@ export function useAppKeys(o: Opts) {
     }
 
     if (keys.match("session.interrupt", key)) {
-      if (!o.streaming && o.onEscape?.()) return
-      if (o.streaming) {
+      if (!o.streaming && !o.starting && o.onEscape?.()) return
+      if (o.streaming || o.starting) {
         const now = Date.now()
         if (now - lastEsc.current < INTERRUPT_MS) {
           o.onInterrupt()

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -32,6 +32,7 @@ type Ctx = {
   setReady: (r: boolean) => void
   setTitle: (t: string) => void
   setBusy: (m: "queue" | "steer" | "interrupt") => void
+  setStarting: (v: boolean) => void
   setUsage: (u: Usage | undefined) => void
   setStatus: (s: string) => void
   setSkin: (s: SkinState) => void
@@ -133,6 +134,10 @@ export function useStream(c: Ctx) {
       onSessionInfo: (si) => {
         x.setInfo(si)
         x.setReady(true)
+        if (si.running === false) {
+          x.setStarting(false)
+          x.setStatus("")
+        }
         if (si.session_id) x.setSid(si.session_id)
         x.settle()
         const bad = (si.mcp_servers ?? []).filter(s => !s.connected)
@@ -148,6 +153,7 @@ export function useStream(c: Ctx) {
       },
       onUsage: (u) => x.setUsage(u),
       onTurnComplete: () => {
+        x.setStarting(false)
         x.setStatus("")
         spawnHistory.flush(gw, x.sidRef.current)
         x.goalHook.check(x.sidRef.current)
@@ -192,6 +198,11 @@ export function useStream(c: Ctx) {
       return
     }
     flush()
+    if (action.kind === "message.start") {
+      x.setStarting(false)
+      x.setStatus("")
+    }
+    if (action.kind === "error") x.setStarting(false)
     if (action.kind === "error") x.setErrorPulse(true)
     x.dispatch(action)
   }, [gw, dialog, toast, flush, bg])

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -56,6 +56,7 @@ type Props = {
   canSubmitPrompt: boolean
   ready: boolean
   streaming: boolean
+  starting?: boolean
   status?: string
   model?: string
   /** Set for ~5s after the first Esc of the interrupt double-tap. */
@@ -394,6 +395,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
   }, [])
 
   const label = !props.ready ? "Connecting..."
+    : props.starting ? (props.status || "Starting agent...")
     : props.streaming ? (props.status || "Generating...")
     : "Ready"
   const dot = props.ready ? (props.streaming ? theme.warning : theme.success) : theme.error
@@ -546,6 +548,10 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
           <span fg={theme.textMuted}> {mode === "shell" ? "Shell" : label}</span>
           {mode === "shell"
             ? <span fg={theme.textMuted}>  esc exit shell mode</span>
+            : props.starting && props.escHint
+            ? <span fg={theme.warning}>  esc again to cancel</span>
+            : props.starting
+            ? <span fg={theme.textMuted}>  esc×2 cancel</span>
             : props.streaming && props.escHint
             ? <span fg={theme.warning}>  esc again to interrupt</span>
             : props.streaming

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -199,6 +199,7 @@ export type SessionInfo = {
   context_max?: number
   context_used?: number
   credential_warning?: string
+  running?: boolean
   yolo?: boolean
   mcp_servers?: McpServer[]
   /** hermes-agent version string (e.g. "1.14.2-dev+abc123") */

--- a/test/queued-submit.test.tsx
+++ b/test/queued-submit.test.tsx
@@ -7,6 +7,68 @@ function info() {
 }
 
 describe("queued prompt submit", () => {
+  test("accepted submit can be interrupted before message.start without resubmitting", async () => {
+    const gw = new MockGateway({
+      "session.interrupt": () => ({ status: "interrupted" }),
+      "prompt.submit": () => ({ status: "streaming" }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("slow boot") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("starting agent"))
+    expect(t.frame()).toContain("esc×2 cancel")
+
+    act(() => t.keys.pressEscape())
+    await until(t, () => t.frame().includes("esc again to cancel"))
+    expect(gw.calls.filter(c => c.method === "session.interrupt")).toHaveLength(0)
+
+    act(() => t.keys.pressEscape())
+    await until(t, () => gw.calls.filter(c => c.method === "session.interrupt").length === 1)
+
+    act(() => gw.push({ type: "session.info", payload: { ...info(), running: false } }))
+    await until(t, () => t.frame().includes("Ready"))
+
+    expect(gw.calls.filter(c => c.method === "prompt.submit")).toHaveLength(1)
+    t.destroy()
+  })
+
+  test("queued input while starting waits for post-cancel idle", async () => {
+    let n = 0
+    const gw = new MockGateway({
+      "config.get": p => p.key === "busy" ? { value: "interrupt" } : {},
+      "session.interrupt": () => ({ status: "interrupted" }),
+      "prompt.submit": () => {
+        n += 1
+        return { status: "streaming" }
+      },
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("slow boot") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("starting agent"))
+
+    await act(async () => { await t.keys.typeText("after cancel") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("⏸ 1. after cancel"))
+
+    act(() => t.keys.pressEscape())
+    await t.settle()
+    act(() => t.keys.pressEscape())
+    await until(t, () => gw.calls.filter(c => c.method === "session.interrupt").length === 2)
+    expect(gw.calls.filter(c => c.method === "prompt.submit")).toHaveLength(1)
+
+    act(() => gw.push({ type: "session.info", payload: { ...info(), running: false } }))
+    await until(t, () => gw.calls.filter(c => c.method === "prompt.submit").length === 2)
+
+    expect(n).toBe(2)
+    expect(gw.last("prompt.submit")?.params.text).toBe("after cancel")
+    t.destroy()
+  })
+
   test("interrupt-mode queue waits for session.info before draining", async () => {
     const gw = new MockGateway({
       "config.get": p => p.key === "busy" ? { value: "interrupt" } : {},


### PR DESCRIPTION
## Summary
- Tracks accepted `prompt.submit` calls as an agent-starting state until `message.start`, terminal error, or idle `session.info`.
- Routes the existing double-Esc interrupt path through `session.interrupt` while starting, with start/cancel status text.
- Holds queue drains across pre-start cancellation so queued prompts submit only after the gateway reports idle.

## Test Plan
- `bun test test/queued-submit.test.tsx`
- `bun test test/app.test.tsx`
- `bun test test/queued-submit.test.tsx test/attachments.test.tsx`
- `bunx tsc --noEmit`
- `bun run test`
- `bun run build`
