### PR TITLE
feat: add cron execution editor

### DIFF
--- a/src/dialogs/cron-editor.tsx
+++ b/src/dialogs/cron-editor.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import { useTheme } from "../theme"
+import type { ThemeCurrent } from "../theme"
+import type { DialogContext } from "../ui/dialog"
+import type { CronDraft } from "../tabs/cron-model"
+import { cronModel } from "../tabs/cron-model"
+
+type Field = keyof CronDraft | "submit"
+type Result = { draft: CronDraft; advanced: boolean }
+
+type Props = {
+  mode: "create" | "edit"
+  initial: CronDraft
+  canUpdate: boolean
+  done: (r: Result | null) => void
+}
+
+const FIELDS: readonly Field[] = [
+  "name", "schedule", "prompt", "script", "no_agent", "attach_to_session", "skills",
+  "provider", "model", "base_url", "context_from", "enabled_toolsets",
+  "workdir", "deliver", "repeat", "submit",
+] as const
+
+const LABELS: Record<Field, string> = {
+  id: "ID",
+  name: "Name",
+  schedule: "Schedule",
+  prompt: "Prompt",
+  script: "Script",
+  no_agent: "No agent",
+  attach_to_session: "Attach session",
+  skills: "Skills",
+  provider: "Provider",
+  model: "Model",
+  base_url: "Base URL",
+  context_from: "Context from",
+  enabled_toolsets: "Toolsets",
+  workdir: "Workdir",
+  deliver: "Deliver",
+  repeat: "Repeat",
+  submit: "",
+}
+
+const HELP: Partial<Record<Field, string>> = {
+  name: "blank lets the server derive one on create",
+  schedule: "cron expr, ISO timestamp, or 'every 30m'",
+  prompt: "required for agent jobs unless skills or script are set",
+  script: "required when no_agent is on",
+  attach_to_session: "continuable job deliveries; no effect with local delivery",
+  skills: "comma or newline separated",
+  context_from: "job ids; not returned by old gateways",
+  enabled_toolsets: "comma or newline separated",
+  deliver: "local, all, origin, or gateway target",
+  repeat: "positive integer; blank uses gateway default",
+}
+
+const multiline = new Set<Field>(["prompt", "skills", "context_from", "enabled_toolsets"])
+const locked = new Set<Field>(["provider", "model", "base_url", "context_from", "enabled_toolsets", "workdir", "repeat"])
+const bools = new Set<Field>(["no_agent", "attach_to_session"])
+const editable = (f: Field, p: Props) => (f !== "submit" && f !== "id" && f !== "name") || (p.mode === "create" && f === "name")
+const editableThrough = (f: Field, p: Props) => p.mode === "create" || p.canUpdate || f === "name"
+const available = (f: Field, p: Props) => {
+  if (f === "submit") return p.mode === "create" || p.canUpdate
+  return p.mode === "create" || p.canUpdate || !locked.has(f)
+}
+
+const value = (d: CronDraft, f: Field) => f === "submit" ? "" : d[f]
+const height = (f: Field) => multiline.has(f) ? 3 : 1
+
+const set = (d: CronDraft, f: Field, v: string | boolean): CronDraft => {
+  if (f === "submit") return d
+  return { ...d, [f]: v }
+}
+
+const FieldRow = (p: {
+  field: Field
+  draft: CronDraft
+  active: boolean
+  disabled: boolean
+  theme: ThemeCurrent
+}) => {
+  const f = p.field
+  const val = value(p.draft, f)
+  const fg = p.disabled ? p.theme.textMuted : p.active ? p.theme.accent : p.theme.text
+  if (f === "submit") return (
+    <box height={1} marginTop={1}>
+      <text fg={p.active ? p.theme.accent : p.theme.textMuted}>[Ctrl+Enter] save</text>
+    </box>
+  )
+  return (
+    <box minHeight={height(f)} flexDirection="row" marginTop={f === "prompt" ? 1 : 0}>
+      <box width={16} flexShrink={0}><text fg={p.active ? p.theme.accent : p.theme.textMuted}>{p.active ? "▸ " : "  "}{LABELS[f]}</text></box>
+      <box flexGrow={1} minWidth={0} flexDirection="column">
+        {typeof val === "boolean" ? (
+          <text fg={fg}>{val ? "● true" : "○ false"}</text>
+        ) : (
+          <box height={height(f)} overflow="hidden" backgroundColor={p.active && !p.disabled ? p.theme.backgroundElement : undefined}>
+            <text wrapMode={multiline.has(f) ? "word" : undefined} fg={fg}>{val || (p.active ? "█" : "—")}</text>
+          </box>
+        )}
+        {p.active && HELP[f] ? <text fg={p.theme.textMuted}>{HELP[f]}</text> : null}
+      </box>
+    </box>
+  )
+}
+
+const CronEditor = (props: Props) => {
+  const theme = useTheme().theme
+  const [draft, setDraft] = useState(props.initial)
+  const [field, setField] = useState<Field>("schedule")
+  const [err, setErr] = useState<string | null>(null)
+  const fields = FIELDS.filter(f => available(f, props))
+
+  const move = (dir: 1 | -1) => {
+    const i = fields.indexOf(field)
+    setField(fields[(i + dir + fields.length) % fields.length] ?? "schedule")
+  }
+  const submit = () => {
+    const msg = cronModel.validate(draft)
+    if (msg) { setErr(msg); return }
+    props.done({ draft, advanced: cronModel.advanced(draft) })
+  }
+  const append = (raw: string) => setDraft(d => {
+    const v = value(d, field)
+    if (typeof v !== "string") return d
+    return set(d, field, v + raw)
+  })
+  const back = () => setDraft(d => {
+    const v = value(d, field)
+    if (typeof v !== "string") return d
+    return set(d, field, v.slice(0, -1))
+  })
+
+  useKeyboard(key => {
+    if (key.name === "escape") return props.done(null)
+    if (key.name === "tab") return move(key.shift ? -1 : 1)
+    if (key.ctrl && key.name === "return") return submit()
+    if (key.name === "up") return move(-1)
+    if (key.name === "down") return move(1)
+    if (field === "submit" && key.name === "return") return submit()
+    if (!editable(field, props) || !editableThrough(field, props)) return
+    if (bools.has(field) && (key.name === "space" || key.name === "return")) {
+      setDraft(d => set(d, field, !value(d, field)))
+      return
+    }
+    if (bools.has(field)) return
+    if (key.name === "backspace") return back()
+    if (key.name === "return") {
+      if (multiline.has(field)) return append("\n")
+      return move(1)
+    }
+    if (key.raw && key.raw.length === 1 && key.raw >= " ") return append(key.raw)
+  })
+
+  return (
+    <box flexDirection="column" width={84} maxHeight={34}>
+      <box height={1}><text fg={theme.primary}><strong>{props.mode === "create" ? "New Cron Job" : "Edit Cron Job"}</strong></text></box>
+      {props.mode === "edit" && !props.canUpdate ? (
+        <text fg={theme.warning}>Current gateway has no cron.manage update; this job is read-only here.</text>
+      ) : null}
+      <box height={1} />
+      <scrollbox scrollY flexGrow={1}>
+        <box flexDirection="column">
+          {fields.map(f => <FieldRow key={f} field={f} draft={draft} active={f === field} disabled={!editableThrough(f, props)} theme={theme} />)}
+        </box>
+      </scrollbox>
+      {err ? <text fg={theme.error}>{err}</text> : null}
+      <box height={1}><text fg={theme.textMuted}>Tab field  ·  ↑↓ field  ·  Ctrl+Enter save  ·  Esc cancel</text></box>
+    </box>
+  )
+}
+
+export function openCronEditor(
+  dialog: DialogContext,
+  opts: { mode: "create" | "edit"; initial: CronDraft; canUpdate: boolean },
+): Promise<Result | null> {
+  return new Promise(resolve => {
+    dialog.replace(
+      <CronEditor
+        mode={opts.mode}
+        initial={opts.initial}
+        canUpdate={opts.canUpdate}
+        done={r => { resolve(r); dialog.clear() }}
+      />,
+      () => resolve(null),
+      { ownCancel: true },
+    )
+  })
+}

--- a/src/tabs/Cron.tsx
+++ b/src/tabs/Cron.tsx
@@ -11,70 +11,34 @@ import { HintBar } from "../ui/hint";
 import { KVBlock } from "../ui/kv";
 import { Col, Hdr, VBAR } from "../ui/table";
 import { openTextPrompt } from "../dialogs/text-prompt";
+import { openCronEditor } from "../dialogs/cron-editor";
 import { ago, until } from "../ui/fmt";
 import { readCronOutput, type CronOutput } from "../service/hermes-home";
+import { cronModel, type CronAction, type CronJob, type RawJob } from "./cron-model";
 
-type CronJob = {
-  id: string
-  name: string
-  prompt: string
-  schedule: string
-  enabled: boolean
-  state: string
-  deliver: string
-  repeat?: string
-  last_run?: string
-  next_run?: string
-  last_status?: "ok" | "error"
-  last_error?: string
-  paused_reason?: string
-  model?: string
-  skills?: string[]
-  workdir?: string
-  script?: string
+type Caps = { update: boolean; advanced: boolean }
+type ListResponse = {
+  jobs?: RawJob[]
+  actions?: string[]
+  fields?: string[]
+  capabilities?: { update?: boolean; advanced?: boolean; advanced_create?: boolean }
 }
 
-type RawJob = {
-  job_id?: string
-  id?: string
-  name?: string
-  prompt_preview?: string
-  prompt?: string
-  schedule?: string
-  enabled?: boolean
-  state?: string
-  deliver?: string
-  repeat?: string
-  last_run_at?: string
-  next_run_at?: string
-  last_status?: string
-  last_delivery_error?: string
-  paused_reason?: string
-  model?: string
-  skills?: string[]
-  workdir?: string
-  script?: string
-}
+const FIELDS = [
+  "script", "no_agent", "attach_to_session", "skills", "provider", "model",
+  "base_url", "context_from", "enabled_toolsets", "workdir", "deliver", "repeat",
+]
 
-const normalize = (j: RawJob): CronJob => ({
-  id: j.job_id ?? j.id ?? "",
-  name: j.name ?? "",
-  prompt: j.prompt ?? j.prompt_preview ?? "",
-  schedule: j.schedule ?? "",
-  enabled: j.enabled ?? true,
-  state: j.state ?? "scheduled",
-  deliver: j.deliver ?? "local",
-  repeat: j.repeat,
-  last_run: j.last_run_at,
-  next_run: j.next_run_at,
-  last_status: j.last_status === "ok" || j.last_status === "error" ? j.last_status : undefined,
-  last_error: j.last_delivery_error,
-  paused_reason: j.paused_reason,
-  model: j.model,
-  skills: j.skills,
-  workdir: j.workdir,
-  script: j.script,
-})
+const caps = (r: ListResponse): Caps => {
+  const actions = new Set(r.actions ?? [])
+  const fields = new Set(r.fields ?? [])
+  return {
+    update: r.capabilities?.update === true || actions.has("update"),
+    advanced: r.capabilities?.advanced === true
+      || r.capabilities?.advanced_create === true
+      || FIELDS.some(f => fields.has(f)),
+  }
+}
 
 // gateway returns ISO timestamps; shared `ago`/`until` want unix seconds
 const sec = (iso?: string) => iso ? new Date(iso).getTime() / 1000 : null
@@ -141,8 +105,14 @@ const DetailPanel = memo((props: { job: CronJob; reloadKey: number }) => {
             ["Last Run", j.last_run ? `${last(j.last_run)}  ·  ${j.last_status ?? "?"}` : "never",
               j.last_status === "error" ? theme.error : undefined],
             ["Next Run", j.enabled ? next(j.next_run) : "paused"],
+            ["Provider", j.provider],
             ["Model", j.model],
+            ["Base URL", j.base_url],
+            ["No Agent", j.no_agent ? "true" : undefined],
+            ["Attach Session", j.attach_to_session ? "true" : undefined],
             ["Skills", j.skills?.length ? j.skills.join(", ") : undefined],
+            ["Context", j.context_from?.length ? j.context_from.join(", ") : undefined],
+            ["Toolsets", j.enabled_toolsets?.length ? j.enabled_toolsets.join(", ") : undefined],
             ["Workdir", j.workdir],
             ["Script", j.script],
             ["Paused", j.paused_reason],
@@ -171,6 +141,7 @@ export const Cron = memo((props: { focused?: boolean }) => {
   const toast = useToast();
   const dims = useTerminalDimensions();
   const [jobs, setJobs] = useState<CronJob[]>([]);
+  const [cap, setCap] = useState<Caps>({ update: false, advanced: false });
   const [sel, setSel] = useState(0);
   const [err, setErr] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
@@ -179,9 +150,10 @@ export const Cron = memo((props: { focused?: boolean }) => {
   live.current = { jobs, sel };
 
   const load = useCallback(() => {
-    gw.request<{ jobs?: RawJob[] }>("cron.manage", { action: "list" })
+    gw.request<ListResponse>("cron.manage", { action: "list" })
       .then(res => {
-        setJobs((res.jobs ?? []).map(normalize));
+        setJobs((res.jobs ?? []).map(cronModel.normalize));
+        setCap(caps(res));
         setErr(null);
         setReloadKey(k => k + 1);
       })
@@ -199,11 +171,38 @@ export const Cron = memo((props: { focused?: boolean }) => {
       title: "New Cron Job", label: "Prompt",
     });
     if (prompt === null) return;
-    // name left blank — server derives one from the prompt text.
-    gw.request("cron.manage", { action: "add", name: "", schedule, prompt })
+    const d = { ...cronModel.draft(), schedule, prompt };
+    const msg = cronModel.validate(d);
+    if (msg) { toast.show({ variant: "error", message: msg }); return; }
+    gw.request("cron.manage", cronModel.payload("add", d))
       .then(() => { toast.show({ variant: "success", message: "Job created" }); load(); })
       .catch((e: Error) => toast.show({ variant: "error", message: e.message }));
   }, [gw, dialog, toast, load]);
+
+  const edit = useCallback(async () => {
+    const j = live.current.jobs[live.current.sel];
+    if (j && !cap.update) {
+      toast.show({ variant: "warning", message: "Current gateway has no cron.manage update; this job is read-only here." });
+      return;
+    }
+    const r = await openCronEditor(dialog, {
+      mode: j ? "edit" : "create",
+      initial: cronModel.draft(j ?? undefined),
+      canUpdate: cap.update,
+    });
+    if (!r) return;
+    if (r.advanced && !cap.advanced) {
+      toast.show({
+        variant: "warning",
+        message: "Gateway only applies schedule+prompt today; advanced fields are documented but not forwarded by cron.manage.",
+        duration: 6000,
+      });
+    }
+    const action: CronAction = j && cap.update ? "update" : "add";
+    gw.request("cron.manage", cronModel.payload(action, r.draft))
+      .then(() => { toast.show({ variant: "success", message: action === "add" ? "Job created" : "Job updated" }); load(); })
+      .catch((e: Error) => toast.show({ variant: "error", message: e.message }));
+  }, [gw, dialog, toast, load, cap]);
 
   const toggle = useCallback(() => {
     const j = live.current.jobs[live.current.sel];
@@ -239,6 +238,7 @@ export const Cron = memo((props: { focused?: boolean }) => {
     onToggle: toggle,
     onDelete: remove,
     onNew: create,
+    onActivate: edit,
     onRefresh: () => { load(); toast.show({ variant: "info", message: "Reloaded", duration: 1000 }) },
   });
 
@@ -284,6 +284,7 @@ export const Cron = memo((props: { focused?: boolean }) => {
     <HintBar pairs={[
       ["↑↓", "nav"],
       [keys.print("list.new"), "new"],
+      [keys.print("list.activate"), "advanced"],
       [keys.print("list.toggle"), "pause/resume"],
       [keys.print("list.delete"), "delete"],
       [keys.print("list.refresh"), "refresh"],

--- a/src/tabs/cron-model.ts
+++ b/src/tabs/cron-model.ts
@@ -1,0 +1,195 @@
+export type CronJob = {
+  id: string
+  name: string
+  prompt: string
+  schedule: string
+  enabled: boolean
+  state: string
+  deliver: string
+  repeat?: string
+  last_run?: string
+  next_run?: string
+  last_status?: "ok" | "error"
+  last_error?: string
+  paused_reason?: string
+  provider?: string
+  model?: string
+  base_url?: string
+  no_agent?: boolean
+  attach_to_session?: boolean
+  skills?: string[]
+  context_from?: string[]
+  enabled_toolsets?: string[]
+  workdir?: string
+  script?: string
+}
+
+export type RawJob = {
+  job_id?: string
+  id?: string
+  name?: string
+  prompt_preview?: string
+  prompt?: string
+  schedule?: string
+  enabled?: boolean
+  state?: string
+  deliver?: string
+  repeat?: string
+  last_run_at?: string
+  next_run_at?: string
+  last_status?: string
+  last_delivery_error?: string
+  paused_reason?: string
+  provider?: string
+  model?: string
+  base_url?: string
+  no_agent?: boolean
+  attach_to_session?: boolean
+  skills?: string[] | string
+  context_from?: string[] | string
+  enabled_toolsets?: string[] | string
+  workdir?: string
+  script?: string
+}
+
+export type CronDraft = {
+  id: string
+  name: string
+  schedule: string
+  prompt: string
+  script: string
+  no_agent: boolean
+  attach_to_session: boolean
+  skills: string
+  provider: string
+  model: string
+  base_url: string
+  context_from: string
+  enabled_toolsets: string
+  workdir: string
+  deliver: string
+  repeat: string
+}
+
+export type CronPayload = Record<string, unknown>
+export type CronAction = "add" | "update"
+
+const arr = (value: string[] | string | undefined): string[] | undefined => {
+  if (Array.isArray(value)) return value.filter(Boolean)
+  if (typeof value === "string") return split(value)
+  return undefined
+}
+
+export const split = (value: string): string[] =>
+  value.split(/[\n,]/).map(s => s.trim()).filter(Boolean)
+
+export const base = (value: string): string =>
+  value.trim().replace(/\/+$/, "")
+
+export const normalize = (j: RawJob): CronJob => ({
+  id: j.job_id ?? j.id ?? "",
+  name: j.name ?? "",
+  prompt: j.prompt ?? j.prompt_preview ?? "",
+  schedule: j.schedule ?? "",
+  enabled: j.enabled ?? true,
+  state: j.state ?? "scheduled",
+  deliver: j.deliver ?? "local",
+  repeat: j.repeat,
+  last_run: j.last_run_at,
+  next_run: j.next_run_at,
+  last_status: j.last_status === "ok" || j.last_status === "error" ? j.last_status : undefined,
+  last_error: j.last_delivery_error,
+  paused_reason: j.paused_reason,
+  provider: j.provider,
+  model: j.model,
+  base_url: j.base_url,
+  no_agent: j.no_agent,
+  attach_to_session: j.attach_to_session,
+  skills: arr(j.skills),
+  context_from: arr(j.context_from),
+  enabled_toolsets: arr(j.enabled_toolsets),
+  workdir: j.workdir,
+  script: j.script,
+})
+
+export const draft = (j?: CronJob): CronDraft => ({
+  id: j?.id ?? "",
+  name: j?.name ?? "",
+  schedule: j?.schedule ?? "",
+  prompt: j?.prompt ?? "",
+  script: j?.script ?? "",
+  no_agent: !!j?.no_agent,
+  attach_to_session: !!j?.attach_to_session,
+  skills: j?.skills?.join(", ") ?? "",
+  provider: j?.provider ?? "",
+  model: j?.model ?? "",
+  base_url: j?.base_url ?? "",
+  context_from: j?.context_from?.join(", ") ?? "",
+  enabled_toolsets: j?.enabled_toolsets?.join(", ") ?? "",
+  workdir: j?.workdir ?? "",
+  deliver: j?.deliver ?? "local",
+  repeat: "",
+})
+
+export const has = (d: CronDraft): boolean => {
+  if (d.no_agent) return d.script.trim().length > 0
+  return d.prompt.trim().length > 0 || d.script.trim().length > 0 || split(d.skills).length > 0
+}
+
+export const validate = (d: CronDraft): string | null => {
+  if (!d.schedule.trim()) return "Schedule is required"
+  if (!has(d)) return d.no_agent
+    ? "No-agent jobs require a script"
+    : "Agent jobs require a prompt, skill, or script"
+  if (d.repeat.trim() && (!Number.isInteger(Number(d.repeat.trim())) || Number(d.repeat.trim()) <= 0))
+    return "Repeat must be a positive integer"
+  if (base(d.base_url)) {
+    const ok = URL.canParse(base(d.base_url))
+    if (!ok) return "Base URL must be a valid URL"
+  }
+  return null
+}
+
+export const payload = (action: CronAction, d: CronDraft): CronPayload => {
+  const out: CronPayload = {
+    action,
+    name: action === "add" ? d.name.trim() : d.id,
+    schedule: d.schedule.trim(),
+    prompt: d.prompt.trim(),
+    deliver: d.deliver.trim() || "local",
+    no_agent: d.no_agent,
+    attach_to_session: d.attach_to_session,
+  }
+  const add = (key: string, value: unknown) => {
+    if (value !== undefined) out[key] = value
+  }
+  const skills = split(d.skills)
+  const refs = split(d.context_from)
+  const tools = split(d.enabled_toolsets)
+  if (action === "update" || skills.length > 0) add("skills", skills)
+  if (action === "update" || refs.length > 0) add("context_from", refs)
+  if (action === "update" || tools.length > 0) add("enabled_toolsets", tools)
+  add("provider", d.provider.trim() || undefined)
+  add("model", d.model.trim() || undefined)
+  add("base_url", base(d.base_url) || undefined)
+  add("script", d.script.trim() || undefined)
+  add("workdir", d.workdir.trim() || undefined)
+  add("repeat", d.repeat.trim() ? Number(d.repeat.trim()) : undefined)
+  return out
+}
+
+export const advanced = (d: CronDraft): boolean =>
+  d.script.trim().length > 0
+  || d.no_agent
+  || d.attach_to_session
+  || split(d.skills).length > 0
+  || d.provider.trim().length > 0
+  || d.model.trim().length > 0
+  || base(d.base_url).length > 0
+  || split(d.context_from).length > 0
+  || split(d.enabled_toolsets).length > 0
+  || d.workdir.trim().length > 0
+  || d.deliver.trim() !== "" && d.deliver.trim() !== "local"
+  || d.repeat.trim().length > 0
+
+export * as cronModel from "./cron-model"

--- a/test/cron.test.tsx
+++ b/test/cron.test.tsx
@@ -4,6 +4,7 @@ import { mkdirSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { mountNode, until, MockGateway } from "./harness"
 import { Cron } from "../src/tabs/Cron"
+import { cronModel } from "../src/tabs/cron-model"
 
 const HH = process.env.HERMES_HOME!
 const iso = (dsec: number) => new Date(Date.now() + dsec * 1000).toISOString()
@@ -38,32 +39,24 @@ const mk = () => new MockGateway({
 
 describe("Cron tab", () => {
   test("renders jobs with enabled/disabled glyphs and detail pane", async () => {
-    const gw = mk()
-    const t = await mountNode(<Cron focused />, { gw })
+    await using t = await mountNode(<Cron focused />, { gw: mk() })
     await until(t, () => t.frame().includes("Cron Jobs (3)"))
 
     const f = t.frame()
     expect(f).toContain("● nightly-digest")
     expect(f).toContain("● broken-job")
     expect(f).toContain("○ disabled-one")
-    // Dead state==="error" ERR tag is gone
     expect(f).not.toMatch(/broken-job.*ERR/)
-
-    // Detail panel for sel=0 shows conditional fields
     expect(f).toContain("Model")
     expect(f).toContain("claude-opus")
     expect(f).toContain("Workdir")
     expect(f).toContain("/tmp/proj")
-    // No skills on job 0 → row hidden
     expect(f).not.toContain("Skills")
-    // last_status surfaced in Last Run row
     expect(f).toMatch(/Last Run\s+.*·\s+ok/)
-    t.destroy()
   })
 
   test("down to disabled job shows paused_reason; next_run reads 'paused'", async () => {
-    const gw = mk()
-    const t = await mountNode(<Cron focused />, { gw })
+    await using t = await mountNode(<Cron focused />, { gw: mk() })
     await until(t, () => t.frame().includes("Cron Jobs (3)"))
 
     act(() => t.keys.pressArrow("down"))
@@ -73,9 +66,7 @@ describe("Cron tab", () => {
     const f = t.frame()
     expect(f).toMatch(/Paused\s+manual/)
     expect(f).toMatch(/Next Run\s+paused/)
-    // Conditional rows absent for this job
     expect(f).not.toContain("claude-opus")
-    t.destroy()
   })
 
   test("detail pane shows last-output tail; '(none yet)' otherwise", async () => {
@@ -83,29 +74,22 @@ describe("Cron tab", () => {
     mkdirSync(dir, { recursive: true })
     writeFileSync(join(dir, "20260426_090000.md"), "## Digest\nitem one\nitem two")
 
-    const gw = mk()
-    const t = await mountNode(<Cron focused />, { gw })
+    await using t = await mountNode(<Cron focused />, { gw: mk() })
     await until(t, () => t.frame().includes("Last Output"))
     await until(t, () => t.frame().includes("item two"))
     expect(t.frame()).toContain("## Digest")
 
-    // d4e5f6 has no output dir → '(none yet)'
     act(() => t.keys.pressArrow("down"))
     await until(t, () => /ID\s+d4e5f6/.test(t.frame()))
     await until(t, () => t.frame().includes("(none yet)"))
     expect(t.frame()).not.toContain("item two")
-    t.destroy()
   })
 
   test("detail pane hidden below 120 cols", async () => {
-    const gw = mk()
-    const t = await mountNode(<Cron focused />, { gw, width: 110 })
+    await using t = await mountNode(<Cron focused />, { gw: mk(), width: 110 })
     await until(t, () => t.frame().includes("Cron Jobs (3)"))
     expect(t.frame()).not.toContain("Job Detail")
-    t.destroy()
   })
-
-  // ── row-level timing + Space toggle ──────────────────────────────
 
   const TIMING_JOBS = [
     { job_id: "j1", name: "nightly", schedule: "0 3 * * *", enabled: true,
@@ -118,7 +102,7 @@ describe("Cron tab", () => {
 
   test("renders rows; next uses until() for future, 'due' for past, 'paused' when disabled", async () => {
     const gw = new MockGateway({ "cron.manage": () => ({ jobs: TIMING_JOBS }) })
-    const t = await mountNode(<Cron focused />, { gw, width: 180 })
+    await using t = await mountNode(<Cron focused />, { gw, width: 180 })
     await until(t, () => t.frame().includes("Cron Jobs (3)"))
 
     const f = t.frame()
@@ -128,9 +112,7 @@ describe("Cron tab", () => {
     expect(row("nightly")).toMatch(/next: in (29|30)m/)
     expect(row("paused-job")).toContain("next: paused")
     expect(row("overdue")).toContain("next: due")
-    // Bug the fix addresses: future ts must NOT render as "just now".
     expect(row("nightly")).not.toContain("next: just now")
-    t.destroy()
   })
 
   test("Space toggles enabled via cron.manage pause/resume", async () => {
@@ -142,12 +124,160 @@ describe("Cron tab", () => {
         return {}
       },
     })
-    const t = await mountNode(<Cron focused />, { gw, width: 180 })
+    await using t = await mountNode(<Cron focused />, { gw, width: 180 })
     await until(t, () => t.frame().includes("nightly"))
 
     await act(async () => { await t.keys.typeText(" ") })
     await t.settle()
     expect(paused).toBe("pause:j1")
-    t.destroy()
+  })
+
+  const ADV_JOB = {
+    job_id: "adv1",
+    name: "advanced",
+    schedule: "every 1h",
+    enabled: true,
+    prompt_preview: "hello",
+    provider: "openrouter",
+    model: "anthropic/claude-sonnet-4",
+    base_url: "https://llm.example/v1",
+    no_agent: true,
+    attach_to_session: true,
+    script: "jobs/ping.py",
+    enabled_toolsets: ["web", "terminal"],
+    repeat: "3 times",
+  }
+
+  test("normalizes and validates execution content", () => {
+    expect(cronModel.normalize(ADV_JOB)).toMatchObject({
+      id: "adv1",
+      provider: "openrouter",
+      base_url: "https://llm.example/v1",
+      no_agent: true,
+      attach_to_session: true,
+      enabled_toolsets: ["web", "terminal"],
+      repeat: "3 times",
+    })
+    expect(cronModel.validate({ ...cronModel.draft(), schedule: "every 1h" })).toBe("Agent jobs require a prompt, skill, or script")
+    expect(cronModel.validate({ ...cronModel.draft(), schedule: "every 1h", no_agent: true })).toBe("No-agent jobs require a script")
+    expect(cronModel.validate({ ...cronModel.draft(), schedule: "every 1h", skills: "one, two" })).toBeNull()
+  })
+
+  test("builds payloads with execution fields and clearable list fields", () => {
+    const d = {
+      ...cronModel.draft(cronModel.normalize(ADV_JOB)),
+      context_from: "upstream-a, upstream-b",
+      repeat: "3",
+    }
+    expect(cronModel.payload("add", d)).toMatchObject({
+      action: "add",
+      name: "advanced",
+      schedule: "every 1h",
+      prompt: "hello",
+      deliver: "local",
+      no_agent: true,
+      attach_to_session: true,
+      provider: "openrouter",
+      model: "anthropic/claude-sonnet-4",
+      base_url: "https://llm.example/v1",
+      script: "jobs/ping.py",
+      enabled_toolsets: ["web", "terminal"],
+      context_from: ["upstream-a", "upstream-b"],
+      repeat: 3,
+    })
+    expect(cronModel.payload("update", { ...cronModel.draft(cronModel.normalize(ADV_JOB)), skills: "", enabled_toolsets: "" })).toMatchObject({
+      action: "update",
+      name: "adv1",
+      skills: [],
+      enabled_toolsets: [],
+      attach_to_session: true,
+    })
+  })
+
+  test("quick create preserves schedule plus prompt payload", async () => {
+    const calls: Record<string, unknown>[] = []
+    const gw = new MockGateway({
+      "cron.manage": p => {
+        calls.push(p)
+        if (p.action === "list") return { jobs: [] }
+        return { ok: true }
+      },
+    })
+    await using t = await mountNode(<Cron focused />, { gw })
+    await until(t, () => t.frame().includes("No cron jobs"))
+
+    await act(async () => { await t.keys.typeText("n") })
+    await until(t, () => t.frame().includes("Schedule"))
+    await act(async () => { await t.keys.typeText("every 5m") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Prompt"))
+    await act(async () => { await t.keys.typeText("say hi") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => calls.some(c => c.action === "add"))
+
+    expect(calls.find(c => c.action === "add")).toMatchObject({ action: "add", name: "", schedule: "every 5m", prompt: "say hi" })
+  })
+
+  test("detail panel displays upstream execution fields from list output", async () => {
+    const gw = new MockGateway({
+      "cron.manage": p => p.action === "list" ? { jobs: [ADV_JOB] } : { ok: true },
+    })
+    await using t = await mountNode(<Cron focused />, { gw, width: 160, height: 40 })
+    await until(t, () => t.frame().includes("Job Detail"))
+
+    expect(t.frame()).toContain("Provider")
+    expect(t.frame()).toContain("openrouter")
+    expect(t.frame()).toContain("Base URL")
+    expect(t.frame()).toContain("No Agent")
+    expect(t.frame()).toContain("Attach")
+    expect(t.frame()).toContain("Session")
+    expect(t.frame()).toContain("Toolsets")
+    expect(t.frame()).toContain("web, terminal")
+    expect(t.frame()).toContain("Repeat")
+  })
+
+  test("advanced editor sends update when gateway advertises update support", async () => {
+    const calls: Record<string, unknown>[] = []
+    const gw = new MockGateway({
+      "cron.manage": p => {
+        calls.push(p)
+        if (p.action === "list") return { jobs: [ADV_JOB], actions: ["update"], fields: ["script", "no_agent", "attach_to_session"] }
+        return { ok: true }
+      },
+    })
+    await using t = await mountNode(<Cron focused />, { gw })
+    await until(t, () => t.frame().includes("Cron Jobs (1)"))
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Edit Cron Job"))
+    act(() => t.keys.pressEnter({ ctrl: true }))
+    await until(t, () => calls.some(c => c.action === "update"))
+
+    expect(calls.find(c => c.action === "update")).toMatchObject({
+      action: "update",
+      name: "adv1",
+      schedule: "every 1h",
+      no_agent: true,
+      attach_to_session: true,
+    })
+  })
+
+  test("advanced editor is read-only for existing jobs without update support", async () => {
+    const calls: Record<string, unknown>[] = []
+    const gw = new MockGateway({
+      "cron.manage": p => {
+        calls.push(p)
+        if (p.action === "list") return { jobs: [ADV_JOB] }
+        return { ok: true }
+      },
+    })
+    await using t = await mountNode(<Cron focused />, { gw })
+    await until(t, () => t.frame().includes("Cron Jobs (1)"))
+
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    expect(t.frame()).not.toContain("Edit Cron Job")
+    expect(calls.filter(c => c.action !== "list")).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Adds an advanced Cron editor from the Cron tab so Enter can create/update jobs with execution fields beyond schedule and prompt.
- Extracts Cron normalization, draft, validation, and payload building into a shared model helper.
- Surfaces execution metadata in job detail: provider, model, base URL, no-agent mode, attach-to-session, skills, context jobs, toolsets, workdir, script, repeat, and delivery.

## Validation behavior
- Requires a schedule for all submissions.
- Requires agent jobs to have a prompt, skill, or script.
- Requires no-agent jobs to have a script.
- Validates repeat as a positive integer and base_url as a valid URL.
- Existing jobs are read-only when the gateway does not advertise cron.manage update support, avoiding duplicate-job creation on old gateways.

## Test plan
- `bunx tsc --noEmit` — pass
- `bun test test/cron.test.tsx test/list-keys.test.tsx` — 15 pass, 0 fail
- `bun test` — 1360 pass, 0 fail
- `bun run build` — pass after relinking this worktree's missing node_modules symlink to `/home/kaio/Dev/herm/node_modules`
- `git diff --check` — pass
- `bunx tsc --noEmit --noUnusedLocals --noUnusedParameters 2>&1 | grep -E 'src/(tabs|dialogs)' | head -50` — only pre-existing unrelated unused errors in `src/tabs/EikonStudio.tsx` and `src/tabs/Kanban.tsx`

## Gateway support notes
- The editor sends the cron execution fields supported by the cronjob tool shape: skills, provider/model/base_url, script, no_agent, attach_to_session, context_from, enabled_toolsets, workdir, deliver, and repeat.
- `cron.manage` update support is capability-gated. Older gateways that only support list/add/remove/pause/resume leave existing jobs read-only in the TUI.
- Fields not returned by older gateways may still be display-empty even though new submissions can include them.
