### PR TITLE
feat: render MoA gateway references

### DIFF
--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -32,6 +32,7 @@ export type Action =
   | { kind: "message.start" }
   | { kind: "message.delta"; chunk: string }
   | { kind: "message.complete"; text?: string; usage?: Usage }
+  | { kind: "reference"; text: string }
   | { kind: "tool.start"; id: string; name: string; preview?: string; args?: string }
   | { kind: "tool.progress"; name?: string; preview?: string }
   | { kind: "tool.generating"; name?: string }
@@ -93,6 +94,17 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
         toolActive: false,
         messages: finalize(state.messages, a.text != null ? sanitize(a.text) : undefined, a.usage),
       }
+
+    case "reference": {
+      const text = sanitize(a.text)
+      if (!text) return state
+      return {
+        ...state,
+        hasContent: true,
+        toolActive: false,
+        messages: appendPart(state.messages, { type: "text", key: pid(), content: text, streaming: false }, true),
+      }
+    }
 
     case "tool.start": {
       // `context` carries the raw tool input; when JSON-shaped we keep it

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -45,6 +45,7 @@ type Ctx = {
 const STREAM_EVENTS = new Set<GatewayEvent["type"]>([
   "message.start",
   "message.delta", "reasoning.delta", "reasoning.available", "thinking.delta",
+  "moa.reference", "moa.aggregating",
   "tool.start", "tool.progress", "tool.generating",
 ])
 const TITLE_DELAYS = [1200, 5000, 15000, 30000] as const

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -30,6 +30,12 @@ function count(o: Record<string, string[]> | undefined): number {
   return o ? Object.values(o).reduce((n, v) => n + v.length, 0) : 0
 }
 
+function reference(label: string, text: string, index: number | undefined, count: number | undefined): string {
+  const head = index && count ? `◇ Reference ${index}/${count} — ${label}` : `◇ Reference — ${label}`
+  const body = text.trim()
+  return body ? `${head}\n${body}` : head
+}
+
 export function formatProcessNotification(text: string): string {
   const body = text.replace(/^\[IMPORTANT: /, "").replace(/\]$/, "")
   const done = body.match(/^Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+?)(?:\n|$)/)
@@ -121,6 +127,23 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       const text = ev.payload?.text
       if (!text) return null
       return { kind: "thinking", text, final: ev.type === "reasoning.available", verbose: ev.payload?.verbose }
+    }
+
+    case "moa.reference":
+      return {
+        kind: "reference",
+        text: reference(
+          ev.payload?.label ?? "reference",
+          ev.payload?.text ?? "",
+          ev.payload?.index,
+          ev.payload?.count,
+        ),
+      }
+
+    case "moa.aggregating": {
+      const agg = ev.payload?.aggregator
+      side.onStatus?.(agg ? `aggregating with ${agg}…` : "aggregating…")
+      return null
     }
 
     case "subagent.start":

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -30,6 +30,8 @@ export type GatewayEvent = ({
   | { type: "thinking.delta"; payload?: { text?: string } }
   | { type: "reasoning.delta"; payload?: { text?: string; verbose?: boolean } }
   | { type: "reasoning.available"; payload?: { text?: string; verbose?: boolean } }
+  | { type: "moa.reference"; payload?: { label?: string; text?: string; index?: number; count?: number } }
+  | { type: "moa.aggregating"; payload?: { aggregator?: string } }
   | { type: "status.update"; payload?: { text?: string; kind?: string } }
   | { type: "notification.show"; payload?: NotificationShowPayload }
   | { type: "notification.clear"; payload?: NotificationClearPayload }

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -165,6 +165,22 @@ describe("mapEvent", () => {
       .toEqual({ kind: "thinking", text: "done", final: true, verbose: true })
   })
 
+  test("moa.reference maps to a visible committed reference block", () => {
+    expect(map({
+      type: "moa.reference",
+      payload: { label: "openrouter:openai/gpt-5.5", text: "Paris.", index: 1, count: 2 },
+    }).action).toEqual({
+      kind: "reference",
+      text: "◇ Reference 1/2 — openrouter:openai/gpt-5.5\nParis.",
+    })
+  })
+
+  test("moa.aggregating is transient status only", () => {
+    const r = map({ type: "moa.aggregating", payload: { aggregator: "openrouter:anthropic/claude-opus-4.8" } })
+    expect(r.action).toBeNull()
+    expect(r.calls.status).toEqual(["aggregating with openrouter:anthropic/claude-opus-4.8…"])
+  })
+
   test("request events return prompt actions (no side callback)", () => {
     expect(map({ type: "clarify.request", payload: { request_id: "x", question: "?", choices: null } }).action)
       .toEqual({ kind: "prompt", id: "x", req: { variant: "clarify", request_id: "x", question: "?", choices: null } })

--- a/test/live-session-events.test.tsx
+++ b/test/live-session-events.test.tsx
@@ -58,6 +58,39 @@ describe("live session event routing", () => {
     t.destroy()
   })
 
+  test("renders MoA references before aggregator answer without aggregating rows", async () => {
+    const gw = new MockGateway({
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "sid-b", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => {
+      t.gw.push({ type: "message.start", session_id: "sid-b" })
+      t.gw.push({
+        type: "moa.reference",
+        session_id: "sid-b",
+        payload: { label: "openrouter:openai/gpt-5.5", text: "Paris.", index: 1, count: 2 },
+      })
+      t.gw.push({
+        type: "moa.aggregating",
+        session_id: "sid-b",
+        payload: { aggregator: "openrouter:anthropic/claude-opus-4.8" },
+      })
+      t.gw.push({ type: "message.delta", session_id: "sid-b", payload: { text: "The answer is Paris." } })
+      t.gw.push({ type: "message.complete", session_id: "sid-b" })
+    })
+    await until(t, () => t.frame().includes("The answer is Paris."))
+
+    const frame = t.frame()
+    expect(frame).toContain("◇ Reference 1/2 — openrouter:openai/gpt-5.5")
+    expect(frame).toContain("Paris.")
+    expect(frame.indexOf("◇ Reference 1/2")).toBeLessThan(frame.indexOf("The answer is Paris."))
+    expect(frame).not.toContain("aggregating with")
+    expect(frame).not.toContain("openrouter:anthropic/claude-opus-4.8")
+    t.destroy()
+  })
+
   test("sibling background completion clears badge without writing into active transcript", async () => {
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/background", "run in background"]] }),

--- a/test/turnReducer.test.ts
+++ b/test/turnReducer.test.ts
@@ -38,6 +38,19 @@ describe("turnReducer", () => {
     expect(parts[2]).toMatchObject({ content: "after", streaming: true })
   })
 
+  test("reference block is committed before aggregator answer", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "reference", text: "◇ Reference 1/2 — openrouter:openai/gpt-5.5\nParis." },
+      { kind: "message.delta", chunk: "The answer is Paris." },
+      { kind: "message.complete" },
+    ])
+    const parts = last(s).parts
+    expect(kinds(parts)).toEqual(["text", "text"])
+    expect(parts[0]).toMatchObject({ content: "◇ Reference 1/2 — openrouter:openai/gpt-5.5\nParis.", streaming: false })
+    expect(parts[1]).toMatchObject({ content: "The answer is Paris.", streaming: false })
+  })
+
   test("complete seals trailing stream and attaches usage", () => {
     const usage = { input: 10, output: 5, total: 15 }
     const s = run([


### PR DESCRIPTION
## Summary
- Adds typed gateway events for moa.reference and moa.aggregating.
- Renders moa.reference as a committed visible reference block before the aggregator answer.
- Keeps moa.aggregating transient as status only and gates both MoA event types through interrupted-turn filtering.

## Verification
- bunx tsc --noEmit
- bun test test/gatewayEvents.test.ts test/turnReducer.test.ts test/live-session-events.test.tsx
- bun run test
- bun run build
