### PR TITLE
fix: retry kanban write transaction boundaries

### DIFF
--- a/src/service/hermes-kanban.ts
+++ b/src/service/hermes-kanban.ts
@@ -227,12 +227,35 @@ export const sortDiags = (ds: Diag[]): Diag[] =>
 const DEFAULT = "default"
 const SLUG = /^[a-z0-9][a-z0-9_-]{0,63}$/
 const DEFAULT_BUSY_TIMEOUT_MS = 120_000
+const BUSY_RETRIES = 5
+const BUSY_MIN_MS = 20
+const BUSY_MAX_MS = 150
 
 const busyTimeoutMs = (): number => {
   const raw = (process.env.HERMES_KANBAN_BUSY_TIMEOUT_MS ?? "").trim()
   if (!raw) return DEFAULT_BUSY_TIMEOUT_MS
   const n = Number(raw)
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_BUSY_TIMEOUT_MS
+}
+
+const isBusy = (err: unknown): boolean => {
+  const msg = String((err as Error)?.message ?? err).toLowerCase()
+  return msg.includes("database is locked") || msg.includes("database is busy")
+}
+
+const nap = () => {
+  const ms = BUSY_MIN_MS + Math.random() * (BUSY_MAX_MS - BUSY_MIN_MS)
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+const boundary = (conn: Pick<Database, "exec">, sql: "BEGIN IMMEDIATE" | "COMMIT") => {
+  for (let i = 0; i <= BUSY_RETRIES; i++) {
+    try { conn.exec(sql); return }
+    catch (err) {
+      if (!isBusy(err) || i === BUSY_RETRIES) throw err
+      nap()
+    }
+  }
 }
 
 /** Shared Hermes root for kanban paths — mirrors upstream
@@ -770,16 +793,22 @@ function checkFileLength(conn: Database) {
  *  kanban_db.write_txn — IMMEDIATE takes the reserved lock up front so
  *  concurrent writers fail fast instead of racing mid-txn. */
 function writeTxn<T>(conn: Database, fn: () => T): T {
-  conn.exec("BEGIN IMMEDIATE")
+  boundary(conn, "BEGIN IMMEDIATE")
+  const out = (() => {
+    try { return fn() }
+    catch (err) {
+      try { conn.exec("ROLLBACK") } catch {}
+      throw err
+    }
+  })()
   try {
-    const out = fn()
-    conn.exec("COMMIT")
-    checkFileLength(conn)
-    return out
+    boundary(conn, "COMMIT")
   } catch (err) {
     try { conn.exec("ROLLBACK") } catch {}
     throw err
   }
+  checkFileLength(conn)
+  return out
 }
 
 const now = () => Math.floor(Date.now() / 1000)
@@ -848,5 +877,7 @@ export const tailLog = (id: string, bytes?: number) => tailLogOf(slug, id, bytes
  *  and toast messages readable for plain ids). */
 export const q = (s: string): string =>
   /^[A-Za-z0-9._\/:+=-]+$/.test(s) ? s : `'${s.replace(/'/g, `'\\''`)}'`
+
+export const internals = { writeTxn }
 
 export * as Kanban from "./hermes-kanban"

--- a/test/kanban.test.tsx
+++ b/test/kanban.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, afterEach } from "bun:test"
+import { describe, test, expect, beforeAll, afterEach, spyOn } from "bun:test"
 import { act } from "react"
 import { Database } from "bun:sqlite"
 import { mkdirSync, writeFileSync, rmSync, chmodSync } from "node:fs"
@@ -1298,6 +1298,78 @@ describe("patchTask direct writes", () => {
     const { patchTask } = await import("../src/service/hermes-kanban")
     expect(() => patchTask("default", "t4", { title: "   " })).toThrow(/empty/)
     expect(patchTask("default", "does-not-exist", { title: "x" })).toBe(false)
+  })
+
+  test("BEGIN IMMEDIATE retries transient BUSY before running body", async () => {
+    const { internals } = await import("../src/service/hermes-kanban")
+    const waits: number[] = []
+    const wait = spyOn(Atomics, "wait").mockImplementation(((arr: Int32Array, idx: number, val: number, timeout?: number) => {
+      void arr; void idx; void val
+      waits.push(Number(timeout))
+      return "timed-out"
+    }) as never)
+    let body = 0
+    const sqls: string[] = []
+    const conn = {
+      exec(sql: string) {
+        sqls.push(sql)
+        if (sql === "BEGIN IMMEDIATE" && sqls.filter(s => s === sql).length === 1)
+          throw new Error("database is locked")
+      },
+      query() { return { get: () => null } },
+    }
+    try {
+      expect(internals.writeTxn(conn as never, () => { body++; return "ok" })).toBe("ok")
+      expect(body).toBe(1)
+      expect(sqls).toEqual(["BEGIN IMMEDIATE", "BEGIN IMMEDIATE", "COMMIT"])
+      expect(waits.length).toBe(1)
+      expect(waits[0]).toBeGreaterThanOrEqual(20)
+      expect(waits[0]).toBeLessThanOrEqual(150)
+    } finally { wait.mockRestore() }
+  })
+
+  test("COMMIT retries transient BUSY without replaying body", async () => {
+    const { internals } = await import("../src/service/hermes-kanban")
+    const wait = spyOn(Atomics, "wait").mockImplementation((() => "timed-out") as never)
+    let body = 0
+    const sqls: string[] = []
+    const conn = {
+      exec(sql: string) {
+        sqls.push(sql)
+        if (sql === "COMMIT" && sqls.filter(s => s === sql).length === 1)
+          throw new Error("database is busy")
+      },
+      query() { return { get: () => null } },
+    }
+    try {
+      internals.writeTxn(conn as never, () => { body++ })
+      expect(body).toBe(1)
+      expect(sqls).toEqual(["BEGIN IMMEDIATE", "COMMIT", "COMMIT"])
+    } finally { wait.mockRestore() }
+  })
+
+  test("persistent COMMIT BUSY rolls back and preserves original error", async () => {
+    const { internals } = await import("../src/service/hermes-kanban")
+    const wait = spyOn(Atomics, "wait").mockImplementation((() => "timed-out") as never)
+    let body = 0
+    const sqls: string[] = []
+    const err = new Error("database is busy")
+    const conn = {
+      exec(sql: string) {
+        sqls.push(sql)
+        if (sql === "COMMIT") throw err
+      },
+      query() { return { get: () => null } },
+    }
+    try {
+      expect(() => internals.writeTxn(conn as never, () => { body++ })).toThrow(err)
+      expect(body).toBe(1)
+      expect(sqls).toEqual([
+        "BEGIN IMMEDIATE",
+        "COMMIT", "COMMIT", "COMMIT", "COMMIT", "COMMIT", "COMMIT",
+        "ROLLBACK",
+      ])
+    } finally { wait.mockRestore() }
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds bounded jitter retries for kanban direct-write transaction boundary statements only: `BEGIN IMMEDIATE` and `COMMIT`.
- Keeps the write transaction body outside all retry loops so task updates and audit-event inserts execute exactly once per `writeTxn()` call.
- Rolls back after body failures and after exhausted/persistent `COMMIT` failures so the cached write connection is not left in an open transaction.

## Test Plan
- `bun test test/kanban.test.tsx -t "BEGIN IMMEDIATE retries transient BUSY|COMMIT retries transient BUSY|persistent COMMIT BUSY"`
- `bun test test/kanban.test.tsx -t "patchTask direct writes"`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run test`
