### PR TITLE
feat: add Journey learning tab

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -222,6 +222,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
         case "status": openStatus(dialog, x.info, x.sid); return
         case "usage": openUsage(dialog, gw); return
         case "profile": openProfile(dialog); return
+        case "journey": x.goTo(TAB_SLASH.journey.tab, TAB_SLASH.journey.sub); return
         case "chafa":
           if (!arg.trim()) { toast.show({ variant: "info", message: "usage: /chafa <path>" }); return }
           openChafa(dialog, arg.trim())

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -40,6 +40,7 @@ export const LOCAL_NAMES = new Set([
   "resume", "branch", "compress", "undo", "redo", "retry", "model", "yolo", "quit",
   "copy", "paste", "image", "background", "voice", "mouse", "redraw", "queue",
   "stash",
+  "journey",
   // Ink-only UI toggles — local no-op with a note
   "compact", "setup",
   // browser: use browser.manage RPC, not slash.exec (issue #82)
@@ -64,6 +65,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "status",  description: "Version, model, paths",       category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "usage",   description: "Credits, account status, tokens, context fill, cost", category: "Info", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "profile", description: "Active profile details",       category: "Info",   aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
+  { name: "journey", description: "Open the learning journey graph", category: "Info", aliases: ["learning", "memory-graph"], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "steer",   description: "Inject a note mid-turn (no interrupt)", category: "Session", aliases: [], argsHint: "[text]", subcommands: [], source: "local", target: "local" },
   { name: "reload-mcp", description: "Restart MCP servers & rediscover tools", category: "Session", aliases: [], argsHint: "[now|always]", subcommands: ["now", "always"], source: "local", target: "local" },
   { name: "reload", description: "Hot-reload ~/.hermes/.env (API keys)", category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },

--- a/src/app/tabs.ts
+++ b/src/app/tabs.ts
@@ -23,7 +23,7 @@ export const CONFIG_TAB = 3
 export const EIKON_TAB = 4
 
 export const SUB_TABS: Record<number, readonly string[]> = {
-  [SESSIONS_TAB]:   ["List", "Context", "Analytics"],
+  [SESSIONS_TAB]:   ["List", "Context", "Analytics", "Journey"],
   [AUTOMATION_TAB]: ["Kanban", "Profiles", "Cron"],
   [CONFIG_TAB]:     ["Config", "Skills", "Toolsets", "Env", "Memory"],
   [EIKON_TAB]:      ["Library", "Catalog", "Studio"],
@@ -37,6 +37,9 @@ export const TAB_SLASH: Record<string, { tab: number; sub: number }> = {
   context:    { tab: SESSIONS_TAB,   sub: 1 },
   analytics:  { tab: SESSIONS_TAB,   sub: 2 },
   insights:   { tab: SESSIONS_TAB,   sub: 2 },
+  journey:    { tab: SESSIONS_TAB,   sub: 3 },
+  learning:   { tab: SESSIONS_TAB,   sub: 3 },
+  "memory-graph": { tab: SESSIONS_TAB, sub: 3 },
   kanban:     { tab: AUTOMATION_TAB, sub: 0 },
   automation: { tab: AUTOMATION_TAB, sub: 0 },
   profiles:   { tab: AUTOMATION_TAB, sub: 1 },

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -317,6 +317,81 @@ export type CommandsCatalogResponse = {
   warning?: string
 }
 
+export type LearningRun = [text: string, style: string, alpha?: number, hexOverride?: string | null]
+
+export type LearningLabel = {
+  key: string
+  glyph: string
+  label: string
+  meta: string
+  style: string
+  alpha: number
+}
+
+export type LearningLegend = {
+  glyph: string
+  style?: string
+  color?: string
+  label: string
+}
+
+export type LearningNode = {
+  id: string
+  glyph: string
+  label: string
+  fullLabel?: string
+  meta: string
+  body?: string
+  style: string
+}
+
+export type LearningBucket = {
+  index: number
+  label: string
+  date: string
+  skills: number
+  memories: number
+  total: number
+  category: string | null
+  color: string | null
+  nodes: LearningNode[]
+}
+
+export type LearningFramesRequest = {
+  cols?: number
+  rows?: number
+  frames?: number
+}
+
+export type LearningFramesResponse = {
+  frames: Array<{
+    reveal: number
+    date: string
+    visible: number
+    grid: LearningRun[][]
+    labels: LearningLabel[]
+  }>
+  legend: LearningLegend[]
+  categories?: LearningLegend[]
+  buckets?: LearningBucket[]
+  summary: string[]
+  axis: { start: string; end: string }
+  count: number
+  cols: number
+  rows: number
+}
+
+export type LearningDetailRequest = { id: string }
+
+export type LearningDetailResponse =
+  | { ok: true; kind: "memory" | "skill"; id: string; label: string; content: string }
+  | { ok: false; message: string }
+
+export type LearningEditRequest = { id: string; content: string }
+export type LearningDeleteRequest = { id: string }
+
+export type LearningMutationResponse = { ok: boolean; message: string }
+
 export type ConfigSetResponse = {
   value?: string
   info?: SessionInfo

--- a/src/tabs/Journey.tsx
+++ b/src/tabs/Journey.tsx
@@ -44,13 +44,14 @@ const latest = (rows: readonly JourneyRow[]) => {
   return i >= 0 ? rows.length - 1 - i : Math.max(0, rows.length - 1)
 }
 
-const snap = (rows: readonly JourneyRow[], i: number) => {
+const snap = (rows: readonly JourneyRow[], i: number, dir = 1) => {
   if (rows.length === 0) return 0
   const at = Math.max(0, Math.min(rows.length - 1, i))
   if (rows[at]?.kind !== "gap") return at
+  const rev = [...rows].reverse().findIndex((r, n) => rows.length - 1 - n < at && r.kind !== "gap")
+  if (dir < 0 && rev >= 0) return rows.length - 1 - rev
   const fwd = rows.findIndex((r, n) => n > at && r.kind !== "gap")
   if (fwd >= 0) return fwd
-  const rev = [...rows].reverse().findIndex((r, n) => rows.length - 1 - n < at && r.kind !== "gap")
   return rev >= 0 ? rows.length - 1 - rev : at
 }
 
@@ -96,7 +97,8 @@ export const Journey = memo((props: { focused?: boolean }) => {
 
   const setListSel = useCallback((next: number | ((prev: number) => number)) => {
     setSel(prev => {
-      const n = snap(rows, typeof next === "function" ? next(prev) : next)
+      const target = typeof next === "function" ? next(prev) : next
+      const n = snap(rows, target, target - prev)
       follow.opts.scrollTo(n)
       return n
     })

--- a/src/tabs/Journey.tsx
+++ b/src/tabs/Journey.tsx
@@ -1,0 +1,277 @@
+import { memo, useCallback, useEffect, useMemo, useState } from "react"
+import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react"
+import { RGBA } from "@opentui/core"
+import { useGateway } from "../context/gateway"
+import type { LearningBucket, LearningFramesResponse, LearningNode, LearningDetailResponse, LearningEditRequest, LearningDeleteRequest, LearningMutationResponse, LearningRun } from "../context/wire"
+import { useTheme } from "../theme"
+import type { Theme } from "../theme"
+import { useDialog } from "../ui/dialog"
+import { useToast } from "../ui/toast"
+import { TabShell } from "../ui/shell"
+import { HintBar } from "../ui/hint"
+import { openConfirm } from "../dialogs/confirm"
+import { editInEditor } from "../utils/editor"
+import { trunc } from "../ui/fmt"
+
+export type JourneyRow =
+  | { kind: "gap" }
+  | { kind: "slice"; bucket: LearningBucket }
+  | { kind: "node"; bucket: LearningBucket; node: LearningNode; last: boolean }
+
+export function buildJourneyRows(buckets: readonly LearningBucket[]): JourneyRow[] {
+  return buckets.flatMap((bucket, b) => [
+    ...(b > 0 ? [{ kind: "gap" as const }] : []),
+    { kind: "slice" as const, bucket },
+    ...bucket.nodes.map((node, i) => ({ kind: "node" as const, bucket, node, last: i === bucket.nodes.length - 1 })),
+  ])
+}
+
+const style = (theme: Theme, key?: string, hex?: string | null): RGBA => {
+  if (hex && /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(hex)) return RGBA.fromHex(hex)
+  if (key === "skill") return theme.primary
+  if (key === "memory") return theme.accent
+  if (key === "label") return theme.text
+  if (key === "dim") return theme.textMuted
+  if (key === "bg") return theme.borderSubtle
+  return theme.textMuted
+}
+
+const last = (data: LearningFramesResponse | null) => data?.frames.at(-1)?.grid ?? []
+
+const latest = (rows: readonly JourneyRow[]) => {
+  const i = [...rows].reverse().findIndex(r => r.kind === "node")
+  return i >= 0 ? rows.length - 1 - i : Math.max(0, rows.length - 1)
+}
+
+const snap = (rows: readonly JourneyRow[], i: number) => {
+  if (rows.length === 0) return 0
+  const at = Math.max(0, Math.min(rows.length - 1, i))
+  if (rows[at]?.kind !== "gap") return at
+  const fwd = rows.findIndex((r, n) => n > at && r.kind !== "gap")
+  if (fwd >= 0) return fwd
+  const rev = [...rows].reverse().findIndex((r, n) => rows.length - 1 - n < at && r.kind !== "gap")
+  return rev >= 0 ? rows.length - 1 - rev : at
+}
+
+const message = (err: unknown) => err instanceof Error ? err.message : String(err)
+
+export const Journey = memo((props: { focused?: boolean }) => {
+  const gw = useGateway()
+  const theme = useTheme().theme
+  const dialog = useDialog()
+  const toast = useToast()
+  const renderer = useRenderer()
+  const dims = useTerminalDimensions()
+  const [data, setData] = useState<LearningFramesResponse | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [sel, setSel] = useState(0)
+  const [detail, setDetail] = useState<LearningDetailResponse | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  const rows = useMemo(() => buildJourneyRows(data?.buckets ?? []), [data])
+  const row = rows[Math.min(sel, Math.max(0, rows.length - 1))]
+  const node = row?.kind === "node" ? row.node : undefined
+  const chart = last(data)
+  const h = Math.max(5, Math.min(8, Math.floor(dims.height * 0.2)))
+  const cols = Math.max(40, dims.width - 8)
+
+  const move = useCallback((delta: number) => {
+    setSel(i => snap(rows, i + delta))
+  }, [rows])
+
+  const load = useCallback(() => {
+    setErr(null)
+    setBusy(true)
+    gw.request<LearningFramesResponse>("learning.frames", { cols, rows: h, frames: 2 })
+      .then(r => {
+        setData(r)
+        const tree = buildJourneyRows(r.buckets ?? [])
+        setSel(latest(tree))
+        setDetail(null)
+      })
+      .catch((e: unknown) => setErr(message(e)))
+      .finally(() => setBusy(false))
+  }, [gw, cols, h])
+
+  useEffect(() => load(), [load, tick])
+
+  const open = useCallback(async () => {
+    if (!node) return
+    setBusy(true)
+    setErr(null)
+    try {
+      const r = await gw.request<LearningDetailResponse>("learning.detail", { id: node.id })
+      setDetail(r)
+      if (!r.ok) toast.show({ variant: "warning", message: r.message })
+    } catch (e) {
+      setErr(message(e))
+    } finally {
+      setBusy(false)
+    }
+  }, [gw, node, toast])
+
+  const edit = useCallback(async () => {
+    if (!node) return
+    setBusy(true)
+    setErr(null)
+    try {
+      const info = await gw.request<LearningDetailResponse>("learning.detail", { id: node.id })
+      if (!info.ok) {
+        toast.show({ variant: "warning", message: info.message })
+        return
+      }
+      const text = await editInEditor(renderer, info.content, info.kind === "skill" ? ".md" : ".txt")
+      if (text === undefined || text.trim() === info.content.trim()) {
+        toast.show({ variant: "info", message: "no changes" })
+        return
+      }
+      const req: LearningEditRequest = { id: node.id, content: text }
+      const r = await gw.request<LearningMutationResponse>("learning.edit", req)
+      toast.show({ variant: r.ok ? "success" : "warning", message: r.message })
+      if (r.ok || /stale|refresh/i.test(r.message)) setTick(n => n + 1)
+    } catch (e) {
+      setErr(message(e))
+    } finally {
+      setBusy(false)
+    }
+  }, [gw, node, renderer, toast])
+
+  const del = useCallback(async () => {
+    if (!node) return
+    const ok = await openConfirm(dialog, {
+      title: `Delete ${node.label}?`,
+      body: `${node.fullLabel || node.label}\n\nThis mutates the learning source through learning.delete.`,
+      yes: "delete",
+      danger: true,
+    })
+    if (!ok) return
+    setBusy(true)
+    setErr(null)
+    try {
+      const req: LearningDeleteRequest = { id: node.id }
+      const r = await gw.request<LearningMutationResponse>("learning.delete", req)
+      toast.show({ variant: r.ok ? "success" : "warning", message: r.message })
+      if (r.ok || /stale|refresh/i.test(r.message)) setTick(n => n + 1)
+    } catch (e) {
+      setErr(message(e))
+    } finally {
+      setBusy(false)
+    }
+  }, [dialog, gw, node, toast])
+
+  useKeyboard(key => {
+    if (!props.focused || dialog.open() || busy) return
+    if (key.name === "escape" && detail) { setDetail(null); return }
+    if (key.name === "up" || key.name === "k" || key.raw === "k") { move(-1); return }
+    if (key.name === "down" || key.name === "j" || key.raw === "j") { move(1); return }
+    if (key.name === "pageup") { move(-10); return }
+    if (key.name === "pagedown") { move(10); return }
+    if (key.raw === "G" || (key.name === "g" && key.shift)) { setSel(snap(rows, rows.length - 1)); return }
+    if (key.name === "g") { setSel(snap(rows, 0)); return }
+    if (key.name === "return" || key.name === "right" || key.name === "l") { void open(); return }
+    if (key.name === "e" || key.raw === "e") { void edit(); return }
+    if (key.name === "d" || key.raw === "d") { void del(); return }
+    if (key.name === "r" || key.raw === "r") { setTick(n => n + 1) }
+  })
+
+  return (
+    <box flexDirection="column" flexGrow={1} minWidth={0}>
+      <box flexDirection="row" flexGrow={1} minWidth={0}>
+        <TabShell title={data ? `Journey · ${data.count} learned item${data.count === 1 ? "" : "s"}` : "Journey"} error={err} focus={!detail} grow={detail ? 2 : 1}>
+          {!data && !err ? <Loading /> : null}
+          {!data && err ? <ErrorState err={err} /> : null}
+          {data && data.count === 0 ? <Empty /> : null}
+          {data && data.count > 0 ? (
+            <box flexDirection="column" flexGrow={1} minHeight={0}>
+              <Legend data={data} />
+              <Chart rows={chart} theme={theme} />
+              <box height={1} />
+              <scrollbox scrollY flexGrow={1}>
+                <box flexDirection="column">
+                  {rows.map((r, i) => <Row key={`${r.kind}-${i}`} row={r} active={i === sel} theme={theme} set={() => setSel(i)} />)}
+                </box>
+              </scrollbox>
+            </box>
+          ) : null}
+        </TabShell>
+        {detail ? <Detail detail={detail} node={node} focus theme={theme} /> : null}
+      </box>
+      <HintBar raw={busy ? "loading…" : "↑↓/jk nav  Enter detail  e edit  d delete  r reload  Esc close detail"} />
+    </box>
+  )
+})
+
+const Loading = () => {
+  const theme = useTheme().theme
+  return <box flexGrow={1} justifyContent="center" alignItems="center"><text fg={theme.textMuted}>assembling learning map…</text></box>
+}
+
+const Empty = () => {
+  const theme = useTheme().theme
+  return <box flexGrow={1} justifyContent="center" alignItems="center"><text fg={theme.textMuted}>No learning yet — skills and memories will appear here.</text></box>
+}
+
+const ErrorState = ({ err }: { err: string }) => {
+  const theme = useTheme().theme
+  return <box flexGrow={1} justifyContent="center" alignItems="center"><text fg={theme.error} wrapMode="word">{err}</text></box>
+}
+
+const Legend = ({ data }: { data: LearningFramesResponse }) => {
+  const theme = useTheme().theme
+  const items = [...(data.legend ?? []), ...(data.categories ?? [])]
+  const text = items.map(i => `${i.glyph} ${i.label}`).join("  ") || data.summary.join("  ")
+  return <box height={1} overflow="hidden"><text fg={theme.textMuted} wrapMode="none">{text}</text></box>
+}
+
+const Chart = ({ rows, theme }: { rows: LearningRun[][]; theme: Theme }) => (
+  <box flexDirection="column" flexShrink={0}>
+    {rows.map((row, i) => (
+      <box key={i} height={1} overflow="hidden">
+        <text wrapMode="none">
+          {row.map((run, n) => <span key={n} fg={style(theme, run[1], run[3])}>{run[0]}</span>)}
+        </text>
+      </box>
+    ))}
+  </box>
+)
+
+const Row = (props: { row: JourneyRow; active: boolean; theme: Theme; set: () => void }) => {
+  const bg = props.active ? props.theme.backgroundElement : undefined
+  if (props.row.kind === "gap") return <box height={1} />
+  if (props.row.kind === "slice") return (
+    <box height={1} backgroundColor={bg} onMouseDown={props.set} overflow="hidden">
+      <text wrapMode="none">
+        <span fg={props.active ? props.theme.accent : props.theme.primary}>{props.row.bucket.label}</span>
+        <span fg={props.theme.textMuted}>{`  ${props.row.bucket.total} total · ${props.row.bucket.memories} memories · ${props.row.bucket.skills} skills`}</span>
+      </text>
+    </box>
+  )
+  return (
+    <box height={1} backgroundColor={bg} onMouseDown={props.set} overflow="hidden">
+      <text wrapMode="none">
+        <span fg={props.theme.textMuted}>{props.row.last ? "  └─ " : "  ├─ "}</span>
+        <span fg={props.active ? props.theme.accent : style(props.theme, props.row.node.style)}>{`${props.row.node.glyph} ${trunc(props.row.node.fullLabel || props.row.node.label, 54)}`}</span>
+        <span fg={props.theme.textMuted}>{props.row.node.meta ? `  ${props.row.node.meta}` : ""}</span>
+      </text>
+    </box>
+  )
+}
+
+const Detail = (props: { detail: LearningDetailResponse; node?: LearningNode; focus: boolean; theme: Theme }) => (
+  <TabShell title={props.detail.ok ? `${props.detail.kind} · ${props.detail.label}` : "Detail"} focus={props.focus} grow={1}>
+    {props.detail.ok ? (
+      <scrollbox scrollY flexGrow={1}>
+        <box flexDirection="column">
+          {props.detail.content.split(/\r?\n/).map((line, i) => (
+            <box key={i} minHeight={1}>
+              <text fg={props.theme.text} wrapMode="word">{line || " "}</text>
+            </box>
+          ))}
+        </box>
+      </scrollbox>
+    ) : (
+      <text fg={props.theme.warning} wrapMode="word">{props.detail.message}</text>
+    )}
+  </TabShell>
+)

--- a/src/tabs/Journey.tsx
+++ b/src/tabs/Journey.tsx
@@ -1,10 +1,11 @@
-import { memo, useCallback, useEffect, useMemo, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react"
-import { RGBA } from "@opentui/core"
+import { RGBA, type ScrollBoxRenderable } from "@opentui/core"
 import { useGateway } from "../context/gateway"
 import type { LearningBucket, LearningFramesResponse, LearningNode, LearningDetailResponse, LearningEditRequest, LearningDeleteRequest, LearningMutationResponse, LearningRun } from "../context/wire"
 import { useTheme } from "../theme"
 import type { Theme } from "../theme"
+import { handleListKey, useFollow, useKeys } from "../keys"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 import { TabShell } from "../ui/shell"
@@ -55,6 +56,13 @@ const snap = (rows: readonly JourneyRow[], i: number) => {
 
 const message = (err: unknown) => err instanceof Error ? err.message : String(err)
 
+const rid = (r: JourneyRow | undefined, i: number) => {
+  if (!r) return `empty-${i}`
+  if (r.kind === "slice") return `slice-${r.bucket.index}-${r.bucket.date ?? r.bucket.label}`
+  if (r.kind === "node") return `node-${r.bucket.index}-${r.node.id}`
+  return `gap-${i}`
+}
+
 export const Journey = memo((props: { focused?: boolean }) => {
   const gw = useGateway()
   const theme = useTheme().theme
@@ -62,10 +70,12 @@ export const Journey = memo((props: { focused?: boolean }) => {
   const toast = useToast()
   const renderer = useRenderer()
   const dims = useTerminalDimensions()
+  const keys = useKeys()
   const [data, setData] = useState<LearningFramesResponse | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [sel, setSel] = useState(0)
   const [detail, setDetail] = useState<LearningDetailResponse | null>(null)
+  const [pane, setPane] = useState<"list" | "detail">("list")
   const [busy, setBusy] = useState(false)
   const [tick, setTick] = useState(0)
 
@@ -75,10 +85,34 @@ export const Journey = memo((props: { focused?: boolean }) => {
   const chart = last(data)
   const h = Math.max(5, Math.min(8, Math.floor(dims.height * 0.2)))
   const cols = Math.max(40, dims.width - 8)
+  const follow = useFollow("journey", i => rid(rows[i], i))
+  const scroll = useRef<ScrollBoxRenderable | null>(null)
 
-  const move = useCallback((delta: number) => {
-    setSel(i => snap(rows, i + delta))
+  const jump = useCallback((i: number) => {
+    const n = snap(rows, i)
+    setSel(n)
+    follow.opts.scrollTo(n)
   }, [rows])
+
+  const setListSel = useCallback((next: number | ((prev: number) => number)) => {
+    setSel(prev => {
+      const n = snap(rows, typeof next === "function" ? next(prev) : next)
+      follow.opts.scrollTo(n)
+      return n
+    })
+  }, [rows])
+
+  useEffect(() => {
+    let n = 0
+    const cb = async () => {
+      n++
+      if (n < 2) return
+      follow.opts.scrollTo(sel)
+      renderer.removeFrameCallback(cb)
+    }
+    renderer.setFrameCallback(cb)
+    return () => renderer.removeFrameCallback(cb)
+  }, [renderer, rows, sel])
 
   const load = useCallback(() => {
     setErr(null)
@@ -89,6 +123,7 @@ export const Journey = memo((props: { focused?: boolean }) => {
         const tree = buildJourneyRows(r.buckets ?? [])
         setSel(latest(tree))
         setDetail(null)
+        setPane("list")
       })
       .catch((e: unknown) => setErr(message(e)))
       .finally(() => setBusy(false))
@@ -96,13 +131,14 @@ export const Journey = memo((props: { focused?: boolean }) => {
 
   useEffect(() => load(), [load, tick])
 
-  const open = useCallback(async () => {
-    if (!node) return
+  const open = useCallback(async (target = node) => {
+    if (!target) return
     setBusy(true)
     setErr(null)
     try {
-      const r = await gw.request<LearningDetailResponse>("learning.detail", { id: node.id })
+      const r = await gw.request<LearningDetailResponse>("learning.detail", { id: target.id })
       setDetail(r)
+      setPane("detail")
       if (!r.ok) toast.show({ variant: "warning", message: r.message })
     } catch (e) {
       setErr(message(e))
@@ -162,23 +198,47 @@ export const Journey = memo((props: { focused?: boolean }) => {
 
   useKeyboard(key => {
     if (!props.focused || dialog.open() || busy) return
-    if (key.name === "escape" && detail) { setDetail(null); return }
-    if (key.name === "up" || key.name === "k" || key.raw === "k") { move(-1); return }
-    if (key.name === "down" || key.name === "j" || key.raw === "j") { move(1); return }
-    if (key.name === "pageup") { move(-10); return }
-    if (key.name === "pagedown") { move(10); return }
-    if (key.raw === "G" || (key.name === "g" && key.shift)) { setSel(snap(rows, rows.length - 1)); return }
-    if (key.name === "g") { setSel(snap(rows, 0)); return }
-    if (key.name === "return" || key.name === "right" || key.name === "l") { void open(); return }
+    if (detail && (key.name === "tab" || keys.match("focus.cycle", key))) { setPane(p => p === "list" ? "detail" : "list"); return }
+    if (detail && pane === "detail") {
+      const page = Math.max(1, (scroll.current?.viewport.height ?? 10) - 1)
+      if (key.name === "escape") { setPane("list"); return }
+      if (key.name === "up" || key.name === "k" || key.raw === "k") { scroll.current?.scrollBy(-1); return }
+      if (key.name === "down" || key.name === "j" || key.raw === "j") { scroll.current?.scrollBy(1); return }
+      if (key.name === "pageup") { scroll.current?.scrollBy(-page); return }
+      if (key.name === "pagedown") { scroll.current?.scrollBy(page); return }
+      if (key.name === "home" || key.name === "g") { scroll.current?.scrollTo(0); return }
+      if (key.name === "end" || key.raw === "G" || (key.name === "g" && key.shift)) { scroll.current?.scrollTo(scroll.current.scrollHeight); return }
+      return
+    }
+    if (key.name === "escape" && detail) { setDetail(null); setPane("list"); return }
+    const matched = handleListKey(keys, key, {
+      count: rows.length,
+      setSel: setListSel,
+      ...follow.opts,
+      onActivate: () => void open(),
+      onToggle: () => void open(),
+      onRefresh: () => setTick(n => n + 1),
+      onDelete: () => void del(),
+    })
+    if (matched) return
     if (key.name === "e" || key.raw === "e") { void edit(); return }
-    if (key.name === "d" || key.raw === "d") { void del(); return }
-    if (key.name === "r" || key.raw === "r") { setTick(n => n + 1) }
   })
+
+  const rowPick = useCallback((i: number) => jump(i), [jump])
+  const rowOpen = useCallback((i: number) => {
+    jump(i)
+    const r = rows[i]
+    if (r?.kind === "node") void open(r.node)
+  }, [jump, open, rows])
+
+  const hint = detail && pane === "detail"
+    ? `↑↓/jk scroll  ${keys.print("list.pageUp")}/${keys.print("list.pageDown")} page  Tab list  Esc list`
+    : `${keys.print("list.activate")} detail  ${keys.print("list.toggle")} detail  e edit  ${keys.print("list.delete")} delete  ${keys.print("list.refresh")} reload${detail ? "  Tab detail  Esc close" : ""}`
 
   return (
     <box flexDirection="column" flexGrow={1} minWidth={0}>
       <box flexDirection="row" flexGrow={1} minWidth={0}>
-        <TabShell title={data ? `Journey · ${data.count} learned item${data.count === 1 ? "" : "s"}` : "Journey"} error={err} focus={!detail} grow={detail ? 2 : 1}>
+        <TabShell title={data ? `Journey · ${data.count} learned item${data.count === 1 ? "" : "s"}` : "Journey"} error={err} focus={pane === "list"} grow={detail ? 2 : 1}>
           {!data && !err ? <Loading /> : null}
           {!data && err ? <ErrorState err={err} /> : null}
           {data && data.count === 0 ? <Empty /> : null}
@@ -187,17 +247,17 @@ export const Journey = memo((props: { focused?: boolean }) => {
               <Legend data={data} />
               <Chart rows={chart} theme={theme} />
               <box height={1} />
-              <scrollbox scrollY flexGrow={1}>
+              <scrollbox ref={follow.ref} scrollY flexGrow={1}>
                 <box flexDirection="column">
-                  {rows.map((r, i) => <Row key={`${r.kind}-${i}`} row={r} active={i === sel} theme={theme} set={() => setSel(i)} />)}
+                  {rows.map((r, i) => <Row key={rid(r, i)} id={follow.id(i)} row={r} active={i === sel} theme={theme} set={() => rowPick(i)} act={() => rowOpen(i)} />)}
                 </box>
               </scrollbox>
             </box>
           ) : null}
         </TabShell>
-        {detail ? <Detail detail={detail} node={node} focus theme={theme} /> : null}
+        {detail ? <Detail detail={detail} box={scroll} focus={pane === "detail"} theme={theme} /> : null}
       </box>
-      <HintBar raw={busy ? "loading…" : "↑↓/jk nav  Enter detail  e edit  d delete  r reload  Esc close detail"} />
+      <HintBar raw={busy ? "loading…" : hint} />
     </box>
   )
 })
@@ -236,20 +296,23 @@ const Chart = ({ rows, theme }: { rows: LearningRun[][]; theme: Theme }) => (
   </box>
 )
 
-const Row = (props: { row: JourneyRow; active: boolean; theme: Theme; set: () => void }) => {
+const Row = (props: { id: string; row: JourneyRow; active: boolean; theme: Theme; set: () => void; act: () => void }) => {
   const bg = props.active ? props.theme.backgroundElement : undefined
-  if (props.row.kind === "gap") return <box height={1} />
+  const caret = props.active ? "▸ " : "  "
+  if (props.row.kind === "gap") return <box id={props.id} height={1} />
   if (props.row.kind === "slice") return (
-    <box height={1} backgroundColor={bg} onMouseDown={props.set} overflow="hidden">
+    <box id={props.id} height={1} backgroundColor={bg} onMouseMove={props.set} onMouseDown={props.act} overflow="hidden">
       <text wrapMode="none">
+        <span fg={props.theme.textMuted}>{caret}</span>
         <span fg={props.active ? props.theme.accent : props.theme.primary}>{props.row.bucket.label}</span>
         <span fg={props.theme.textMuted}>{`  ${props.row.bucket.total} total · ${props.row.bucket.memories} memories · ${props.row.bucket.skills} skills`}</span>
       </text>
     </box>
   )
   return (
-    <box height={1} backgroundColor={bg} onMouseDown={props.set} overflow="hidden">
+    <box id={props.id} height={1} backgroundColor={bg} onMouseMove={props.set} onMouseDown={props.act} overflow="hidden">
       <text wrapMode="none">
+        <span fg={props.theme.textMuted}>{caret}</span>
         <span fg={props.theme.textMuted}>{props.row.last ? "  └─ " : "  ├─ "}</span>
         <span fg={props.active ? props.theme.accent : style(props.theme, props.row.node.style)}>{`${props.row.node.glyph} ${trunc(props.row.node.fullLabel || props.row.node.label, 54)}`}</span>
         <span fg={props.theme.textMuted}>{props.row.node.meta ? `  ${props.row.node.meta}` : ""}</span>
@@ -258,11 +321,11 @@ const Row = (props: { row: JourneyRow; active: boolean; theme: Theme; set: () =>
   )
 }
 
-const Detail = (props: { detail: LearningDetailResponse; node?: LearningNode; focus: boolean; theme: Theme }) => (
+const Detail = (props: { detail: LearningDetailResponse; box: React.RefObject<ScrollBoxRenderable | null>; focus: boolean; theme: Theme }) => (
   <TabShell title={props.detail.ok ? `${props.detail.kind} · ${props.detail.label}` : "Detail"} focus={props.focus} grow={1}>
     {props.detail.ok ? (
-      <scrollbox scrollY flexGrow={1}>
-        <box flexDirection="column">
+      <scrollbox ref={props.box} scrollY flexGrow={1}>
+        <box flexDirection="column" width="100%">
           {props.detail.content.split(/\r?\n/).map((line, i) => (
             <box key={i} minHeight={1}>
               <text fg={props.theme.text} wrapMode="word">{line || " "}</text>

--- a/src/tabs/SessionsGroup.tsx
+++ b/src/tabs/SessionsGroup.tsx
@@ -4,6 +4,7 @@ import type { SessionInfo } from "../context/wire"
 import { Sessions } from "./Sessions"
 import { Context } from "./Context"
 import { Analytics } from "./Analytics"
+import { Journey } from "./Journey"
 import { SubTabBar } from "../components/tabs/SubTabBar"
 import { SUB_TABS, SESSIONS_TAB } from "../app/tabs"
 
@@ -53,6 +54,9 @@ export const SessionsGroup = memo((props: Props) => {
         </Pane>
         <Pane visible={props.sub === 2}>
           <Analytics focused={!!props.focused && props.sub === 2} />
+        </Pane>
+        <Pane visible={props.sub === 3}>
+          <Journey focused={!!props.focused && props.sub === 3} />
         </Pane>
       </box>
     </box>

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,17 +1,17 @@
 // Suspend the renderer, open $VISUAL/$EDITOR on a tmpfile seeded with the
 // current input, read it back. Returns undefined if no editor configured
-// or the user emptied the file.
+// or the user emptied the file. `suffix` hints syntax mode to editors.
 
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { rm } from "node:fs/promises"
 import type { CliRenderer } from "@opentui/core"
 
-export async function editInEditor(renderer: CliRenderer, seed: string): Promise<string | undefined> {
+export async function editInEditor(renderer: CliRenderer, seed: string, suffix = ".md"): Promise<string | undefined> {
   const cmd = process.env.VISUAL || process.env.EDITOR
   if (!cmd) return undefined
 
-  const path = join(tmpdir(), `herm-${Date.now()}.md`)
+  const path = join(tmpdir(), `herm-${Date.now()}${suffix}`)
   await Bun.write(path, seed)
 
   renderer.suspend()

--- a/test/editor.test.ts
+++ b/test/editor.test.ts
@@ -56,6 +56,20 @@ describe("editInEditor", () => {
     rmSync(script, { force: true })
   })
 
+  test("uses requested temp suffix", async () => {
+    const script = join(tmpdir(), `herm-fake-editor-suffix-${Date.now()}.sh`)
+    await Bun.write(script, `#!/bin/sh\ncase "$1" in *.txt) printf 'txt file' > "$1" ;; *) printf 'wrong' > "$1" ;; esac\n`)
+    await Bun.$`chmod +x ${script}`.quiet()
+    process.env.VISUAL = script
+
+    const f = fake()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await editInEditor(f.renderer as any, "seed", ".txt")
+    expect(out).toBe("txt file")
+
+    rmSync(script, { force: true })
+  })
+
   test("handles $EDITOR with args (split on space)", async () => {
     // `sh -c 'printf hello > "$0"'` — $0 is the appended path arg.
     process.env.VISUAL = ""

--- a/test/journey.test.tsx
+++ b/test/journey.test.tsx
@@ -104,6 +104,18 @@ describe("Journey", () => {
     await until(t, () => t.frame().includes("▸   └─ ● Memory card 23"))
   })
 
+  test("moves backward across bucket gaps", async () => {
+    const gw = new MockGateway({ "learning.frames": () => oldFrames() })
+
+    await using t = await mountNode(<Journey focused />, { gw, width: 120, height: 36 })
+    await until(t, () => t.frame().includes("▸   └─ ● Newest memory"))
+
+    act(() => t.keys.pressArrow("up"))
+    await until(t, () => t.frame().includes("▸ Jul 01"))
+    act(() => t.keys.pressArrow("up"))
+    await until(t, () => t.frame().includes("▸   └─ ● Memory card"))
+  })
+
   test("mouse hover selects and mouse down opens detail", async () => {
     const gw = new MockGateway({
       "learning.frames": () => frames(),

--- a/test/journey.test.tsx
+++ b/test/journey.test.tsx
@@ -78,6 +78,67 @@ describe("Journey", () => {
     expect(t.gw.last("learning.detail")?.params.id).toBe("memory:memory:0")
   })
 
+  test("uses shared list keys and keeps selection visible", async () => {
+    const many = frames()
+    const nodes = Array.from({ length: 24 }, (_, i) => ({
+      id: `memory:memory:${i}`,
+      glyph: "●",
+      label: `Memory ${i}`,
+      fullLabel: `Memory card ${i}`,
+      meta: "MEMORY.md",
+      body: `body ${i}`,
+      style: "memory",
+    }))
+    many.buckets = [{ ...many.buckets![0], nodes, total: nodes.length, memories: nodes.length, skills: 0 }]
+    many.count = nodes.length
+    const gw = new MockGateway({ "learning.frames": () => many })
+
+    await using t = await mountNode(<Journey focused />, { gw, width: 100, height: 20 })
+    await until(t, () => t.frame().includes("▸   └─ ● Memory card 23"))
+
+    act(() => t.keys.pressKey("HOME"))
+    await until(t, () => t.frame().includes("▸ Jun 30"))
+    await act(async () => { await t.keys.pressKeys(["\x1B[6~"]) })
+    await until(t, () => t.frame().includes("▸   ├─ ● Memory card 8"))
+    act(() => t.keys.pressKey("END"))
+    await until(t, () => t.frame().includes("▸   └─ ● Memory card 23"))
+  })
+
+  test("mouse hover selects and mouse down opens detail", async () => {
+    const gw = new MockGateway({
+      "learning.frames": () => frames(),
+      "learning.detail": p => ({ ok: true, kind: "skill", id: p.id, label: "Skill A", content: "skill detail" }),
+    })
+    await using t = await mountNode(<Journey focused />, { gw, width: 120, height: 36 })
+    await until(t, () => t.frame().includes("Skill A"))
+    const y = t.frame().split("\n").findIndex(l => l.includes("Skill A"))
+
+    await act(async () => { await t.mouse.moveTo(6, y) })
+    await until(t, () => t.frame().includes("▸   ├─ ◆ Skill A"))
+    await act(async () => { await t.mouse.pressDown(6, y) })
+    await until(t, () => t.frame().includes("skill detail"))
+    expect(t.gw.last("learning.detail")?.params.id).toBe("skill-a")
+  })
+
+  test("detail pane receives Tab focus and keyboard scrolling", async () => {
+    const content = Array.from({ length: 30 }, (_, i) => `detail line ${i}`).join("\n")
+    const gw = new MockGateway({
+      "learning.frames": () => frames(),
+      "learning.detail": p => ({ ok: true, kind: "memory", id: p.id, label: "Memory card", content }),
+    })
+    await using t = await mountNode(<Journey focused />, { gw, width: 120, height: 22 })
+    await until(t, () => t.frame().includes("Memory card"))
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("detail line 0"))
+    act(() => t.keys.pressKey("tab"))
+    await until(t, () => !t.frame().includes("Esc close"))
+    await act(async () => { await t.keys.pressKeys(["\x1B[6~"]) })
+    await until(t, () => t.frame().includes("detail line 14") || t.frame().includes("detail line 15"))
+    act(() => t.keys.pressEscape())
+    await until(t, () => t.frame().includes("Esc close"))
+  })
+
   test("opens on the newest learned node", async () => {
     const gw = new MockGateway({
       "learning.frames": () => oldFrames(),

--- a/test/journey.test.tsx
+++ b/test/journey.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mount, mountNode, MockGateway, until } from "./harness"
+import { Journey, buildJourneyRows } from "../src/tabs/Journey"
+import { TAB_SLASH } from "../src/app/tabs"
+import { resolve, LOCAL_COMMANDS } from "../src/app/slashCommands"
+import type { LearningFramesResponse } from "../src/context/wire"
+
+const frames = (): LearningFramesResponse => ({
+  frames: [{
+    reveal: 1,
+    date: "2026-06-30",
+    visible: 2,
+    grid: [[
+      ["╭", "dim"],
+      ["●", "memory"],
+      ["─", "dim"],
+      ["◆", "skill"],
+      ["╯", "dim"],
+    ]],
+    labels: [],
+  }],
+  legend: [{ glyph: "●", style: "memory", label: "memory" }],
+  categories: [{ glyph: "◆", color: "#00ffff", label: "skills" }],
+  buckets: [{
+    index: 0,
+    label: "Jun 30",
+    date: "2026-06-30",
+    skills: 1,
+    memories: 1,
+    total: 2,
+    category: "recent",
+    color: "#00ffff",
+    nodes: [
+      { id: "skill-a", glyph: "◆", label: "Skill", fullLabel: "Skill A", meta: "skill", body: "", style: "skill" },
+      { id: "memory:memory:0", glyph: "●", label: "Memory", fullLabel: "Memory card", meta: "MEMORY.md", body: "remember me", style: "memory" },
+    ],
+  }],
+  summary: ["2 learned items"],
+  axis: { start: "2026-06-30", end: "2026-06-30" },
+  count: 2,
+  cols: 80,
+  rows: 8,
+})
+
+const oldFrames = (): LearningFramesResponse => ({
+  ...frames(),
+  buckets: [
+    frames().buckets![0],
+    { ...frames().buckets![0], index: 1, label: "Jul 01", nodes: [
+      { id: "memory:memory:1", glyph: "●", label: "New", fullLabel: "Newest memory", meta: "MEMORY.md", body: "new", style: "memory" },
+    ] },
+  ],
+  count: 3,
+})
+
+describe("Journey", () => {
+  test("builds chronological slice and item rows with gaps", () => {
+    const data = frames()
+    const rows = buildJourneyRows([data.buckets![0], { ...data.buckets![0], index: 1, label: "Jul 01" }])
+    expect(rows.map(r => r.kind)).toEqual(["slice", "node", "node", "gap", "slice", "node", "node"])
+  })
+
+  test("renders learning frames and opens detail through RPC", async () => {
+    const gw = new MockGateway({
+      "learning.frames": () => frames(),
+      "learning.detail": p => ({ ok: true, kind: "memory", id: p.id, label: "Memory card", content: "full memory body" }),
+    })
+    await using t = await mountNode(<Journey focused />, { gw, width: 120, height: 36 })
+    await until(t, () => t.frame().includes("Journey · 2 learned items"))
+
+    expect(t.frame()).toContain("Jun 30")
+    expect(t.frame()).toContain("Memory card")
+    expect(t.gw.last("learning.frames")?.params.frames).toBe(2)
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("full memory body"))
+    expect(t.gw.last("learning.detail")?.params.id).toBe("memory:memory:0")
+  })
+
+  test("opens on the newest learned node", async () => {
+    const gw = new MockGateway({
+      "learning.frames": () => oldFrames(),
+      "learning.detail": p => ({ ok: true, kind: "memory", id: p.id, label: "Newest memory", content: "newest detail" }),
+    })
+    await using t = await mountNode(<Journey focused />, { gw, width: 120, height: 36 })
+    await until(t, () => t.frame().includes("Newest memory"))
+
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("newest detail"))
+    expect(t.gw.last("learning.detail")?.params.id).toBe("memory:memory:1")
+  })
+
+  test("shows empty and RPC-error states", async () => {
+    await using empty = await mountNode(<Journey focused />, {
+      gw: new MockGateway({ "learning.frames": () => ({ ...frames(), count: 0, buckets: [] }) }),
+    })
+    await until(empty, () => empty.frame().includes("No learning yet"))
+
+    await using fail = await mountNode(<Journey focused />, {
+      gw: new MockGateway({ "learning.frames": () => { throw new Error("learning.frames failed") } }),
+    })
+    await until(fail, () => fail.frame().includes("learning.frames failed"))
+  })
+
+  test("delete uses confirm dialog and refreshes after mutation", async () => {
+    let n = 0
+    const gw = new MockGateway({
+      "learning.frames": () => { n++; return frames() },
+      "learning.delete": p => ({ ok: true, message: `deleted ${p.id}` }),
+    })
+    await using t = await mountNode(<Journey focused />, { gw })
+    await until(t, () => t.frame().includes("Memory card"))
+
+    act(() => t.keys.pressKey("d"))
+    await until(t, () => t.frame().includes("Delete Memory?"))
+    act(() => t.keys.pressKey("y"))
+    await until(t, () => n > 1)
+    expect(t.gw.last("learning.delete")?.params.id).toBe("memory:memory:0")
+  })
+
+  test("slash aliases route to the native Journey surface", async () => {
+    expect(TAB_SLASH.journey).toEqual({ tab: 1, sub: 3 })
+    expect(TAB_SLASH.learning).toEqual({ tab: 1, sub: 3 })
+    expect(TAB_SLASH["memory-graph"]).toEqual({ tab: 1, sub: 3 })
+    expect(resolve(LOCAL_COMMANDS, "learning")).toMatchObject({ hit: { name: "journey" } })
+    expect(resolve(LOCAL_COMMANDS, "journey")).toMatchObject({ hit: { target: "local" } })
+
+    await using t = await mount({
+      handlers: { "learning.frames": () => frames() },
+      width: 130,
+      height: 40,
+    })
+    await until(t, () => t.frame().includes("Ready"))
+    await act(async () => { await t.keys.typeText("/journey") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Journey · 2 learned items"))
+    expect(t.gw.last("slash.exec")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds the Sessions → Journey learning surface backed by gateway learning RPCs.
- Renders learning frames, bucket rows, item detail, edit/delete flows, and `/journey`/`/learning` routing.
- Review fixes: Journey now uses shared list key handling with scroll-follow, stable row ids/carets, mouse hover/select + click/open parity, and Tab focus/keyboard scrolling for the detail pane.

## Verification
- `bunx tsc --noEmit`
- `bun test test/journey.test.tsx test/editor.test.ts test/slash.test.ts` (26 pass)
- `bun run build`
- `bun run test` (1364 pass)

## Known limitations
- None known.