### PR TITLE
fix: strip friendly prefixes from diff tab fallback

### DIFF
--- a/src/components/chat/DiffTabs.tsx
+++ b/src/components/chat/DiffTabs.tsx
@@ -26,6 +26,7 @@ const PATH_KEY = /"(?:path|file_path|filename|target|file)"\s*:\s*"((?:\\.|[^"\\
 const DIFF_HEAD_ARROW = /(?:^|\s)a\/+\S.*?\s*→\s*b\/+(\S.+?)\s*$/m
 const DIFF_HEAD_NEW = /^\+\+\+ b?\/+(\S.*?)\s*$/m
 const DIFF_HEAD_OLD = /^--- a?\/+(\S.*?)\s*$/m
+const VERB = /^(?:Browsing|Clicking|Delegating|Editing|Generating image|Generating speech|Generating video|Listing skills|Looking at the image|Reading skill|Reading|Running code|Running|Scheduling|Searching files for|Searching past sessions|Searching the web for|Typing|Updating memory|Updating skill|Updating tasks|Writing)\s+(.+)$/
 function pathFor(t: ToolPart): string {
   const args = (t as { args?: string }).args
   if (args && /^\s*\{/.test(args)) {
@@ -38,7 +39,8 @@ function pathFor(t: ToolPart): string {
     const m = c.match(DIFF_HEAD_ARROW) || c.match(DIFF_HEAD_NEW) || c.match(DIFF_HEAD_OLD)
     if (m) return m[1]
   }
-  return clean(t.preview ?? t.name)
+  const fallback = clean(t.preview ?? t.name)
+  return fallback.match(VERB)?.[1] ?? fallback
 }
 
 // Strip the gateway's CLI-rendered chrome from inline_diff so DiffBlock

--- a/test/diff-tabs.test.tsx
+++ b/test/diff-tabs.test.tsx
@@ -163,6 +163,41 @@ describe("DiffTabs", () => {
     t.destroy()
   })
 
+  test("strips friendly verb prefix only after args and diff headers miss", async () => {
+    const t = await mountNode(
+      <DiffTabs tools={[{
+        type: "tool", id: "p3", name: "patch", args: "",
+        preview: "Editing src/fallback.ts", status: "done", duration: 5,
+        diff: ["@@ -1 +1 @@", "-old", "+new"].join("\n"),
+      }]} />,
+      { width: 80, height: 14 },
+    )
+    await until(t, () => t.frame().includes("fallback.ts"))
+    expect(t.frame()).not.toContain("Editing")
+    t.destroy()
+  })
+
+  test("keeps args and diff header precedence over friendly preview", async () => {
+    const tools: ToolPart[] = [
+      {
+        type: "tool", id: "args", name: "patch",
+        args: JSON.stringify({ path: "src/from-args.ts" }),
+        preview: "Editing src/from-preview.ts", status: "done", duration: 5,
+        diff: udiff("src/from-diff.ts", "a"),
+      },
+      {
+        type: "tool", id: "diff", name: "patch", args: "",
+        preview: "Editing src/from-preview.ts", status: "done", duration: 5,
+        diff: udiff("src/from-diff.ts", "b"),
+      },
+    ]
+    const t = await mountNode(<DiffTabs tools={tools} />, { width: 100, height: 14 })
+    await until(t, () => t.frame().includes("from-args.ts") && t.frame().includes("from-diff.ts"))
+    expect(t.frame()).not.toContain("from-preview.ts")
+    expect(t.frame()).not.toContain("Editing")
+    t.destroy()
+  })
+
   test("sanitizes gateway CLI-rendered inline_diff (┊/summary/…/arrow-header)", async () => {
     // Actual shape gateway sends: display.py's _render_inline_unified_diff
     // REPLACES `--- a/` / `+++ b/` with `a/path → b/path` (one line),


### PR DESCRIPTION
## Summary
- Keeps diff tab labels sourced from structured JSON args and diff headers before considering preview text.
- Strips known friendly tool verb prefixes only as the final `pathFor` fallback so fallback labels do not render prose like `Editing ...`.
- Adds component coverage for the fallback strip and for args/header precedence over friendly preview text.

## Test plan
- `bun test test/diff-tabs.test.tsx` — 13 pass, 0 fail
- `bunx tsc --noEmit` — pass

## Evidence
- `src/components/chat/DiffTabs.tsx` now applies the friendly-prefix strip only after args and diff header parsing miss.
- `test/diff-tabs.test.tsx` covers fallback stripping and verifies args/diff header precedence.