### PR TITLE
fix: latch pending prompt submits

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -205,7 +205,13 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [skin, setSkin] = useState<SkinState>(() => deriveSkin(undefined))
   const inflight = useRef(false)
   const hold = useRef(false)
+  const pending = useRef(false)
   const [pulse, setPulse] = useState(0)
+  const start = useCallback(() => {
+    inflight.current = false
+    pending.current = false
+    setPulse(n => n + 1)
+  }, [])
   const settle = useCallback(() => {
     if (!hold.current) return
     hold.current = false
@@ -336,12 +342,14 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
     setSid, setInfo, setReady, setTitle, setBusy, setUsage, setStatus, setSkin, setErrorPulse, settle,
+    start,
   })
   intr.current = stream.doInterrupt
 
   const reset = useCallback(() => {
     stream.interrupted.current = false
     hold.current = false
+    pending.current = false
     toast.clear("credits.depleted")
     undone.current = []
     dispatch({ kind: "reset" })
@@ -617,6 +625,13 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     const withMedia = attachments.length
       ? [...attachments.flatMap(a => a.path ? [`MEDIA:${a.path}`] : []), text].filter(Boolean).join("\n")
       : text
+    if (pending.current) {
+      setQueue(q => [...q, raw])
+      setStatus("queued for next turn")
+      return
+    }
+    pending.current = true
+    setPulse(n => n + 1)
     gw.request("prompt.submit", { text })
       .then(() => {
         dispatch({ kind: "user", text: withMedia })
@@ -627,6 +642,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       .catch((e: Error) => {
         const msg = e instanceof Error ? e.message : String(e)
         if (BUSY_RE.test(msg)) {
+          pending.current = false
+          setPulse(n => n + 1)
           inflight.current = true
           setQueue(q => [text, ...q])
           setStatus("queued for next turn")
@@ -637,6 +654,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
           }, 400)
           return
         }
+        pending.current = false
+        setPulse(n => n + 1)
         inflight.current = false
         dispatch({ kind: "system", text: `submit failed: ${msg}` })
         toast.show({ variant: "error", message: msg })
@@ -681,10 +700,10 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // `queue`; on idle the head auto-submits. turnReducer doesn't flip
   // `streaming` until the gateway emits message.start (async), so a
   // naive effect would fire repeatedly and drain the whole queue in
-  // one tick. `inflight` bridges the dispatch→message.start gap.
-  useEffect(() => { if (turn.streaming) inflight.current = false }, [turn.streaming])
+  // one tick. `pending`/`inflight` bridge the submit→message.start gap.
+  useEffect(() => { if (turn.streaming) start() }, [turn.streaming, start])
   useEffect(() => {
-    if (!capabilities.canDrainQueue || inflight.current || hold.current || queue.length === 0) return
+    if (!capabilities.canDrainQueue || inflight.current || hold.current || pending.current || queue.length === 0) return
     const [head, ...rest] = queue
     inflight.current = true
     setQueue(rest)
@@ -883,7 +902,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
               <VoiceIndicator voice={voice.state} keyLabel={voice.keyLabel} />
               <Composer
                 ref={composer}
-                focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming}
+                focused={inputFocused} canSubmitPrompt={capabilities.canSubmitPrompt} ready={ready} streaming={turn.streaming || pending.current}
                 status={status}
                 model={info?.model}
                 hidden={hidden}

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -37,6 +37,7 @@ type Ctx = {
   setSkin: (s: SkinState) => void
   setErrorPulse: (v: boolean) => void
   settle: () => void
+  start: () => void
 }
 
 // Events that mutate the in-progress assistant turn. Everything else
@@ -104,6 +105,7 @@ export function useStream(c: Ctx) {
   const handle = useCallback((ev: GatewayEvent) => {
     const x = ctx.current
     if (ev.type === "gateway.ready") info.current = false
+    if (ev.type === "message.start") x.start()
     if (ev.type === "background.complete" && ev.session_id && x.sidRef.current
         && ev.session_id !== x.sidRef.current) {
       bg.unregister(ev.payload.task_id)

--- a/test/attachments.test.tsx
+++ b/test/attachments.test.tsx
@@ -181,6 +181,8 @@ describe("composer: image attachments (D4+D7)", () => {
     expect(t.gw.last("prompt.submit")?.params.text).toBe("")
     // Pre-send tray is gone; chip still appears in the transcript MEDIA
     // echo, which is expected.
+    act(() => t.gw.push({ type: "message.start" }))
+    act(() => t.gw.push({ type: "message.complete", payload: { status: "complete", text: "done" } }))
     await until(t, () => t.frame().includes("Ready"))
     t.destroy()
   })

--- a/test/queued-submit.test.tsx
+++ b/test/queued-submit.test.tsx
@@ -7,6 +7,38 @@ function info() {
 }
 
 describe("queued prompt submit", () => {
+  test("rapid submit queues behind accepted prompt before message.start", async () => {
+    let release!: () => void
+    const first = new Promise<{ status: string }>(resolve => {
+      release = () => resolve({ status: "streaming" })
+    })
+    const gw = new MockGateway({
+      "prompt.submit": () => first,
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("message A") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.calls.filter(c => c.method === "prompt.submit").length === 1)
+
+    await act(async () => { await t.keys.typeText("message B") })
+    act(() => t.keys.pressEnter())
+    await t.settle()
+
+    expect(gw.calls.filter(c => c.method === "prompt.submit")).toHaveLength(1)
+    expect(t.frame()).toContain("⏸ 1. message B")
+
+    act(() => release())
+    await until(t, () => t.frame().includes("message A"))
+    act(() => gw.push({ type: "message.start" }))
+    act(() => gw.push({ type: "message.complete", payload: { status: "complete", text: "done" } }))
+    await until(t, () => gw.calls.filter(c => c.method === "prompt.submit").length === 2)
+
+    expect(gw.last("prompt.submit")?.params.text).toBe("message B")
+    t.destroy()
+  })
+
   test("interrupt-mode queue waits for session.info before draining", async () => {
     const gw = new MockGateway({
       "config.get": p => p.key === "busy" ? { value: "interrupt" } : {},


### PR DESCRIPTION
## Summary
- Latches accepted prompt submits immediately so rapid follow-up Enter presses route through the existing queue instead of issuing a second prompt.submit before message.start.
- Clears the latch from message.start in the stream path and preserves the existing session-busy fallback, interrupt flush, slash, steer, shell, and attachment flows.
- Adds a MockGateway regression with deferred prompt.submit and updates the attachment-empty-submit test to settle the mocked turn.

## Test Commands
- bunx tsc --noEmit
- bun test test/composer.test.tsx test/queued-submit.test.tsx test/session-steer.test.tsx test/app.test.tsx test/attachments.test.tsx
- bun run test
- bun run build

## Risks
- Pending-submit chip uses the existing streaming composer state, so it shows the normal Generating/queue affordances during the small submit→message.start window.
