### PR TITLE
fix: keep log out of live tool progress

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 import { SKINS } from "../context/skin"
 import { SCHEMA, SCHEMA_KEYS, type ConfigEffect } from "./schema"
-import { route } from "./lane"
+import { route, TOOL_PROGRESS } from "./lane"
 
 export type FieldType = "boolean" | "select" | "number" | "string" | "readonly"
 
@@ -29,7 +29,7 @@ const SELECTS: Record<string, string[]> = {
   "display.busy_input_mode": ["queue", "steer", "interrupt"],
   "display.details_mode": ["hidden", "collapsed", "expanded"],
   "display.thinking_mode": ["collapsed", "truncated", "full"],
-  "display.tool_progress": ["off", "new", "all", "verbose"],
+  "display.tool_progress": [...TOOL_PROGRESS],
   "approvals.mode": ["manual", "ask", "yolo", "deny"],
   "onboarding.profile_build": ["ask", "off"],
   "streaming.transport": ["auto", "draft", "edit", "off"],

--- a/src/config/lane.ts
+++ b/src/config/lane.ts
@@ -14,12 +14,18 @@ type RpcAlias = {
 
 const onOff = (v: unknown) => (v ? "on" : "off")
 
+export const TOOL_PROGRESS = ["off", "new", "all", "verbose"] as const
+const progress = new Set<string>(TOOL_PROGRESS)
+const progressErr = "log is a gateway-only config-file mode, not a live TUI mode"
+
 export const RPC_ALIAS: Record<string, RpcAlias> = {
   model: { alias: "model" },
   provider: { alias: "model" },
   "agent.service_tier": { alias: "fast" },
   "agent.reasoning_effort": { alias: "reasoning" },
   "display.show_reasoning": { alias: "reasoning", toWire: v => (v ? "show" : "hide") },
+  // Upstream messaging gateways support `display.tool_progress=log`, but
+  // stock TUI `config.set verbose` only live-applies these four modes.
   "display.tool_progress": { alias: "verbose" },
   "display.busy_input_mode": { alias: "busy" },
   "display.details_mode": { alias: "details_mode" },
@@ -80,10 +86,13 @@ export const writeConfig = async (gw: Gw, diffs: Diff[]): Promise<WriteResult> =
   const ok: string[] = []
   const failed: WriteResult["failed"] = []
   const warnings: WriteResult["warnings"] = []
+  const blocked = diffs.filter(d => d.key === "display.tool_progress" && !progress.has(String(d.to ?? "")))
+  for (const d of blocked) failed.push({ key: d.key, err: progressErr })
+  const safe = diffs.filter(d => !blocked.includes(d))
 
-  const rpc = diffs.filter(d => route(d.key).via === "rpc")
-  const cli = diffs.filter(d => route(d.key).via === "cli")
-  const ro = diffs.filter(d => route(d.key).via === "readonly")
+  const rpc = safe.filter(d => route(d.key).via === "rpc")
+  const cli = safe.filter(d => route(d.key).via === "cli")
+  const ro = safe.filter(d => route(d.key).via === "readonly")
   for (const d of ro) failed.push({ key: d.key, err: "structured value — edit in YAML mode" })
 
   for (const d of rpc) {

--- a/src/config/rules.ts
+++ b/src/config/rules.ts
@@ -9,6 +9,8 @@
  * not "is this a number".
  */
 
+import { TOOL_PROGRESS } from "./lane"
+
 type Rule = (raw: string) => string | null
 
 const int = (lo: number, hi: number, what = `${lo}–${hi}`): Rule => raw => {
@@ -68,7 +70,7 @@ export const RULES: Record<string, Rule> = {
   "display.busy_input_mode": oneOf("queue", "steer", "interrupt"),
   "display.details_mode": oneOf("hidden", "collapsed", "expanded"),
   "display.thinking_mode": oneOf("collapsed", "truncated", "full"),
-  "display.tool_progress": oneOf("off", "new", "all", "verbose"),
+  "display.tool_progress": oneOf(...TOOL_PROGRESS),
   "display.final_response_markdown": oneOf("render", "strip", "raw"),
   "logging.level": oneOf("DEBUG", "INFO", "WARNING", "ERROR"),
   "approvals.mode": oneOf("manual", "ask", "yolo", "deny"),

--- a/test/config-index.test.ts
+++ b/test/config-index.test.ts
@@ -28,6 +28,13 @@ describe("config/index", () => {
     expect(fs.find(x => x.key === "agent.max_turns")!.type).toBe("number")
   })
 
+  test("tool progress offers only live TUI modes", () => {
+    const f = buildFields({}).find(x => x.key === "display.tool_progress")!
+    expect(f.type).toBe("select")
+    expect(f.options).toEqual(["off", "new", "all", "verbose"])
+    expect(f.options).not.toContain("log")
+  })
+
   test("unknown user key surfaces as an extra field", () => {
     const fs = buildFields({ mystery: { flag: true } })
     const f = fs.find(x => x.key === "mystery.flag")

--- a/test/config-lane.test.ts
+++ b/test/config-lane.test.ts
@@ -110,6 +110,27 @@ describe("lane.writeConfig", () => {
     expect(res.failed[0]).toMatchObject({ key: "model" })
     expect(res.failed[0].err).toContain("session busy")
   })
+
+  test("tool progress live modes use verbose RPC alias", async () => {
+    const gw = mockGw({ "config.set": () => ({}) })
+    const res = await writeConfig(gw, [{ key: "display.tool_progress", to: "verbose" }])
+    expect(res).toEqual({ ok: ["display.tool_progress"], failed: [], warnings: [] })
+    expect(gw.calls).toEqual([
+      { method: "config.set", params: { key: "verbose", value: "verbose" } },
+    ])
+  })
+
+  test("tool progress log is never sent to verbose RPC alias", async () => {
+    const gw = mockGw({
+      "config.set": () => { throw new Error("should not call rpc") },
+    })
+    const res = await writeConfig(gw, [{ key: "display.tool_progress", to: "log" }])
+    expect(gw.calls).toEqual([])
+    expect(res.ok).toEqual([])
+    expect(res.failed).toEqual([
+      { key: "display.tool_progress", err: "log is a gateway-only config-file mode, not a live TUI mode" },
+    ])
+  })
 })
 
 describe("lane.verifyWrite", () => {

--- a/test/config-rules.test.ts
+++ b/test/config-rules.test.ts
@@ -38,6 +38,12 @@ describe("rules", () => {
     expect(check("logging.level", "TRACE")).toMatch(/one of/)
   })
 
+  test("tool progress accepts only live TUI modes", () => {
+    for (const mode of ["off", "new", "all", "verbose"])
+      expect(check("display.tool_progress", mode), mode).toBeNull()
+    expect(check("display.tool_progress", "log")).toMatch(/one of/)
+  })
+
   test("nonNeg accepts 0", () => {
     expect(check("agent.gateway_timeout", "0")).toBeNull()
     expect(check("agent.gateway_timeout", "-1")).toMatch(/≥/)


### PR DESCRIPTION
## Summary
- keep display.tool_progress Config-tab options limited to live TUI modes
- share the live mode list across selector validation and write routing
- guard writeConfig so `display.tool_progress=log` is never sent through the `verbose` RPC alias

## Selected log-mode behavior
- `display.tool_progress=log` remains a config-file/gateway-only mode.
- The Config tab hides `log`, rejects live edits to `log`, and returns a gateway-only/config-file error if a bypass reaches writeConfig.
- Live TUI edits continue to support only `off`, `new`, `all`, and `verbose` through `config.set verbose`.

## Schema regeneration
- No schema regeneration occurred.
- `src/config/schema.ts` and `scripts/gen-schema.ts` were already aligned with the live TUI mode set: `off | new | all | verbose`.

## Verification
- `bun test test/config-index.test.ts test/config-rules.test.ts test/config-lane.test.ts` — 35 pass, 0 fail
- `bunx tsc --noEmit` — pass
- Reviewer verification before finalization: `bun run test` — 1358 pass, 0 fail; `bun run build` — pass
