### PR TITLE
feat: add compress compact parity

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -82,6 +82,57 @@ export type SlashCtx = {
   voiceToggle: (action: string, sid: string) => Promise<void>
 }
 
+const AGGRESSIVE = "--aggressive is not supported; use '/compress here [N]' to keep only recent exchanges, or /undo to drop turns."
+
+function flags(arg: string) {
+  const kept: string[] = []
+  const preview = { on: false, aggressive: false }
+  for (const tok of arg.split(/\s+/).filter(Boolean)) {
+    const low = tok.toLowerCase()
+    if (low === "--preview" || low === "--dry-run" || low === "--dryrun") preview.on = true
+    else if (low === "--aggressive") preview.aggressive = true
+    else kept.push(tok)
+  }
+  return { arg: kept.join(" "), preview: preview.on, aggressive: preview.aggressive }
+}
+
+function partial(arg: string) {
+  const text = arg.trim()
+  if (!text) return { on: false, keep: 2, focus: "" }
+  const norm = text.toLowerCase().startsWith("up to here") ? text.slice(6).trim() : text
+  const bits = norm.toLowerCase().split(/\s+/)
+  const keep = (v: string | undefined) => Math.min(Math.max(parseInt(v ?? "", 10) || 2, 1), 100)
+  if (bits[0] === "here") return { on: true, keep: keep(bits[1]), focus: "" }
+  if ((bits[0] === "--keep" || bits[0] === "-k") && bits[1]) return { on: true, keep: keep(bits[1]), focus: "" }
+  if (bits[0]?.startsWith("--keep=")) return { on: true, keep: keep(bits[0].split("=", 2)[1]), focus: "" }
+  return { on: false, keep: 2, focus: text }
+}
+
+function preview(arg: string, msgs: Message[]): string[] | null {
+  const f = flags(arg)
+  if (f.aggressive && !f.preview) return [AGGRESSIVE]
+  if (!f.preview) return null
+  const p = partial(f.arg)
+  const at = p.on ? [...msgs].reverse().reduce((acc, m, i) => {
+    if (acc.length < p.keep && m.role === "user") return [...acc, msgs.length - 1 - i]
+    return acc
+  }, [] as number[]).at(-1) : undefined
+  const head = at === undefined || at === 0 ? msgs : msgs.slice(0, at)
+  const tail = at === undefined || at === 0 ? [] : msgs.slice(at)
+  const lines = [
+    "Preview — no changes made.",
+    `Would compress ${head.length} of ${msgs.length} message(s) (~${Math.ceil(msgs.map(msgText).join("\n\n").length / 4).toLocaleString()} tokens currently in context).`,
+  ]
+  if (p.on && tail.length)
+    lines.push(`Boundary: keeping the last ${p.keep} exchange(s) (${tail.length} message(s)) verbatim.`)
+  else if (p.on)
+    lines.push("Boundary: 'here' split would keep everything — falling back to full compression.")
+  if (p.focus) lines.push(`Focus topic: "${p.focus}"`)
+  lines.push("Run the command again without --preview to apply.")
+  if (f.aggressive) lines.push(AGGRESSIVE)
+  return lines
+}
+
 export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void {
   const gw = useGateway()
   const dialog = useDialog()
@@ -147,11 +198,26 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
 
   // Manual compression mutates server context only; keep the live chat
   // transcript visually stable, matching auto-compression.
-  const runCompress = useCallback(async () => {
+  const runCompress = useCallback(async (arg = "") => {
+    const raw = arg.trim()
+    const pv = preview(raw, ctx.current.turnRef.current.messages)
+    if (pv) {
+      ctx.current.dispatch({ kind: "system", text: pv.join("\n") })
+      toast.show({ variant: pv.length === 1 ? "warning" : "info",
+        message: pv.length === 1 ? "compress unsupported" : "Preview — no changes made" })
+      return
+    }
     toast.show({ variant: "info", message: "Compressing session…" })
-    const r = await ctx.current.session.compress()
+    const r = await ctx.current.session.compress(raw)
     if (!r) return
     if (r.info) ctx.current.setInfo(r.info)
+    const out = r.lines?.length ? r.lines : r.message ? [r.message] : []
+    if (r.status === "preview" || r.status === "unsupported" || out.length) {
+      if (out.length) ctx.current.dispatch({ kind: "system", text: out.join("\n") })
+      toast.show({ variant: r.status === "unsupported" ? "warning" : "info",
+        message: r.status === "unsupported" ? "compress unsupported" : "Preview — no changes made" })
+      return
+    }
     // r.usage.context_used reads comp.last_prompt_tokens which is set by
     // the last *model turn*, not updated by compression. r.after_tokens
     // IS the fresh rough estimate of the compacted transcript, so splice
@@ -259,7 +325,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
         case "branch":
           branch(arg)
           return
-        case "compress": void runCompress(); return
+        case "compress": void runCompress(arg); return
         case "undo":
           destructive(arg,
             { title: "Undo last turn?", body: "Pops the last user + assistant pair from the transcript. /redo in this session to restore.", yes: "undo" },
@@ -430,7 +496,6 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             .catch((e: Error) => toast.show({ variant: "error", message: `browser: ${e.message}` }))
           return
         }
-        case "compact":
         case "setup":
           x.dispatch({ kind: "system",
             text: `/${c.name} is an Ink-TUI command and has no effect in herm` })

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -41,7 +41,7 @@ export const LOCAL_NAMES = new Set([
   "copy", "paste", "image", "background", "voice", "mouse", "redraw", "queue",
   "stash",
   // Ink-only UI toggles — local no-op with a note
-  "compact", "setup",
+  "setup",
   // browser: use browser.manage RPC, not slash.exec (issue #82)
   "browser",
 ])
@@ -79,6 +79,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "branch", description: "Fork current conversation",              category: "Session", aliases: ["fork"], argsHint: "[name]", subcommands: [], source: "local", target: "local" },
+  { name: "compress", description: "Compress conversation context",         category: "Session", aliases: ["compact"], argsHint: "[here [N] | focus topic | --preview|--dry-run]", subcommands: [], source: "local", target: "local" },
   { name: "browser", description: "Connect/disconnect a CDP browser",      category: "Session", aliases: [], argsHint: "[connect|disconnect|status] [url]", subcommands: ["connect", "disconnect", "status"], source: "local", target: "local" },
 ]
 

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -19,12 +19,14 @@ import type { Message, Usage } from "../types/message"
 /** session.compress response shape. `messages` is compacted server context;
  *  the live chat transcript intentionally stays visually unchanged. */
 export type CompressResult = {
-  status?: "compressed" | "skipped"
+  status?: "compressed" | "skipped" | "preview" | "unsupported"
   removed?: number
   before_messages?: number
   after_messages?: number
   before_tokens?: number
   after_tokens?: number
+  lines?: string[]
+  message?: string
   messages?: TranscriptMessage[]
   info?: SessionInfo
   usage?: Usage
@@ -55,7 +57,7 @@ type SessionOps = {
   close: (sid: string, opts?: Close) => Promise<boolean>
   interrupt: () => Promise<void>
   branch: (name?: string) => Promise<string | null>
-  compress: () => Promise<CompressResult | null>
+  compress: (arg?: string) => Promise<CompressResult | null>
   undo: () => Promise<void>
 }
 
@@ -181,8 +183,10 @@ export function useSession(): SessionOps {
     } catch { return null }
   }, [gw])
 
-  const compress = useCallback(async (): Promise<CompressResult | null> => {
-    try { return await gw.request<CompressResult>("session.compress") }
+  const compress = useCallback(async (arg = ""): Promise<CompressResult | null> => {
+    const raw = arg.trim()
+    const params = raw ? { raw_args: raw, focus_topic: raw } : {}
+    try { return await gw.request<CompressResult>("session.compress", params) }
     catch { return null }
   }, [gw])
 

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -279,7 +279,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       return
     }
     const p = live.current.pop
-    if (p.open) {
+    if (p.open && !(p.spot?.whole && p.spot.query.includes(" "))) {
       const c = p.popover?.[p.cursor]
       if (c) fill(c)
       return

--- a/test/compress.test.tsx
+++ b/test/compress.test.tsx
@@ -19,8 +19,24 @@ const postCompactMessages = [
   { role: "assistant" as const, text: "Tighter version …" },
 ]
 
+const longMessages = [
+  { role: "user" as const, text: "u1" },
+  { role: "assistant" as const, text: "a1" },
+  { role: "user" as const, text: "u2" },
+  { role: "assistant" as const, text: "a2" },
+  { role: "user" as const, text: "u3" },
+  { role: "assistant" as const, text: "a3" },
+  { role: "user" as const, text: "u4" },
+  { role: "assistant" as const, text: "a4" },
+  { role: "user" as const, text: "u5" },
+  { role: "assistant" as const, text: "a5" },
+]
+
 const mkGw = () => new MockGateway({
-  "commands.catalog": () => ({ pairs: [["/compress", "compress transcript"]] }),
+  "commands.catalog": () => ({
+    pairs: [["/compress", "compress transcript"]],
+    canon: { "/compact": "/compress" },
+  }),
   "session.resume": () => ({
     session_id: "pre-sid",
     messages: preCompactMessages,
@@ -109,6 +125,100 @@ describe("/compress", () => {
     // turns still visible.
     expect(t.frame()).toContain("draft the rfc")
 
+    t.destroy()
+  })
+
+  test("passes args through the session.compress RPC", async () => {
+    const gw = mkGw()
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
+    await until(t, () => t.frame().includes("draft the rfc"))
+
+    await act(async () => { await t.keys.typeText("/compress project notes") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("session.compress") !== undefined)
+
+    expect(t.gw.last("session.compress")?.params).toMatchObject({
+      raw_args: "project notes",
+      focus_topic: "project notes",
+    })
+    t.destroy()
+  })
+
+  test("/compact aliases to /compress", async () => {
+    const gw = mkGw()
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
+    await until(t, () => t.frame().includes("draft the rfc"))
+
+    await act(async () => { await t.keys.typeText("/compact project notes") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.gw.last("session.compress") !== undefined)
+
+    expect(t.gw.last("session.compress")?.params.raw_args).toBe("project notes")
+    expect(t.gw.last("slash.exec")).toBeUndefined()
+    expect(t.frame()).not.toContain("Ink-TUI command")
+    t.destroy()
+  })
+
+  test("preview and dry-run are no-mutation previews", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/compress", "compress transcript"]] }),
+      "session.resume": () => ({ session_id: "pre-sid", messages: longMessages }),
+      "session.create": () => ({ session_id: "pre-sid" }),
+      "session.compress": () => { throw new Error("preview must not mutate") },
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false }, height: 80 })
+    await until(t, () => t.frame().includes("u1"))
+
+    await act(async () => { t.gw.calls.length = 0 })
+    await act(async () => { await t.keys.typeText("/compress --preview") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Preview — no changes made."))
+
+    expect(t.gw.last("session.compress")).toBeUndefined()
+    expect(t.frame()).toContain("Would compress 10 of 10 message(s)")
+    await act(async () => { await t.keys.typeText("/compress --dry-run") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().split("Preview — no changes made.").length > 2)
+    expect(t.gw.last("session.compress")).toBeUndefined()
+    t.destroy()
+  })
+
+  test("here preview preserves upstream boundary semantics", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/compress", "compress transcript"]] }),
+      "session.resume": () => ({ session_id: "pre-sid", messages: longMessages }),
+      "session.create": () => ({ session_id: "pre-sid" }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false }, height: 80 })
+    await until(t, () => t.frame().includes("u1"))
+
+    await act(async () => { t.gw.calls.length = 0 })
+    await act(async () => { await t.keys.typeText("/compress here 3 --preview") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Boundary: keeping the last 3 exchange(s)"))
+
+    expect(t.frame()).toContain("Would compress 4 of 10 message(s)")
+    expect(t.frame()).toContain("(6 message(s)) verbatim")
+    expect(t.gw.last("session.compress")).toBeUndefined()
+    t.destroy()
+  })
+
+  test("aggressive is unsupported, not a focus topic", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/compress", "compress transcript"]] }),
+      "session.resume": () => ({ session_id: "pre-sid", messages: longMessages }),
+      "session.create": () => ({ session_id: "pre-sid" }),
+      "session.compress": () => { throw new Error("aggressive must not mutate") },
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false }, height: 80 })
+    await until(t, () => t.frame().includes("u1"))
+
+    await act(async () => { t.gw.calls.length = 0 })
+    await act(async () => { await t.keys.typeText("/compress --aggressive") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("--aggressive is not supported"))
+
+    expect(t.gw.last("session.compress")).toBeUndefined()
     t.destroy()
   })
 })

--- a/test/quit-argshint.test.tsx
+++ b/test/quit-argshint.test.tsx
@@ -60,4 +60,15 @@ describe("useSlashCommands /quit description", () => {
     expect(quit.aliases).not.toContain("q")
     t.destroy()
   })
+
+  test("keeps /compact canonicalized as a /compress alias", async () => {
+    const { t, ref } = await setup({
+      pairs: [["/compress", "Compress conversation context"]],
+      canon: { "/compact": "/compress" },
+    })
+    const cmd = ref.current!.cmds().find(c => c.name === "compress")!
+    expect(cmd.aliases).toContain("compact")
+    expect(cmd.target).toBe("local")
+    t.destroy()
+  })
 })


### PR DESCRIPTION
## Summary
- Treat /compact as a real /compress alias in slash resolution.
- Preserve no-arg compression while forwarding argument-bearing compression through session.compress with raw args.
- Add preview/dry-run and unsupported aggressive handling that reports no-mutation output without touching the transcript or session context.

## Test Plan
- bun test
- bunx tsc --noEmit
- bun run build