### PR TITLE
fix: refresh model picker catalog explicitly

### DIFF
--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -12,6 +12,8 @@ import { DialogSelect, type SelectOption } from "../ui/dialog-select"
 import { SecretPrompt } from "./secret-prompt"
 import { useTheme } from "../theme"
 import { useToast } from "../ui/toast"
+import { useKeys } from "../keys/context"
+import type { ParsedKey } from "@opentui/core"
 import type { Gateway } from "../context/gateway"
 import type { ConfigSetResponse, ModelOptionProvider, ModelOptionsResponse } from "../context/wire"
 
@@ -60,6 +62,7 @@ const replaceProvider = (
 const ModelPickerDialog = (props: Props) => {
   const dialog = useDialog()
   const toast = useToast()
+  const keys = useKeys()
   const theme = useTheme().theme
   const [data, setData] = useState<ModelOptionsResponse | null>(null)
   const [step, setStep] = useState<Step>("provider")
@@ -67,11 +70,16 @@ const ModelPickerDialog = (props: Props) => {
   const [setupProvider, setSetupProvider] = useState<ModelOptionProvider | null>(null)
   const [global, setGlobal] = useState(false)
 
-  const refresh = useCallback(() => props.gw.request<ModelOptionsResponse>("model.options")
+  const load = useCallback((refresh = false) => props.gw.request<ModelOptionsResponse>("model.options", refresh ? { refresh: true } : undefined)
     .then(setData)
     .catch(() => setData({ providers: [] })), [props.gw])
 
-  useEffect(() => { void refresh() }, [refresh])
+  useEffect(() => { void load() }, [load])
+
+  const refresh = useCallback(() => {
+    toast.show({ variant: "info", message: "Refreshing model catalog; custom-provider probes may be slower…" })
+    void load(true)
+  }, [load, toast])
 
   const apply = useCallback((model: string, prov: string) => {
     if (props.onApply) return void props.onApply(prov, model)
@@ -91,7 +99,7 @@ const ModelPickerDialog = (props: Props) => {
     try {
       const r = await props.gw.request<SaveKeyResponse>("model.save_key", { slug: p.slug, api_key: key })
       if (r.warning) toast.show({ variant: "warning", message: r.warning })
-      const next = r.provider ?? (await props.gw.request<ModelOptionsResponse>("model.options"))
+      const next = r.provider ?? (await props.gw.request<ModelOptionsResponse>("model.options", { refresh: true }))
         .providers?.find(pp => pp.slug === p.slug)
       if (!next) {
         toast.show({ variant: "warning", message: "Provider saved; refresh model options to continue" })
@@ -121,21 +129,22 @@ const ModelPickerDialog = (props: Props) => {
     setStep("setup")
   }, [toast])
 
-  const onKey = useCallback((k: { name: string }) => {
+  const onKey = useCallback((k: ParsedKey) => {
+    if (keys.match("list.refresh", k)) { refresh(); return true }
     if (k.name === "tab" && !props.onApply) { setGlobal(g => !g); return true }
     if (k.name === "left" && step !== "provider") { setStep("provider"); return true }
     return false
-  }, [step, props.onApply])
+  }, [keys, refresh, step, props.onApply])
 
   const footer = props.onApply
-    ? <text fg={theme.textMuted}>{step === "model" ? "←: providers" : " "}</text>
+    ? <text fg={theme.textMuted}>{`${keys.print("list.refresh")}: refresh${step === "model" ? " · ←: providers" : ""}`}</text>
     : (
       <text fg={theme.textMuted}>
         <span>Scope: </span>
         <span fg={global ? theme.warning : theme.accent}>
           {global ? "global (persists to config)" : "this session"}
         </span>
-        <span> · Tab: toggle{step === "model" ? " · ←: providers" : ""}</span>
+        <span>{` · ${keys.print("list.refresh")}: refresh · Tab: toggle${step === "model" ? " · ←: providers" : ""}`}</span>
       </text>
     )
 

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -31,6 +31,51 @@ const OPTIONS = {
 }
 
 describe("model-picker", () => {
+  test("initial open requests model options without refresh", async () => {
+    const t = await mountNode(<Open />, {
+      handlers: { "model.options": () => OPTIONS },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+
+    expect(t.gw.calls.filter(c => c.method === "model.options")).toEqual([
+      { method: "model.options", params: {} },
+    ])
+    t.destroy()
+  })
+
+  test("refresh key probes catalog with refresh and updates providers", async () => {
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": p => p.refresh ? {
+          provider: "anthropic",
+          model: "claude-3",
+          providers: [
+            { slug: "anthropic", name: "Anthropic", total_models: 1, models: ["claude-3"] },
+            { slug: "custom", name: "Custom Probe", total_models: 1, models: ["custom-1"] },
+          ],
+        } : {
+          provider: "anthropic",
+          model: "claude-3",
+          providers: [
+            { slug: "anthropic", name: "Anthropic", total_models: 1, models: ["claude-3"] },
+          ],
+        },
+      },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+    expect(t.frame()).not.toContain("Custom Probe")
+
+    act(() => t.keys.pressKey("r")); await t.settle()
+    await until(t, () => t.frame().includes("Custom Probe"))
+
+    expect(t.gw.calls.filter(c => c.method === "model.options").map(c => c.params)).toEqual([
+      {},
+      { refresh: true },
+    ])
+    expect(t.frame()).toContain("custom-provider")
+    t.destroy()
+  })
+
   test("session-scoped by default → config.set sends combined arg with session_id; Tab toggles global", async () => {
     const sets: Array<Record<string, unknown>> = []
     const t = await mountNode(<Open />, {
@@ -158,6 +203,53 @@ describe("model-picker", () => {
     await until(t, () => t.frame().includes("claude-opus"))
 
     expect(saves).toEqual([{ slug: "anthropic", api_key: "sk-test" }])
+    expect(t.frame()).toContain("Switch Model (Anthropic)")
+    t.destroy()
+  })
+
+  test("api-key setup fallback refreshes catalog before missing-provider warning", async () => {
+    const t = await mountNode(<Open />, {
+      handlers: {
+        "model.options": p => p.refresh ? {
+          providers: [
+            { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
+            {
+              slug: "anthropic",
+              name: "Anthropic",
+              authenticated: true,
+              total_models: 1,
+              models: ["claude-opus"],
+            },
+          ],
+        } : {
+          providers: [
+            { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
+            {
+              slug: "anthropic",
+              name: "Anthropic",
+              total_models: 0,
+              models: [],
+              authenticated: false,
+              auth_type: "api_key",
+              key_env: "ANTHROPIC_API_KEY",
+            },
+          ],
+        },
+        "model.save_key": () => ({}),
+      },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+    act(() => t.keys.pressArrow("down")); await t.settle()
+    act(() => t.keys.pressEnter()); await t.settle()
+    await until(t, () => t.frame().includes("Paste ANTHROPIC_API_KEY"))
+    await act(async () => { await t.keys.typeText("sk-test") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("claude-opus"))
+
+    expect(t.gw.calls.filter(c => c.method === "model.options").map(c => c.params)).toEqual([
+      {},
+      { refresh: true },
+    ])
     expect(t.frame()).toContain("Switch Model (Anthropic)")
     t.destroy()
   })


### PR DESCRIPTION
## Summary
- Refreshes the model picker catalog only when the user invokes the list refresh key, allowing upstream `model.options` to perform explicit provider probes behind `refresh: true`.
- Preserves the initial picker load as a no-probe `model.options` request with no params.
- Adds model-picker feedback for explicit refresh so users know custom-provider probes can be slower.
- Updates the API-key save fallback path to request `model.options` with `refresh: true` when `model.save_key` does not return a provider.

## Behavior notes
- Initial open still reads cached/known model options without forcing provider probes.
- `list.refresh` now calls `model.options` with `{ refresh: true }` and updates the provider list from the refreshed response.
- Saving an API key still prefers the provider returned by `model.save_key`; only the missing-provider fallback performs a refresh probe.

## Verification
- `PATH=/home/kaio/.bun/bin:$PATH bunx tsc --noEmit` — passed
- `PATH=/home/kaio/.bun/bin:$PATH bun test test/model-picker.test.tsx` — 12 pass, 0 fail
- `PATH=/home/kaio/.bun/bin:$PATH bun run test` — 1357 pass, 0 fail
- `PATH=/home/kaio/.bun/bin:$PATH bun run build` — passed after installing dependencies with `bun install --frozen-lockfile` in the isolated worktree
