### PR TITLE
feat: refresh model picker options

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -291,6 +291,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
         }
         case "model":
           if (!arg) { openModelPicker(dialog, gw); return }
+          if (arg.trim() === "--refresh") { openModelPicker(dialog, gw, { refresh: true }); return }
           gw.request<{ value?: string; warning?: string }>("config.set",
             { key: "model", value: arg })
             .then(r => {

--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -7,11 +7,13 @@
 // than a provider/model pair.
 
 import { useEffect, useState, useCallback } from "react"
+import type { ParsedKey } from "@opentui/core"
 import { useDialog } from "../ui/dialog"
 import { DialogSelect, type SelectOption } from "../ui/dialog-select"
 import { SecretPrompt } from "./secret-prompt"
 import { useTheme } from "../theme"
 import { useToast } from "../ui/toast"
+import { useKeys } from "../keys/context"
 import type { Gateway } from "../context/gateway"
 import type { ConfigSetResponse, ModelOptionProvider, ModelOptionsResponse } from "../context/wire"
 
@@ -23,6 +25,7 @@ type Props = {
    *  set, the scope toggle is hidden and the caller owns the write. */
   onApply?: (provider: string, model: string) => Promise<void>
   title?: string
+  refresh?: boolean
 }
 
 type SaveKeyResponse = {
@@ -60,6 +63,7 @@ const replaceProvider = (
 const ModelPickerDialog = (props: Props) => {
   const dialog = useDialog()
   const toast = useToast()
+  const keys = useKeys()
   const theme = useTheme().theme
   const [data, setData] = useState<ModelOptionsResponse | null>(null)
   const [step, setStep] = useState<Step>("provider")
@@ -67,11 +71,20 @@ const ModelPickerDialog = (props: Props) => {
   const [setupProvider, setSetupProvider] = useState<ModelOptionProvider | null>(null)
   const [global, setGlobal] = useState(false)
 
-  const refresh = useCallback(() => props.gw.request<ModelOptionsResponse>("model.options")
-    .then(setData)
-    .catch(() => setData({ providers: [] })), [props.gw])
+  const refresh = useCallback(async (force = false, quiet = false) => {
+    try {
+      const next = await props.gw.request<ModelOptionsResponse>("model.options", force ? { refresh: true } : undefined)
+      setData(next)
+      if (force && !quiet) toast.show({ variant: "info", message: "Model options refreshed", duration: 1000 })
+      return next
+    } catch (e) {
+      toast.show({ variant: "error", message: e instanceof Error ? e.message : String(e) })
+      setData(d => d ?? { providers: [] })
+      return null
+    }
+  }, [props.gw, toast])
 
-  useEffect(() => { void refresh() }, [refresh])
+  useEffect(() => { void refresh(props.refresh) }, [refresh, props.refresh])
 
   const apply = useCallback((model: string, prov: string) => {
     if (props.onApply) return void props.onApply(prov, model)
@@ -91,8 +104,9 @@ const ModelPickerDialog = (props: Props) => {
     try {
       const r = await props.gw.request<SaveKeyResponse>("model.save_key", { slug: p.slug, api_key: key })
       if (r.warning) toast.show({ variant: "warning", message: r.warning })
-      const next = r.provider ?? (await props.gw.request<ModelOptionsResponse>("model.options"))
-        .providers?.find(pp => pp.slug === p.slug)
+      const opts = await refresh(true, true)
+      const hit = opts?.providers?.find(pp => pp.slug === p.slug)
+      const next = hit && configured(hit) ? hit : r.provider ?? hit
       if (!next) {
         toast.show({ variant: "warning", message: "Provider saved; refresh model options to continue" })
         return
@@ -109,7 +123,7 @@ const ModelPickerDialog = (props: Props) => {
     } catch (e) {
       toast.show({ variant: "error", message: e instanceof Error ? e.message : String(e) })
     }
-  }, [props.gw, toast])
+  }, [props.gw, refresh, toast])
 
   const setup = useCallback((p: ModelOptionProvider) => {
     const msg = setupDescription(p)
@@ -121,21 +135,22 @@ const ModelPickerDialog = (props: Props) => {
     setStep("setup")
   }, [toast])
 
-  const onKey = useCallback((k: { name: string }) => {
+  const onKey = useCallback((k: ParsedKey) => {
+    if (keys.match("list.refresh", k)) { void refresh(true); return true }
     if (k.name === "tab" && !props.onApply) { setGlobal(g => !g); return true }
     if (k.name === "left" && step !== "provider") { setStep("provider"); return true }
     return false
-  }, [step, props.onApply])
+  }, [keys, refresh, step, props.onApply])
 
   const footer = props.onApply
-    ? <text fg={theme.textMuted}>{step === "model" ? "←: providers" : " "}</text>
+    ? <text fg={theme.textMuted}>{`${keys.print("list.refresh")}: refresh${step === "model" ? " · ←: providers" : ""}`}</text>
     : (
       <text fg={theme.textMuted}>
         <span>Scope: </span>
         <span fg={global ? theme.warning : theme.accent}>
           {global ? "global (persists to config)" : "this session"}
         </span>
-        <span> · Tab: toggle{step === "model" ? " · ←: providers" : ""}</span>
+        <span>{` · Tab: toggle · ${keys.print("list.refresh")}: refresh${step === "model" ? " · ←: providers" : ""}`}</span>
       </text>
     )
 
@@ -207,7 +222,7 @@ const ModelPickerDialog = (props: Props) => {
 
 export const openModelPicker = (
   dialog: ReturnType<typeof useDialog>, gw: Gateway,
-  opts?: { title?: string; onApply?: (provider: string, model: string) => Promise<void> },
+  opts?: { title?: string; onApply?: (provider: string, model: string) => Promise<void>; refresh?: boolean },
 ) => {
-  dialog.replace(<ModelPickerDialog gw={gw} title={opts?.title} onApply={opts?.onApply} />)
+  dialog.replace(<ModelPickerDialog gw={gw} title={opts?.title} onApply={opts?.onApply} refresh={opts?.refresh} />)
 }

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -699,6 +699,31 @@ describe("app", () => {
     expect(prefs.get("themeMode")).toBe("dark")
   })
 
+  test("/model --refresh opens picker with forced refresh", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/model", "Switch model"]] }),
+      "model.options": () => ({
+        provider: "anthropic",
+        model: "claude-3",
+        providers: [{ slug: "anthropic", name: "Anthropic", is_current: true, total_models: 1, models: ["claude-3"] }],
+      }),
+      "config.set": () => { throw new Error("unexpected config.set") },
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+
+    await act(async () => { await t.keys.typeText("/model --refresh") })
+    act(() => t.keys.pressEscape())
+    await t.settle()
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Switch Provider"))
+
+    expect(t.gw.last("model.options")?.params).toMatchObject({ refresh: true })
+    expect(t.gw.last("config.set")).toBeUndefined()
+    expect(t.gw.last("prompt.submit")).toBeUndefined()
+    t.destroy()
+  })
+
   test("/branch activates the live branch session id", async () => {
     const gw = new MockGateway({
       "commands.catalog": () => ({ pairs: [["/branch", "Branch current session"]] }),

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { act } from "react"
-import { mountNode, until } from "./harness"
+import { mountNode, until, MockGateway } from "./harness"
 import { useDialog } from "../src/ui/dialog"
 import { useGateway } from "../src/context/gateway"
 import { openModelPicker } from "../src/dialogs/model-picker"
@@ -11,6 +11,13 @@ const Open = () => {
   const d = useDialog()
   const gw = useGateway()
   useEffect(() => { openModelPicker(d, gw) }, [])
+  return null
+}
+
+const OpenRefresh = () => {
+  const d = useDialog()
+  const gw = useGateway()
+  useEffect(() => { openModelPicker(d, gw, { refresh: true }) }, [])
   return null
 }
 
@@ -31,6 +38,36 @@ const OPTIONS = {
 }
 
 describe("model-picker", () => {
+  test("initial open uses normal options and r refreshes with refresh param", async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const gw = new MockGateway({
+      "model.options": p => { calls.push(p); return OPTIONS },
+    })
+    gw.setSession("sess-abc")
+    const t = await mountNode(<Open />, { gw })
+    await until(t, () => t.frame().includes("Anthropic"))
+
+    expect(calls).toEqual([{ session_id: "sess-abc" }])
+    act(() => t.keys.pressKey("r"))
+    await until(t, () => calls.length === 2)
+    expect(calls[1]).toMatchObject({ session_id: "sess-abc", refresh: true })
+    expect(t.frame()).toContain("Anthropic")
+    t.destroy()
+  })
+
+  test("forced refresh open calls model.options with refresh param", async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const t = await mountNode(<OpenRefresh />, {
+      handlers: {
+        "model.options": p => { calls.push(p); return OPTIONS },
+      },
+    })
+    await until(t, () => t.frame().includes("Anthropic"))
+
+    expect(calls).toEqual([{ refresh: true }])
+    t.destroy()
+  })
+
   test("session-scoped by default → config.set sends combined arg with session_id; Tab toggles global", async () => {
     const sets: Array<Record<string, unknown>> = []
     const t = await mountNode(<Open />, {


### PR DESCRIPTION
## Summary
- Add a forced-refresh option for the Herm model picker that calls model.options with refresh: true on initial open.
- Wire the picker's list refresh key to refetch model options with refresh: true while preserving the normal non-refresh open path.
- Route /model --refresh to the picker instead of config.set and refresh model options after saving provider keys.

## Verification
- bun test test/model-picker.test.tsx test/app.test.tsx
- bun run test
- bunx tsc --noEmit
- bun run build