### PR TITLE
fix: preserve setup providers in model picker

### DIFF
--- a/src/dialogs/model-picker.tsx
+++ b/src/dialogs/model-picker.tsx
@@ -32,6 +32,8 @@ type SaveKeyResponse = {
 
 const configured = (p: ModelOptionProvider) => (p.models?.length ?? 0) > 0
 
+const params = { include_unconfigured: true }
+
 const setupDescription = (p: ModelOptionProvider): string | undefined => {
   if (p.warning) return p.warning
   if (p.auth_type === "api_key" && p.key_env) return `paste ${p.key_env} to activate`
@@ -67,7 +69,7 @@ const ModelPickerDialog = (props: Props) => {
   const [setupProvider, setSetupProvider] = useState<ModelOptionProvider | null>(null)
   const [global, setGlobal] = useState(false)
 
-  const refresh = useCallback(() => props.gw.request<ModelOptionsResponse>("model.options")
+  const refresh = useCallback(() => props.gw.request<ModelOptionsResponse>("model.options", params)
     .then(setData)
     .catch(() => setData({ providers: [] })), [props.gw])
 
@@ -91,7 +93,7 @@ const ModelPickerDialog = (props: Props) => {
     try {
       const r = await props.gw.request<SaveKeyResponse>("model.save_key", { slug: p.slug, api_key: key })
       if (r.warning) toast.show({ variant: "warning", message: r.warning })
-      const next = r.provider ?? (await props.gw.request<ModelOptionsResponse>("model.options"))
+      const next = r.provider ?? (await props.gw.request<ModelOptionsResponse>("model.options", params))
         .providers?.find(pp => pp.slug === p.slug)
       if (!next) {
         toast.show({ variant: "warning", message: "Provider saved; refresh model options to continue" })

--- a/test/model-picker.test.tsx
+++ b/test/model-picker.test.tsx
@@ -85,12 +85,12 @@ describe("model-picker", () => {
   test("unauthenticated provider rows show setup metadata and do not advance to empty models", async () => {
     const t = await mountNode(<Open />, {
       handlers: {
-        "model.options": () => ({
+        "model.options": p => ({
           provider: "openai",
           model: "gpt-4",
           providers: [
             { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
-            {
+            p.include_unconfigured === true ? {
               slug: "anthropic",
               name: "Anthropic",
               total_models: 0,
@@ -99,12 +99,13 @@ describe("model-picker", () => {
               auth_type: "api_key",
               key_env: "ANTHROPIC_API_KEY",
               warning: "paste ANTHROPIC_API_KEY to activate",
-            },
-          ],
+            } : undefined,
+          ].filter(p => p !== undefined),
         }),
       },
     })
     await until(t, () => t.frame().includes("Anthropic"))
+    expect(t.gw.last("model.options")?.params).toEqual({ include_unconfigured: true })
     expect(t.frame()).toContain("Setup required")
     expect(t.frame()).toContain("paste ANTHROPIC_API_KEY to activate")
     expect(t.frame()).toContain("auth_type=")
@@ -118,12 +119,13 @@ describe("model-picker", () => {
 
   test("api-key setup calls model.save_key and advances to refreshed models", async () => {
     const saves: Array<Record<string, unknown>> = []
+    let calls = 0
     const t = await mountNode(<Open />, {
       handlers: {
-        "model.options": () => ({
+        "model.options": p => ({
           providers: [
             { slug: "openai", name: "OpenAI", total_models: 1, models: ["gpt-4"] },
-            {
+            calls++ === 0 ? {
               slug: "anthropic",
               name: "Anthropic",
               total_models: 0,
@@ -132,20 +134,18 @@ describe("model-picker", () => {
               auth_type: "api_key",
               key_env: "ANTHROPIC_API_KEY",
               warning: "paste ANTHROPIC_API_KEY to activate",
-            },
-          ],
-        }),
-        "model.save_key": (p) => {
-          saves.push(p)
-          return {
-            provider: {
+            } : p.include_unconfigured === true ? {
               slug: "anthropic",
               name: "Anthropic",
               authenticated: true,
               total_models: 1,
               models: ["claude-opus"],
-            },
-          }
+            } : undefined,
+          ],
+        }),
+        "model.save_key": (p) => {
+          saves.push(p)
+          return {}
         },
       },
     })
@@ -158,6 +158,8 @@ describe("model-picker", () => {
     await until(t, () => t.frame().includes("claude-opus"))
 
     expect(saves).toEqual([{ slug: "anthropic", api_key: "sk-test" }])
+    expect(t.gw.calls.filter(c => c.method === "model.options").map(c => c.params))
+      .toEqual([{ include_unconfigured: true }, { include_unconfigured: true }])
     expect(t.frame()).toContain("Switch Model (Anthropic)")
     t.destroy()
   })


### PR DESCRIPTION
## Summary
- Requests model.options with include_unconfigured=true from the model picker initial load and post-save refresh path.
- Keeps unauthenticated api_key providers visible with setup hints so they can enter the model.save_key flow.
- Extends model-picker headless tests to assert include_unconfigured params, setup metadata visibility, save-key flow, and existing provider/model selection behavior.

## Test Plan
- bun test test/model-picker.test.tsx
- bunx tsc --noEmit
- bun run build

## Caveats
- Full bun run test currently has a pre-existing unrelated failure in test/app.test.tsx: /usage opens KV dialog populated from session.usage, where the frame includes branch wt/t_8123dfcc and trips expect(f).not.toContain("123").