### PR TITLE
feat: show install warning in status dialog

### DIFF
--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -199,6 +199,7 @@ export type SessionInfo = {
   context_max?: number
   context_used?: number
   credential_warning?: string
+  install_warning?: string
   yolo?: boolean
   mcp_servers?: McpServer[]
   /** hermes-agent version string (e.g. "1.14.2-dev+abc123") */

--- a/src/dialogs/info.tsx
+++ b/src/dialogs/info.tsx
@@ -15,12 +15,15 @@ import { hermesPath } from "../service/hermes-home"
 
 type Row = [string, string | undefined, RGBA?]
 
-const InfoDialog = (props: { title: string; rows: Row[]; lines?: string[]; note?: string }) => {
+const InfoDialog = (props: { title: string; rows: Row[]; lines?: string[]; note?: string; warning?: string }) => {
   const theme = useTheme().theme
   const body = props.rows.filter(r => r[1] !== undefined)
   return (
     <box flexDirection="column" minWidth={52} gap={1}>
       <box height={1}><text fg={theme.primary}><strong>{props.title}</strong></text></box>
+      {props.warning
+        ? <box minHeight={1}><text wrapMode="word" fg={theme.warning}>{props.warning}</text></box>
+        : null}
       {props.lines?.length
         ? <box flexDirection="column">
             {props.lines.map((line, i) => (
@@ -53,7 +56,7 @@ export function openStatus(dialog: DialogContext, info: SessionInfo | null, sid:
       ["Tools",    `${nTools} in ${toolsets.length} toolset${toolsets.length === 1 ? "" : "s"}`],
       ["Skills",   String(Object.values(info?.skills ?? {}).reduce((n, v) => n + v.length, 0))],
       ["MCP",      mcp.length ? `${up}/${mcp.length} connected` : undefined],
-    ]} />,
+    ]} warning={info?.install_warning} />,
   )
 }
 

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1170,6 +1170,8 @@ describe("app", () => {
       payload: {
         model: "test-model", session_id: "sid-abc", version: "9.9.9",
         cwd: "/workspace", tools: { web: ["a", "b"], file: ["c"] }, skills: {},
+        credential_warning: "credential warning stays transient",
+        install_warning: "Herm CLI is not on PATH",
       },
     }))
     await until(t, () => t.frame().includes("Ready"))
@@ -1187,6 +1189,8 @@ describe("app", () => {
     expect(f).toContain("sid-abc")
     expect(f).toContain("/workspace")
     expect(f).toContain("3 in 2 toolsets")
+    expect(f).toContain("Herm CLI is not on PATH")
+    expect(f).not.toContain("credential warning stays transient")
     t.destroy()
   })
 


### PR DESCRIPTION
Summary:
- Adds install_warning to the SessionInfo wire type.
- Shows upstream install_warning in the /status dialog with warning styling.
- Covers /status with a mocked session.info payload containing both install_warning and credential_warning.

Test plan:
- bun test test/app.test.tsx -t '/status dialog reads from cached SessionInfo'
- bun test test/gatewayEvents.test.ts test/app.test.tsx -t 'credential_warning|/status dialog reads from cached SessionInfo'
- bunx tsc --noEmit