### PR TITLE
fix: route compact through session compression

### DIFF
--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -259,7 +259,9 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
         case "branch":
           branch(arg)
           return
-        case "compress": void runCompress(); return
+        case "compress":
+        case "compact":
+          void runCompress(); return
         case "undo":
           destructive(arg,
             { title: "Undo last turn?", body: "Pops the last user + assistant pair from the transcript. /redo in this session to restore.", yes: "undo" },
@@ -430,10 +432,9 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             .catch((e: Error) => toast.show({ variant: "error", message: `browser: ${e.message}` }))
           return
         }
-        case "compact":
         case "setup":
           x.dispatch({ kind: "system",
-            text: `/${c.name} is an Ink-TUI command and has no effect in herm` })
+            text: "/setup is an Ink-TUI command and has no effect in herm" })
           return
         case "steer": {
           const fire = (text: string) =>

--- a/src/app/slashCommands.ts
+++ b/src/app/slashCommands.ts
@@ -40,7 +40,7 @@ export const LOCAL_NAMES = new Set([
   "resume", "branch", "compress", "undo", "redo", "retry", "model", "yolo", "quit",
   "copy", "paste", "image", "background", "voice", "mouse", "redraw", "queue",
   "stash",
-  // Ink-only UI toggles — local no-op with a note
+  // /compact aliases live session compression; /setup stays an Ink-only no-op.
   "compact", "setup",
   // browser: use browser.manage RPC, not slash.exec (issue #82)
   "browser",
@@ -79,6 +79,7 @@ export const LOCAL_COMMANDS: ReadonlyArray<SlashCommand> = [
   { name: "stash",  description: "Park the prompt (pop/list to restore)", category: "Client",  aliases: [], argsHint: "[pop|list]", subcommands: ["pop", "list"], source: "local", target: "local" },
   { name: "redo",   description: "Re-send the last undone message",       category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "branch", description: "Fork current conversation",              category: "Session", aliases: ["fork"], argsHint: "[name]", subcommands: [], source: "local", target: "local" },
+  { name: "compact", description: "Compress session context",              category: "Session", aliases: [], argsHint: "", subcommands: [], source: "local", target: "local" },
   { name: "browser", description: "Connect/disconnect a CDP browser",      category: "Session", aliases: [], argsHint: "[connect|disconnect|status] [url]", subcommands: ["connect", "disconnect", "status"], source: "local", target: "local" },
 ]
 

--- a/test/compress.test.tsx
+++ b/test/compress.test.tsx
@@ -39,8 +39,8 @@ const mkGw = () => new MockGateway({
   }),
 })
 
-const run = async (t: Awaited<ReturnType<typeof mount>>) => {
-  await act(async () => { await t.keys.typeText("/compress") })
+const run = async (t: Awaited<ReturnType<typeof mount>>, cmd = "compress") => {
+  await act(async () => { await t.keys.typeText(`/${cmd}`) })
   act(() => t.keys.pressEnter())
 }
 
@@ -108,6 +108,22 @@ describe("/compress", () => {
     // Messages untouched (no `messages` field in response) — original
     // turns still visible.
     expect(t.frame()).toContain("draft the rfc")
+
+    t.destroy()
+  })
+
+  test("/compact uses the same session compression path", async () => {
+    const gw = mkGw()
+    const t = await mount({ gw, launch: { mode: "resume", sid: "pre-sid", splash: false } })
+    await until(t, () => t.frame().includes("draft the rfc"))
+
+    await run(t, "compact")
+
+    await until(t, () => t.frame().includes("Compacted 4→3 messages"))
+    expect(gw.last("session.compress")).toBeDefined()
+    expect(t.frame()).toContain("8.0k → 2.5k")
+    expect(t.frame()).toContain("draft the rfc")
+    expect(t.frame()).not.toContain("has no effect in herm")
 
     t.destroy()
   })


### PR DESCRIPTION
## Summary
- Route local /compact through the same runCompress() path as /compress.
- Add /compact to local command fallback copy as session compression instead of an Ink-only no-op.
- Cover /compact in the existing compression slash-handler test.

## Test Plan
- bun test test/compress.test.tsx test/slash.test.ts
- bunx tsc --noEmit

## Risks
- Low: /setup remains the only local Ink-TUI no-op in this handler.