### PR TITLE
fix: break session.title ↔ session.info feedback loop causing 96% CPU

### DIFF
--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -135,12 +135,15 @@ export function useStream(c: Ctx) {
         x.setReady(true)
         if (si.session_id) x.setSid(si.session_id)
         x.settle()
+        // Use title from session.info directly — avoids a redundant
+        // session.title RPC that would re-emit session.info and create
+        // a feedback loop (config.get ↔ session.title ↔ session.info).
+        if (si.title !== undefined) x.setTitle(si.title)
         const bad = (si.mcp_servers ?? []).filter(s => !s.connected)
         if (bad.length) x.dispatch({
           kind: "system",
           text: `MCP: ${bad.length} server(s) failed to connect — ${bad.map(s => s.name + (s.error ? ` (${s.error})` : "")).join(", ")}`,
         })
-        sync()
         gw.request<{ value?: string }>("config.get", { key: "busy" }).then(r => {
           const m = r.value
           if (m === "queue" || m === "steer" || m === "interrupt") x.setBusy(m)

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -207,6 +207,8 @@ export type SessionInfo = {
   update_behind?: number | null
   /** platform-appropriate update invocation */
   update_command?: string
+  /** Live session title from gateway (avoids redundant session.title RPC) */
+  title?: string
 }
 
 export type SessionCreateResponse = {


### PR DESCRIPTION
## Problem

When launching `herm`, the Python gateway (`tui_gateway.entry`) consumes ~96% CPU constantly, even at idle.

## Root Cause

A feedback loop between the TUI frontend and the gateway:

1. Gateway sends `session.info` event
2. TUI `onSessionInfo` handler calls `sync()` → `session.title` RPC
3. Gateway `session.title` handler ALWAYS re-emits `session.info` (server.py L6190/L6204/L6210/L6232/L6237)
4. → GOTO 1

Result: ~30-38 req/s ping-pong, burning CPU.

The `session.info` payload already includes the `title` field, so the `sync()` call is completely redundant.

## Fix

Two files changed:

1. **`src/context/wire.ts`**: Added `title?: string` to `SessionInfo` type (the gateway already sends it, but the type was missing it)
2. **`src/app/useStream.ts`**: Removed the redundant `sync()` call from `onSessionInfo`, using `si.title` directly instead

## Results

| Metric | Before | After |
|--------|--------|-------|
| Python gateway CPU | 96% | ~5% |
| Bun TUI CPU | 10% | ~1% |
| Total | 106% | ~6% |
| Gateway wchan | 0 (spin) | unix_stream_data_wait (blocked) |

Diagnosed by: **Guy Bot 3000** (Hermes Agent)  
Co-debugged with: **zaze-oO**