### PR TITLE
fix(chat): stop streamed markdown source flicker

### DIFF
--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -65,6 +65,8 @@ const BOTTOM_RULE = {
   topT: "", bottomT: "", leftT: "", rightT: "", cross: "",
 }
 
+const TABLE = { style: "grid" as const }
+
 // OpenTUI has no onClick; synthesize one from down→up at the same cell
 // so text-selection drags don't fire it.
 function useClick(fn?: () => void) {
@@ -232,7 +234,8 @@ const AssistantMessage = memo(({ message, streaming, prompt, onPick }: {
       return (
         <box key={`${k}-${j}`}>
           <markdown content={mathify(s.md)} fg={theme.markdownText}
-            syntaxStyle={ctx.syntaxStyle} streaming={tail} />
+            syntaxStyle={ctx.syntaxStyle} streaming={tail}
+            internalBlockMode="top-level" tableOptions={TABLE} />
         </box>
       )
     })

--- a/test/messagelist.test.tsx
+++ b/test/messagelist.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
+import { TestRecorder } from "@opentui/core/testing"
 import { mountNode, until, type Harness } from "./harness"
 import { turnReducer, initialTurn, type Action } from "../src/app/turnReducer"
 import { MessageList } from "../src/components/chat/MessageList"
@@ -42,6 +43,23 @@ function reduce(actions: Action[]) {
   return actions.reduce(turnReducer, initialTurn)
 }
 
+const SOURCE = "# Heading\n\nThis is **bold** and `code`."
+let stream!: (content: string) => void
+
+function StreamProbe() {
+  const [content, set] = useState(SOURCE)
+  stream = set
+  const message: Message = {
+    id: "stream-probe", role: "assistant", timestamp: 0,
+    parts: [{ type: "text", key: "stream-part", content, streaming: true }],
+  }
+  return (
+    <box flexDirection="column" width="100%" height="100%">
+      <MessageList messages={[message]} streaming />
+    </box>
+  )
+}
+
 describe("message transcript contracts", () => {
   test("markdown images route to media without interpreting fenced examples", () => {
     expect(splitContent([
@@ -55,6 +73,22 @@ describe("message transcript contracts", () => {
       { md: " after" },
       { code: "![literal](/tmp/owl.png)", lang: "md" },
     ])
+  })
+
+  test("streamed assistant headings never expose source markers between highlight passes", async () => {
+    await using t = await mountNode(<StreamProbe />, { width: 80, height: 16 })
+    const recorder = new TestRecorder(t.renderer)
+    recorder.rec()
+
+    for (const suffix of [" stream-one", " stream-two", " stream-three", " stream-four"]) {
+      act(() => stream(SOURCE + suffix))
+      await until(t, () => t.frame().includes(suffix.trim()) && !t.frame().includes("# Heading"))
+    }
+    recorder.stop()
+
+    const frames = recorder.recordedFrames.map(frame => frame.frame)
+    expect(frames.length).toBeGreaterThan(0)
+    expect(frames.some(frame => frame.includes("# Heading"))).toBe(false)
   })
 
   test("trim-equivalent completion cannot duplicate or reorder streamed parts", () => {


### PR DESCRIPTION
## Summary

OpenTUI 0.4.3 could repaint streamed assistant Markdown through a source-like fallback between asynchronous highlighting passes, causing headings to alternate between `# Heading` and rendered `Heading`.

Assistant chat now keeps Markdown in top-level block mode throughout streaming and completion, so headings and lists remain structurally rendered while Tree-sitter catches up. Grid table styling remains explicit and stable instead of adopting top-level mode's borderless default.

## Screenshots

**Before:** the pending-highlight frame exposes the raw heading marker.

![Before: raw Markdown heading marker during streaming](https://files.catbox.moe/rbfbvy.png)

**After:** the same pending-highlight frame keeps the heading rendered.

![After: rendered Markdown heading during streaming](https://files.catbox.moe/5i4i96.png)

## Safety

- Limits the change to assistant Markdown rendering.
- Leaves fenced code blocks, media routing, tool rows, and message ordering unchanged.
- Preserves the existing grid table presentation with a stable options object.

## Verification

- `bun test test/messagelist.test.tsx`
- Recorded-frame streaming check repeated 20 times
- `bun run test:check:changed dev`
- `bunx tsc --noEmit`
- `bun test`: 1,367 passed, 0 failed
- `bun test --randomize --seed=230714`: 1,367 passed, 0 failed
- `bun run build`
