### PR TITLE
feat: show activity in terminal title

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -41,6 +41,7 @@ import { turnReducer, initialTurn } from "./app/turnReducer"
 import { useSession } from "./app/useSession"
 import { SkinProvider, deriveSkin, type SkinState } from "./context/skin"
 import { useAppKeys } from "./app/useAppKeys"
+import { useTerminalTitle } from "./app/useTerminalTitle"
 import { quit } from "./app/exit"
 import { Stash } from "./app/stash"
 import { TABS, CHAT_TAB, SESSIONS_TAB, AUTOMATION_TAB, CONFIG_TAB, EIKON_TAB, SUB_TABS } from "./app/tabs"
@@ -254,6 +255,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setTimeout(() => sendRef.current(text), 0)
     })
   }, [])
+
+  useTerminalTitle(active, info?.cwd)
 
   // Transient error pulse — set on any reducer {kind:"error"} or
   // gateway exit; cleared when the avatar's play-once error clip

--- a/src/app/control.ts
+++ b/src/app/control.ts
@@ -455,6 +455,8 @@ async function handle(req: Request): Promise<Response> {
   // GET /quit — clean exit so a recording PTY sees EOF. Macrotask so the
   // 200 flushes before the process dies.
   if (path === "/quit") {
+    const renderer = bridge.renderer() as { setTerminalTitle?: (title: string) => void } | null
+    try { renderer?.setTerminalTitle?.("") } catch {}
     setTimeout(() => process.exit(0), 10)
     return json({ ok: true })
   }

--- a/src/app/exit.ts
+++ b/src/app/exit.ts
@@ -8,15 +8,14 @@
 // mode-reset blob synchronously on process.exit().
 //
 // Parity: opencode context/exit.tsx — minus onBeforeExit/onExit (no
-// plugin runtime), setTerminalTitle (herm never sets it), and the
-// win32 input-buffer flush (tracked as a bead).
+// plugin runtime) and the win32 input-buffer flush (tracked as a bead).
 
 import { writeSync } from "node:fs"
 
 let done = false
 
 export function quit(
-  renderer: { destroy: () => void },
+  renderer: { destroy: () => void; setTerminalTitle: (t: string) => void },
   sid?: string,
   title?: string,
   gw?: { kill: () => void },
@@ -29,6 +28,7 @@ export function quit(
   // the explicit signal starts cleanup sooner and matches Ink TUI's
   // setupGracefulExit cleanup.
   try { gw?.kill() } catch {}
+  try { renderer.setTerminalTitle("") } catch {}
   renderer.destroy()
   if (process.stdout.isTTY) {
     const banner = sid

--- a/src/app/useTerminalTitle.ts
+++ b/src/app/useTerminalTitle.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react"
+import { useRenderer } from "@opentui/react"
+
+export function useTerminalTitle(active: boolean, cwd?: string) {
+  const renderer = useRenderer()
+  useEffect(() => {
+    const title = active ? "● Herm" : "Herm"
+    const name = cwd?.split(/[\\/]/).filter(Boolean).at(-1)
+    renderer.setTerminalTitle(name ? `${title} · ${name}` : title)
+  }, [renderer, active, cwd])
+}

--- a/test/control.test.ts
+++ b/test/control.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import { internals, isDangerous, isLoopback, setBridge, warningFor } from "../src/app/control"
 import { TABS } from "../src/app/tabs"
 
@@ -188,4 +188,28 @@ test("POST /send returns the bridge failure", async () => {
   }))
   expect(response.status).toBe(502)
   expect(await response.json()).toEqual({ error: "submit unavailable" })
+})
+
+test("GET /quit clears the terminal title before scheduling exit", async () => {
+  const calls: string[] = []
+  setBridge({
+    tab: () => 0, setTab: () => {}, send: async () => {},
+    ready: () => true, streaming: () => false, messages: () => 0,
+    session: () => "sid", input: () => "", setInput: () => {},
+    focusRegion: () => "input", setFocusRegion: () => {},
+    renderer: () => ({ setTerminalTitle: (title: string) => calls.push(`title:${title}`) }),
+    logs: () => "", plugin: async () => true, push: () => {},
+  })
+  const timer = spyOn(globalThis, "setTimeout").mockImplementation(((_fn: TimerHandler, ms?: number) => {
+    calls.push(`timer:${ms}`)
+    return 0 as unknown as ReturnType<typeof setTimeout>
+  }) as unknown as typeof setTimeout)
+
+  try {
+    const response = await internals.handle(new Request("http://localhost/quit"))
+    expect(response.status).toBe(200)
+    expect(calls).toEqual(["title:", "timer:10"])
+  } finally {
+    timer.mockRestore()
+  }
 })

--- a/test/exit.test.ts
+++ b/test/exit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, spyOn } from "bun:test"
+import * as exit from "../src/app/exit"
+
+describe("quit()", () => {
+  it("kills gateway, resets title, destroys renderer in order before exit", () => {
+    const steps: string[] = []
+    const gw = { kill: () => steps.push("kill") }
+    const renderer = {
+      destroy: () => steps.push("destroy"),
+      setTerminalTitle: (t: string) => {
+        expect(t).toBe("")
+        steps.push("title")
+      },
+    }
+
+    const stop = spyOn(process, "exit").mockImplementation((() => {
+      steps.push("exit")
+      throw new Error("process.exit")
+    }) as typeof process.exit)
+
+    try {
+      expect(() => exit.quit(renderer, undefined, undefined, gw)).toThrow("process.exit")
+      expect(steps).toEqual(["kill", "title", "destroy", "exit"])
+    } finally {
+      stop.mockRestore()
+    }
+  })
+})

--- a/test/terminal-title.test.tsx
+++ b/test/terminal-title.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { mount } from "./harness"
+
+describe("terminal title", () => {
+  it("updates title on active/idle transitions and cwd changes including Windows paths", async () => {
+    await using t = await mount()
+    const calls: string[] = []
+    t.renderer.setTerminalTitle = (title: string) => calls.push(title)
+
+    act(() => t.gw.push({ type: "session.info", payload: { model: "test", session_id: "test-sid", cwd: "/home/user/project", tools: {}, skills: {} } }))
+    await t.settle()
+
+    act(() => t.gw.push({ type: "message.start" }))
+    await t.settle()
+
+    act(() => t.gw.push({ type: "session.info", payload: { model: "test", session_id: "test-sid", cwd: "C:\\Users\\foo\\bar", tools: {}, skills: {} } }))
+    await t.settle()
+
+    act(() => t.gw.push({ type: "message.complete", payload: { text: "done" } }))
+    await t.settle()
+
+    act(() => t.gw.push({ type: "session.info", payload: { model: "test", session_id: "test-sid", tools: {}, skills: {} } }))
+    await t.settle()
+
+    act(() => t.gw.push({ type: "message.start" }))
+    await t.settle()
+
+    expect(calls).toEqual([
+      "Herm · project",
+      "● Herm · project",
+      "● Herm · bar",
+      "Herm · bar",
+      "Herm",
+      "● Herm",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- show the current session working-directory basename in the terminal title
- prefix the title with `●` while a turn is active
- clear the title on normal and control-server exits

## Testing

All run with Bun 1.3.13:

- `bun run test:check:strict`
- `bunx tsc --noEmit`
- `bun test` (1,362 passed, 8 skipped)
- `bun run build`
- manually verified idle, active, cwd-change, and exit title updates in a real PTY

Closes #42
