### PR TITLE
fix: exit nonzero on fatal boot failure

### DIFF
--- a/src/app/fatal.ts
+++ b/src/app/fatal.ts
@@ -1,0 +1,7 @@
+import { resetTerminalModes } from "../utils/terminal-reset"
+
+export function fatal(err: unknown): never {
+  resetTerminalModes()
+  console.error(err)
+  process.exit(1)
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ import { warmup as warmTokens } from "./utils/tokens";
 import { prime as primeTheme, DEFAULT_THEME } from "./theme";
 import { resolveProfileHome } from "./service/hermes-profiles";
 import { rehome } from "./home/rehome";
+import { fatal } from "./app/fatal";
 
 // Static ESM imports hoist above module-level code, so the only
 // honest import-graph measurement is process-uptime at the point
@@ -124,6 +125,6 @@ const main = async () => {
   control.start()
 };
 
-main().catch(console.error);
+main().catch(fatal);
 
 export {};

--- a/test/boot-fatal.test.ts
+++ b/test/boot-fatal.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { TERMINAL_MODE_RESET } from "../src/utils/terminal-reset"
+
+describe("boot fatal handling", () => {
+  test("exits nonzero after terminal cleanup on early startup failure", async () => {
+    const root = mkdtempSync(join(tmpdir(), "herm-boot-fatal-"))
+    try {
+      const child = Bun.spawn([process.execPath, "-e", `
+        const { fatal } = await import("./src/app/fatal")
+        Object.defineProperty(process.stdout, "isTTY", { value: true })
+        process.stdin.resume()
+        fatal(new Error("boot exploded"))
+      `], {
+        cwd: resolve(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          HERMES_HOME: join(root, "home"),
+          HERM_CONFIG_DIR: join(root, "cfg"),
+          HERMES_AGENT_ROOT: join(root, "agent"),
+          CONTROL: "",
+          PERF: "",
+        },
+      })
+      const [code, out, err] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ])
+
+      expect(code).toBe(1)
+      expect(out).toContain(TERMINAL_MODE_RESET)
+      expect(err).toContain("boot exploded")
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Context
Fatal initialization failures can happen after Herm has already touched terminal modes. Without an explicit fatal boot path, shell automation can misread a failed startup as success and the terminal may not be restored first.

## Summary
- Adds a fatal boot handler that synchronously resets terminal modes before exiting
- Routes async startup rejections through the fatal handler
- Covers the no-renderer early-failure path with a subprocess regression
