### PR TITLE
fix(sessions): make fallback delete transactional

### DIFF
--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -543,11 +543,13 @@ export function rename(sid: string, title: string): boolean {
 export function remove(sid: string): boolean {
   const db = new Database(conn.path)
   try {
-    if (!db.query("SELECT 1 FROM sessions WHERE id = ?").get(sid)) return false
-    db.run("UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id = ?", [sid])
-    db.run("DELETE FROM messages WHERE session_id = ?", [sid])
-    db.run("DELETE FROM sessions WHERE id = ?", [sid])
-    return true
+    return db.transaction((id: string) => {
+      if (!db.query("SELECT 1 FROM sessions WHERE id = ?").get(id)) return false
+      db.run("UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id = ?", [id])
+      db.run("DELETE FROM messages WHERE session_id = ?", [id])
+      db.run("DELETE FROM sessions WHERE id = ?", [id])
+      return true
+    })(sid)
   } finally { db.close() }
 }
 

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -59,6 +59,11 @@ const badge = (s: string): string => s
 
 const label = (r: Row) => r.title.trim() || (r.live ? "-" : "Untitled")
 const src = (r: Row): string => r.detail?.sessionSource || r.source || ""
+const fallback = (msg: string): boolean => {
+  const s = msg.trim()
+  if (/\b(?:timeout|timed out)\b/i.test(s)) return false
+  return /^(method not found|unknown method(?::|\b)|gateway not running\b|gateway exited(?:\s*\(|$))/i.test(s)
+}
 
 type View = {
   id: string
@@ -888,7 +893,7 @@ export const Sessions = memo((props: Props) => {
             toast.show({ variant: "error", message: "Can't delete the active session" })
             return false
           }
-          if (/method not found|unknown method|gateway not running|gateway exited/i.test(e.message))
+          if (fallback(e.message))
             return io.remove(r.id)
           toast.show({ variant: "error", message: e.message })
           return false

--- a/test/hermes-home-sessions.test.ts
+++ b/test/hermes-home-sessions.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterAll } from "bun:test"
 import { openStateDb } from "./fixtures/state-db"
 import { searchSessions, queryRecentSessions, querySubagents, queryLineage } from "../src/service/hermes-home"
-import { kind, resetDb, peek, lastReal, chainTip } from "../src/service/sessions-db"
+import { kind, resetDb, peek, lastReal, chainTip, remove } from "../src/service/sessions-db"
 
 // Seeds a clean state.db and exercises the real SQL paths in
 // sessions-db.ts via the hermes-home re-exports.
@@ -67,6 +67,40 @@ const msg = (
   db.prepare("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?,?,?,?)")
     .run(sid, role, content, ts)
 }
+
+describe("remove", () => {
+  afterAll(wipe)
+
+  test("keeps parent, child, and messages when fallback deletion faults after orphaning", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1700000000)
+    sess(db, "child", "tui", 1700000001, { parent_session_id: "root" })
+    msg(db, "root", "user", "parent content")
+    db.run(`CREATE TRIGGER stab_remove_fault
+      BEFORE DELETE ON messages WHEN old.session_id = 'root'
+      BEGIN SELECT RAISE(FAIL, 'fault delete message'); END`)
+    db.close()
+
+    expect(() => remove("root")).toThrow("fault delete message")
+
+    const check = openStateDb()
+    try {
+      const rows = check.query("SELECT id, parent_session_id FROM sessions ORDER BY id").all() as Array<{
+        id: string
+        parent_session_id: string | null
+      }>
+      const count = check.query("SELECT COUNT(*) AS c FROM messages WHERE session_id = 'root'").get() as { c: number }
+      expect(rows).toEqual([
+        { id: "child", parent_session_id: "root" },
+        { id: "root", parent_session_id: null },
+      ])
+      expect(count.c).toBe(1)
+    } finally {
+      check.run("DROP TRIGGER IF EXISTS stab_remove_fault")
+      check.close()
+    }
+  })
+})
 
 describe("searchSessions (gsk.12: all sources, not just tui/cli)", () => {
   beforeEach(() => {

--- a/test/sessions.test.tsx
+++ b/test/sessions.test.tsx
@@ -577,6 +577,44 @@ describe("Sessions tab", () => {
     t.destroy()
   })
 
+  test("session.delete local gateway process absence falls back to io.remove", async () => {
+    const deleted: string[] = []
+    let listed = ROWS
+    const gw = new MockGateway({
+      "session.list": () => ({ sessions: listed }),
+      "session.delete": () => { throw new Error("gateway not running") },
+    })
+    const remove = (sid: string) => {
+      deleted.push(sid)
+      listed = listed.filter(r => r.id !== sid)
+      return true
+    }
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, remove }} />, { gw })
+    await until(t, () => t.frame().includes("Sessions (2)"))
+    await act(async () => { await t.keys.typeText("d") })
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("Sessions (1)"))
+
+    expect(deleted).toEqual(["sid-a"])
+    t.destroy()
+  })
+
+  test("session.delete remote gateway disconnect does not enter local fallback", async () => {
+    const gw = new MockGateway({
+      "session.list": () => ({ sessions: ROWS }),
+      "session.delete": () => { throw new Error("gateway not connected") },
+    })
+    let local = 0
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, remove: () => (local++, true) }} />, { gw })
+    await until(t, () => t.frame().includes("Sessions (2)"))
+    await act(async () => { await t.keys.typeText("d") })
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("gateway not connected"))
+
+    expect(local).toBe(0)
+    t.destroy()
+  })
+
   test("session.delete safety failure does not fall back to direct deletion", async () => {
     const gw = new MockGateway({
       "session.list": () => ({ sessions: ROWS }),
@@ -605,6 +643,21 @@ describe("Sessions tab", () => {
     await act(async () => { await t.keys.typeText("d") })
     await act(async () => { await t.keys.typeText("y") })
     await until(t, () => t.frame().includes("timeout: session.delete"))
+    expect(local).toBe(0)
+    t.destroy()
+  })
+
+  test("session.delete ambiguous timeout text does not enter local fallback", async () => {
+    const gw = new MockGateway({
+      "session.list": () => ({ sessions: ROWS }),
+      "session.delete": () => { throw new Error("timeout waiting for Method not found response") },
+    })
+    let local = 0
+    const t = await mountNode(<Sessions focused io={{ ...NOIO, remove: () => (local++, true) }} />, { gw })
+    await until(t, () => t.frame().includes("Sessions (2)"))
+    await act(async () => { await t.keys.typeText("d") })
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => t.frame().includes("timeout waiting for Method not found response"))
     expect(local).toBe(0)
     t.destroy()
   })


### PR DESCRIPTION
## Context
Session deletion can fall back to direct local SQLite cleanup when the Hermes gateway does not expose `session.delete` or is not running locally. That fallback must avoid partially deleting related rows if one cleanup step fails.

## Summary
- Wraps fallback session deletion in one SQLite transaction so child orphaning, message deletion, and session deletion commit or roll back together.
- Keeps upstream `session.delete` as the preferred path and narrows fallback use to capability or local process absence cases.
- Adds regression coverage for rollback and fallback classification paths.
