### PR TITLE
fix(queue): clear prompts on session transitions

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -417,6 +417,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     stream.interrupted.current = false
     hold.current = false
     pending.current = false
+    setQueue([])
     toast.clear("credits.depleted")
     undone.current = []
     dispatch({ kind: "reset" })

--- a/test/queued-submit.test.tsx
+++ b/test/queued-submit.test.tsx
@@ -1,9 +1,30 @@
 import { describe, expect, test } from "bun:test"
 import { act } from "react"
 import { mount, until, MockGateway } from "./harness"
+import { tmpHome } from "./fixture/home"
 
 function info() {
   return { model: "test-model", session_id: "test-sid", tools: {}, skills: {} }
+}
+
+const stale = "stale queued prompt"
+
+async function fill(t: Awaited<ReturnType<typeof mount>>) {
+  act(() => t.gw.push({ type: "message.start" }))
+  await until(t, () => t.frame().includes("Type to queue"))
+  await act(async () => { await t.keys.typeText(stale) })
+  act(() => t.keys.pressEnter())
+  await until(t, () => t.frame().includes(`⏸ 1. ${stale}`))
+}
+
+const submitted = (gw: MockGateway) =>
+  gw.calls.filter(c => c.method === "prompt.submit" && c.params.text === stale)
+
+function loc(t: Awaited<ReturnType<typeof mount>>, text: string) {
+  const rows = t.frame().split("\n")
+  const y = rows.findIndex(r => r.includes(text))
+  expect(y).toBeGreaterThan(-1)
+  return { x: rows[y].indexOf(text), y }
 }
 
 describe("queued prompt submit", () => {
@@ -162,6 +183,115 @@ describe("queued prompt submit", () => {
     expect(tries).toBe(2)
     expect(gw.last("prompt.submit")?.params.text).toBe("retry after settle")
     expect(t.frame()).toContain("retry after settle")
+    t.destroy()
+  })
+
+  test("/new clears queued prompts before the replacement session can drain them", async () => {
+    let n = 0
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/new", "new session"]] }),
+      "session.create": () => ({ session_id: `sid-${++n}` }),
+    })
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("Ready"))
+    await fill(t)
+
+    await act(async () => { await t.keys.typeText("/new now") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => n === 2 && t.frame().includes("Ready"))
+    await t.settle()
+
+    expect(submitted(gw)).toHaveLength(0)
+    expect(t.frame()).not.toContain(stale)
+    t.destroy()
+  })
+
+  test("/resume clears queued prompts before the resumed session can drain them", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/resume", "resume session"]] }),
+      "session.resume": p => ({ session_id: p.session_id, messages: [] }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "first", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+    await fill(t)
+
+    await act(async () => { await t.keys.typeText("/resume second") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.last("session.resume")?.params.session_id === "second" && t.frame().includes("Ready"))
+    await t.settle()
+
+    expect(submitted(gw)).toHaveLength(0)
+    expect(t.frame()).not.toContain(stale)
+    await act(async () => { await t.keys.typeText("fresh second") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.last("prompt.submit")?.params.text === "fresh second")
+    expect(gw.last("prompt.submit")?.params.session_id).toBe("second")
+    t.destroy()
+  })
+
+  test("live activation clears queued prompts before the activated session can drain them", async () => {
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/sessions", "sessions"]] }),
+      "session.active_list": () => ({ sessions: [
+        { id: "live-a", title: "Live A", message_count: 1, started_at: 1700000000, status: "idle" },
+      ]}),
+      "session.activate": p => ({
+        session_id: p.session_id,
+        status: "idle",
+        running: false,
+        info: { model: "live-model", session_id: p.session_id, tools: {}, skills: {} },
+        messages: [{ role: "user", text: "live seed" }],
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "resume", sid: "first", splash: false } })
+    await until(t, () => t.frame().includes("Ready"))
+    await fill(t)
+
+    await act(async () => { await t.keys.typeText("/sessions") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Live A"))
+    const live = loc(t, "▸ Live A")
+    await act(async () => { await t.mouse.click(live.x, live.y) })
+    await until(t, () => gw.last("session.activate")?.params.session_id === "live-a" && t.frame().includes("live seed"))
+    await t.settle()
+
+    expect(submitted(gw)).toHaveLength(0)
+    expect(t.frame()).not.toContain(stale)
+    await act(async () => { await t.keys.typeText("fresh live") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.last("prompt.submit")?.params.text === "fresh live")
+    expect(gw.last("prompt.submit")?.params.session_id).toBe("live-a")
+    t.destroy()
+  })
+
+  test("profile switch clears queued prompts before the new profile can drain them", async () => {
+    await using h = await tmpHome({
+      files: {
+        "config.yaml": "model:\n  default: test-model\n  provider: anthropic\n",
+        "profiles/coder/config.yaml": "model:\n  default: coder-model\n  provider: anthropic\n",
+      },
+    })
+    const gw = new MockGateway({
+      "commands.catalog": () => ({ pairs: [["/profiles", "profiles"]] }),
+    })
+    const t = await mount({ gw, width: 200 })
+    await until(t, () => t.frame().includes("Ready"))
+    await fill(t)
+
+    await act(async () => { await t.keys.typeText("/profiles") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Profiles (2)") && t.frame().includes("coder"))
+    const row = loc(t, "coder")
+    await act(async () => { await t.mouse.click(row.x, row.y) })
+    await until(t, () => t.frame().includes("Profile · coder"))
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Switch to 'coder'?"))
+    await act(async () => { await t.keys.typeText("y") })
+    await until(t, () => process.env.HERMES_HOME === `${h.path}/profiles/coder` && t.frame().includes("Ready"))
+    await t.settle()
+
+    expect(submitted(gw)).toHaveLength(0)
+    expect(t.frame()).not.toContain(stale)
     t.destroy()
   })
 })


### PR DESCRIPTION
## Context
Queued prompts can outlive session/profile transitions, allowing text queued in one session owner to be submitted after a different session or profile becomes active. That violates prompt ownership and can route stale input to the wrong session.

## Summary
- Clears queued prompt state through the existing transition reset path so successful new, resume, live activation, and profile switch flows cannot drain stale prompts.
- Adds full-shell regression coverage for queued prompt behavior across those transition paths while preserving same-session queue draining.
- Screenshots were not required because this is a queued prompt/session-ownership interaction defect covered by headless full-shell tests and RPC assertions.
