### PR TITLE
fix(sessions): match Hermes listability lineage

### DIFF
--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -17,9 +17,8 @@
  *                    files; local remove() is the fallback
  *
  * All query functions here share ONE readonly connection and ONE
- * parent→child classification rule. Upstream owns that semantic
- * (hermes_state.py:893-970); if it changes, `kind()` is the only line
- * that moves.
+ * repository-level parent→child relation. Upstream owns that semantic;
+ * if it changes, the SQL helpers around `next()` are the lines that move.
  */
 
 import { Database, type Statement } from "bun:sqlite"
@@ -159,39 +158,57 @@ export interface PeekMsg {
   observed?: number | null
   at: number
 }
-//
-// parent_session_id is overloaded across three unrelated relationships
-// in hermes-agent. The ONLY discriminator is (parent.end_reason,
-// child.started_at vs parent.ended_at):
-//
-//   subagent     — child started while parent was still live
-//                  (parent.ended_at NULL OR child.started_at < it)
-//   continuation — parent.end_reason='compression' AND child started
-//                  at/after parent.ended_at
-//   branch       — parent.end_reason='branched'    AND child started
-//                  at/after parent.ended_at
-//
-// This mirrors hermes_state.py compression-tip walker (:893-926) and
-// list_sessions_rich root filter (:956-971). Every query below derives
-// its WHERE from these three predicates — change the rule here, not
-// per-call. They take the child-table alias because queries variously
-// see the child as the outer `s` or an inner `c`.
+// parent_session_id is overloaded across subagent, compression, branch,
+// and delegate relationships. Current Hermes stores durable branch and
+// delegate markers in model_config, while compression continuation is the
+// best clean child of a compression-ended parent, not a timestamp gate.
 
 export type Kind = "root" | "subagent" | "continuation" | "branch"
 
-const SUB  = (c: string) => `(p.ended_at IS NULL OR ${c}.started_at < p.ended_at)`
-const CONT = (c: string) => `(p.end_reason = 'compression' AND ${c}.started_at >= p.ended_at)`
-const BR   = (c: string) => `(p.end_reason = 'branched'    AND ${c}.started_at >= p.ended_at)`
+const cfg = (c: string, key: "_branched_from" | "_delegate_from") =>
+  `json_extract(COALESCE(${c}.model_config, '{}'), '$.${key}')`
+const branched = (c: string) => `${cfg(c, "_branched_from")} IS NOT NULL`
+const delegated = (c: string) => `${cfg(c, "_delegate_from")} IS NOT NULL`
+const clean = (c: string) =>
+  `COALESCE(${c}.source, '') != 'tool' AND NOT (${branched(c)}) AND NOT (${delegated(c)})`
+const cont = (c: string, p: string) =>
+  `(${p}.ended_at IS NOT NULL AND COALESCE(${p}.end_reason, '') = 'compression' AND ${clean(c)})`
+const branch = (c: string, p: string) =>
+  `(NOT (${delegated(c)}) AND (${branched(c)} OR (` +
+  `${p}.ended_at IS NOT NULL AND COALESCE(${p}.end_reason, '') = 'branched' AND ${c}.started_at >= ${p}.ended_at)))`
+const sub = (c: string, p: string) =>
+  `(NOT (${branch(c, p)}) AND NOT (${cont(c, p)}) AND (` +
+  `${p}.ended_at IS NULL OR ${c}.started_at < ${p}.ended_at OR ` +
+  `COALESCE(${p}.end_reason, '') NOT IN ('compression', 'branched')))`
+const order = (c: string) =>
+  `CASE WHEN ${c}.end_reason = 'compression' THEN 0 WHEN ${c}.ended_at IS NULL THEN 1 ELSE 2 END ASC, ` +
+  `COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = ${c}.id), ${c}.started_at) DESC, ` +
+  `${c}.started_at DESC, ${c}.id DESC`
+const next = (p: string, c = "n") =>
+  `(SELECT ${c}.id FROM sessions ${c} WHERE ${c}.parent_session_id = ${p}.id AND ${cont(c, p)} ` +
+  `ORDER BY ${order(c)} LIMIT 1)`
+
+const marker = (raw: string | null | undefined, key: "_branched_from" | "_delegate_from") => {
+  if (!raw) return false
+  try { return Object.prototype.hasOwnProperty.call(JSON.parse(raw) as object, key) }
+  catch { return false }
+}
 
 /** Classify a child session given its parent. Pure — for tests and
  *  any caller that already has both rows in hand. */
 export const kind = (
   parent: { ended_at: number | null; end_reason: string | null } | null,
-  child: { started_at: number },
+  child: { started_at: number; source?: string | null; model_config?: string | null },
 ): Kind => {
   if (!parent) return "root"
+  if (marker(child.model_config, "_branched_from")) return "branch"
+  if (
+    parent.end_reason === "compression" &&
+    parent.ended_at != null &&
+    child.source !== "tool" &&
+    !marker(child.model_config, "_delegate_from")
+  ) return "continuation"
   if (parent.ended_at == null || child.started_at < parent.ended_at) return "subagent"
-  if (parent.end_reason === "compression") return "continuation"
   if (parent.end_reason === "branched") return "branch"
   return "subagent"
 }
@@ -214,7 +231,7 @@ const COLS = `
   (SELECT MAX(timestamp) FROM messages WHERE session_id = s.id) AS last_active,
   (SELECT COUNT(*) FROM sessions c
    WHERE c.parent_session_id = s.id
-     AND (s.ended_at IS NULL OR c.started_at < s.ended_at)) AS subagent_count`
+     AND ${sub("c", "s")}) AS subagent_count`
 
 type Raw = {
   id: string; source: string; model: string | null; billing_provider: string | null
@@ -273,7 +290,7 @@ export const lastReal = (): SessionRow | undefined => {
     SELECT s.id FROM sessions s
     LEFT JOIN sessions p ON p.id = s.parent_session_id
     WHERE s.source IN ('tui', 'cli') AND s.message_count > 0
-      AND (s.parent_session_id IS NULL OR ${CONT("s")})
+      AND (s.parent_session_id IS NULL OR ${branch("s", "p")} OR s.id = ${next("p")})
     ORDER BY s.started_at DESC LIMIT 1
   `)?.get() as { id: string } | undefined
   if (!hit) return undefined
@@ -291,7 +308,7 @@ function walkUp(sid: string): string {
   const step = q(
     `SELECT p.id FROM sessions c
      JOIN sessions p ON p.id = c.parent_session_id
-     WHERE c.id = ? AND ${CONT("c")}`,
+     WHERE c.id = ? AND c.id = ${next("p")}`,
   )
   let cur = sid
   for (let i = 0; i < 100; i++) {
@@ -321,7 +338,7 @@ export function roots(limit = 30): SessionRow[] {
        WHERE s.parent_session_id IS NULL
           OR EXISTS (SELECT 1 FROM sessions p
                      WHERE p.id = s.parent_session_id
-                       AND ${BR("s")})
+                       AND ${branch("s", "p")})
        ORDER BY s.started_at DESC
        LIMIT ?`,
     )?.all(limit) ?? []) as Raw[]
@@ -347,7 +364,7 @@ export function children(pid: string): SessionRow[] {
     return ((q(
       `SELECT ${COLS} FROM sessions s
        JOIN sessions p ON p.id = s.parent_session_id
-       WHERE s.parent_session_id = ? AND ${SUB("s")}
+       WHERE s.parent_session_id = ? AND ${sub("s", "p")}
        ORDER BY s.started_at ASC`,
     )?.all(pid) ?? []) as Raw[]).map(r => toRow(r))
   } finally { end() }
@@ -360,13 +377,12 @@ export function lineage(sid: string): LineageInfo {
     const pred = q(
       `SELECT p.id, p.title FROM sessions c
        JOIN sessions p ON p.id = c.parent_session_id
-       WHERE c.id = ? AND ${CONT("c")}`,
+       WHERE c.id = ? AND c.id = ${next("p")}`,
     )?.get(sid) as { id: string; title: string | null } | undefined
     const succ = q(
       `SELECT c.id, c.title FROM sessions c
        JOIN sessions p ON p.id = c.parent_session_id
-       WHERE p.id = ? AND ${CONT("c")}
-       ORDER BY c.started_at DESC LIMIT 1`,
+       WHERE p.id = ? AND c.id = ${next("p")}`,
     )?.get(sid) as { id: string; title: string | null } | undefined
     return {
       ...(pred && { continuesFrom: pred }),
@@ -381,8 +397,7 @@ function tip(sid: string): string {
   const step = q(
     `SELECT c.id FROM sessions c
      JOIN sessions p ON p.id = c.parent_session_id
-     WHERE p.id = ? AND ${CONT("c")}
-     ORDER BY c.started_at DESC LIMIT 1`,
+     WHERE p.id = ? AND c.id = ${next("p")}`,
   )
   let cur = sid
   for (let i = 0; i < 100; i++) {

--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -180,9 +180,14 @@ const sub = (c: string, p: string) =>
   `(NOT (${branch(c, p)}) AND NOT (${cont(c, p)}) AND (` +
   `${p}.ended_at IS NULL OR ${c}.started_at < ${p}.ended_at OR ` +
   `COALESCE(${p}.end_reason, '') NOT IN ('compression', 'branched')))`
+const top = (s: string) =>
+  `(${s}.parent_session_id IS NULL OR EXISTS (SELECT 1 FROM sessions p ` +
+  `WHERE p.id = ${s}.parent_session_id AND ${branch(s, "p")}))`
+const active = (s: string) =>
+  `COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = ${s}.id), ${s}.started_at)`
 const order = (c: string) =>
   `CASE WHEN ${c}.end_reason = 'compression' THEN 0 WHEN ${c}.ended_at IS NULL THEN 1 ELSE 2 END ASC, ` +
-  `COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = ${c}.id), ${c}.started_at) DESC, ` +
+  `${active(c)} DESC, ` +
   `${c}.started_at DESC, ${c}.id DESC`
 const next = (p: string, c = "n") =>
   `(SELECT ${c}.id FROM sessions ${c} WHERE ${c}.parent_session_id = ${p}.id AND ${cont(c, p)} ` +
@@ -287,11 +292,27 @@ export const byId = (id: string): SessionRow | null => {
  *  can have 0 messages when compaction rotated but no turn landed yet. */
 export const lastReal = (): SessionRow | undefined => {
   const hit = q(`
+    WITH RECURSIVE chain(root_id, cur_id) AS (
+      SELECT s.id, s.id FROM sessions s
+      WHERE s.source IN ('tui', 'cli') AND ${top("s")}
+      UNION ALL
+      SELECT c.root_id, child.id
+      FROM chain c
+      JOIN sessions parent ON parent.id = c.cur_id
+      JOIN sessions child ON child.parent_session_id = c.cur_id
+      WHERE ${cont("child", "parent")}
+    ), stats AS (
+      SELECT c.root_id,
+             MAX(${active("s")}) AS tick,
+             MAX(CASE WHEN s.source IN ('tui', 'cli') AND s.message_count > 0 THEN 1 ELSE 0 END) AS real
+      FROM chain c
+      JOIN sessions s ON s.id = c.cur_id
+      GROUP BY c.root_id
+    )
     SELECT s.id FROM sessions s
-    LEFT JOIN sessions p ON p.id = s.parent_session_id
-    WHERE s.source IN ('tui', 'cli') AND s.message_count > 0
-      AND (s.parent_session_id IS NULL OR ${branch("s", "p")} OR s.id = ${next("p")})
-    ORDER BY s.started_at DESC LIMIT 1
+    JOIN stats st ON st.root_id = s.id
+    WHERE st.real = 1
+    ORDER BY st.tick DESC, s.started_at DESC, s.id DESC LIMIT 1
   `)?.get() as { id: string } | undefined
   if (!hit) return undefined
   return byId(chainTip(hit.id)) ?? undefined
@@ -319,7 +340,7 @@ function walkUp(sid: string): string {
   return cur
 }
 
-/** Root-level sessions, newest-started first, compression chains
+/** Root-level sessions, newest-active first, compression chains
  *  projected to their tip (the resumable end), with lineage_root_id
  *  recording the original root when projection happened. Mirrors
  *  list_sessions_rich.
@@ -334,12 +355,25 @@ export function roots(limit = 30): SessionRow[] {
     // and continuations are hidden — they surface via children()/
     // lineage() instead. `p`/`c` aliases satisfy SUB/CONT/BR above.
     const raw = (q(
-      `SELECT ${COLS} FROM sessions s
-       WHERE s.parent_session_id IS NULL
-          OR EXISTS (SELECT 1 FROM sessions p
-                     WHERE p.id = s.parent_session_id
-                       AND ${branch("s", "p")})
-       ORDER BY s.started_at DESC
+      `WITH RECURSIVE chain(root_id, cur_id) AS (
+         SELECT s.id, s.id FROM sessions s
+         WHERE ${top("s")}
+         UNION ALL
+         SELECT c.root_id, child.id
+         FROM chain c
+         JOIN sessions parent ON parent.id = c.cur_id
+         JOIN sessions child ON child.parent_session_id = c.cur_id
+         WHERE ${cont("child", "parent")}
+       ), stats AS (
+         SELECT c.root_id, MAX(${active("s")}) AS tick
+         FROM chain c
+         JOIN sessions s ON s.id = c.cur_id
+         GROUP BY c.root_id
+       )
+       SELECT ${COLS} FROM sessions s
+       LEFT JOIN stats st ON st.root_id = s.id
+       WHERE ${top("s")}
+       ORDER BY COALESCE(st.tick, s.started_at) DESC, s.started_at DESC, s.id DESC
        LIMIT ?`,
     )?.all(limit) ?? []) as Raw[]
 

--- a/src/service/sessions-db.ts
+++ b/src/service/sessions-db.ts
@@ -183,6 +183,7 @@ const sub = (c: string, p: string) =>
 const top = (s: string) =>
   `(${s}.parent_session_id IS NULL OR EXISTS (SELECT 1 FROM sessions p ` +
   `WHERE p.id = ${s}.parent_session_id AND ${branch(s, "p")}))`
+const listable = (s: string) => `(NOT (${delegated(s)}) AND ${top(s)})`
 const active = (s: string) =>
   `COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = ${s}.id), ${s}.started_at)`
 const order = (c: string) =>
@@ -294,7 +295,7 @@ export const lastReal = (): SessionRow | undefined => {
   const hit = q(`
     WITH RECURSIVE chain(root_id, cur_id) AS (
       SELECT s.id, s.id FROM sessions s
-      WHERE s.source IN ('tui', 'cli') AND ${top("s")}
+      WHERE s.source IN ('tui', 'cli') AND ${listable("s")}
       UNION ALL
       SELECT c.root_id, child.id
       FROM chain c
@@ -351,13 +352,12 @@ function walkUp(sid: string): string {
 export function roots(limit = 30): SessionRow[] {
   const end = perf.mark("io:sessions.roots")
   try {
-    // Root filter: no parent, OR parent link is a branch. Subagents
-    // and continuations are hidden — they surface via children()/
-    // lineage() instead. `p`/`c` aliases satisfy SUB/CONT/BR above.
+    // Root filter: no parent, OR parent link is a branch, excluding
+    // delegate markers. `p`/`c` aliases satisfy SUB/CONT/BR above.
     const raw = (q(
       `WITH RECURSIVE chain(root_id, cur_id) AS (
          SELECT s.id, s.id FROM sessions s
-         WHERE ${top("s")}
+         WHERE ${listable("s")}
          UNION ALL
          SELECT c.root_id, child.id
          FROM chain c
@@ -372,7 +372,7 @@ export function roots(limit = 30): SessionRow[] {
        )
        SELECT ${COLS} FROM sessions s
        LEFT JOIN stats st ON st.root_id = s.id
-       WHERE ${top("s")}
+       WHERE ${listable("s")}
        ORDER BY COALESCE(st.tick, s.started_at) DESC, s.started_at DESC, s.id DESC
        LIMIT ?`,
     )?.all(limit) ?? []) as Raw[]

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -563,8 +563,8 @@ export const Sessions = memo((props: Props) => {
   const [warn, setWarn] = useState("")
   const [searchErr, setSearchErr] = useState("")
   const [pending, setPending] = useState(rows.length === 0)
-  // Persisted, user-toggleable list ordering. roots() always returns
-  // newest-started; we re-sort here so the choice can flip live
+  // Persisted, user-toggleable list ordering. roots() returns the
+  // producer's active window; we re-sort here so the choice can flip live
   // without re-hitting state.db.
   const sort: Sort = prefs.usePref("sessions")?.sort ?? "active"
   const setSort = useCallback((s: Sort) => prefs.set("sessions", { sort: s }), [])

--- a/test/fixtures/state-db.ts
+++ b/test/fixtures/state-db.ts
@@ -31,7 +31,8 @@ export const openStateDb = (): Database => {
     cache_read_tokens INTEGER DEFAULT 0, cache_write_tokens INTEGER DEFAULT 0,
     reasoning_tokens INTEGER DEFAULT 0,
     estimated_cost_usd REAL, actual_cost_usd REAL,
-    parent_session_id TEXT
+    parent_session_id TEXT,
+    model_config TEXT
   )`)
   db.run(`CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/test/hermes-home-sessions.test.ts
+++ b/test/hermes-home-sessions.test.ts
@@ -191,6 +191,19 @@ describe("queryRecentSessions (gsk.13: root-only + subagent_count + tip projecti
     expect(ids).toEqual(["branch", "root"])
   })
 
+  test("shows model_config branch children even when the parent stays live", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1700000000)
+    sess(db, "branch", "tui", 1700000500, {
+      parent_session_id: "root",
+      model_config: JSON.stringify({ _branched_from: "root" }),
+    })
+    db.close()
+
+    const ids = queryRecentSessions(10).map(r => r.id).sort()
+    expect(ids).toEqual(["branch", "root"])
+  })
+
   test("projects compression root forward to tip (one row, tip identity, root started_at)", () => {
     const db = seed()
     // Root (compressed) → continuation A (compressed) → continuation B (live tip).
@@ -232,6 +245,86 @@ describe("queryRecentSessions (gsk.13: root-only + subagent_count + tip projecti
     expect(rows[0].id).toBe("tip")
     expect(rows[0].started_at).toBe(1600000000)    // root's
     expect(rows[0].last_active).toBe(1700099999)   // tip's
+  })
+
+  test("projects compression root to a continuation inserted before parent ended_at", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1700000000,
+      { ended_at: 1700003000, end_reason: "compression", title: "Root" })
+    sess(db, "cont", "tui", 1700002500,
+      { parent_session_id: "root", title: "Race continuation" })
+    db.close()
+
+    const rows = queryRecentSessions(10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe("cont")
+    expect(rows[0].lineage_root_id).toBe("root")
+    expect(chainTip("root")).toBe("cont")
+  })
+
+  test("prefers the live continuation over a later closed stale sibling", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1700000000,
+      { ended_at: 1700003000, end_reason: "compression", title: "Root" })
+    sess(db, "stale", "tui", 1700004000,
+      { parent_session_id: "root", ended_at: 1700004100, end_reason: "ws_orphan_reap", title: "Stale" })
+    sess(db, "live", "tui", 1700002500,
+      { parent_session_id: "root", title: "Live" })
+    msg(db, "stale", "user", "stale message", 1700009000)
+    msg(db, "live", "user", "live message", 1700005000)
+    db.close()
+
+    const rows = queryRecentSessions(10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe("live")
+    expect(chainTip("root")).toBe("live")
+    expect(queryLineage("root").compressedTo).toEqual({ id: "live", title: "Live" })
+    expect(queryLineage("stale")).toEqual({})
+  })
+
+  test("prefers a compression child over a newer live sibling", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1700000000,
+      { ended_at: 1700003000, end_reason: "compression", title: "Root" })
+    sess(db, "live", "tui", 1700005000, { parent_session_id: "root", title: "Live" })
+    sess(db, "chain", "tui", 1700002500, {
+      parent_session_id: "root",
+      ended_at: 1700003500,
+      end_reason: "compression",
+      title: "Chain",
+    })
+    sess(db, "tip", "tui", 1700003600, { parent_session_id: "chain", title: "Tip" })
+    db.close()
+
+    expect(chainTip("root")).toBe("tip")
+    expect(queryLineage("root").compressedTo).toEqual({ id: "chain", title: "Chain" })
+    expect(queryLineage("live")).toEqual({})
+  })
+
+  test("excludes branch, delegate, and tool children from compression tips", () => {
+    const db = seed()
+    sess(db, "root", "tui", 1700000000,
+      { ended_at: 1700003000, end_reason: "compression", title: "Root" })
+    sess(db, "branch", "tui", 1700004000, {
+      parent_session_id: "root",
+      title: "Branch",
+      model_config: JSON.stringify({ _branched_from: "root" }),
+    })
+    sess(db, "delegate", "tui", 1700005000, {
+      parent_session_id: "root",
+      title: "Delegate",
+      model_config: JSON.stringify({ _delegate_from: "root" }),
+    })
+    sess(db, "tool", "tool", 1700006000, { parent_session_id: "root", title: "Tool" })
+    sess(db, "cont", "tui", 1700002500, { parent_session_id: "root", title: "Cont" })
+    db.close()
+
+    const ids = queryRecentSessions(10).map(r => r.id).sort()
+    expect(ids).toEqual(["branch", "cont"])
+    expect(chainTip("root")).toBe("cont")
+    expect(queryLineage("branch")).toEqual({})
+    expect(queryLineage("delegate")).toEqual({})
+    expect(queryLineage("tool")).toEqual({})
   })
 
   test("non-chain roots get lineage_root_id = null", () => {
@@ -411,8 +504,8 @@ describe("kind() — pure classifier (single source of truth for parent→child 
     expect(kind({ ended_at: null, end_reason: null }, { started_at: 100 })).toBe("subagent")
     expect(kind({ ended_at: null, end_reason: "compression" }, { started_at: 100 })).toBe("subagent")
   })
-  test("child started before parent ended → subagent", () => {
-    expect(kind({ ended_at: 200, end_reason: "compression" }, { started_at: 100 })).toBe("subagent")
+  test("clean child of compression-ended parent → continuation even before ended_at", () => {
+    expect(kind({ ended_at: 200, end_reason: "compression" }, { started_at: 100 })).toBe("continuation")
   })
   test("child started at/after compression-ended parent → continuation", () => {
     expect(kind({ ended_at: 100, end_reason: "compression" }, { started_at: 100 })).toBe("continuation")
@@ -420,6 +513,20 @@ describe("kind() — pure classifier (single source of truth for parent→child 
   })
   test("child started at/after branched parent → branch", () => {
     expect(kind({ ended_at: 100, end_reason: "branched" }, { started_at: 200 })).toBe("branch")
+  })
+  test("model_config branch marker wins over timestamp and parent reason", () => {
+    expect(kind(
+      { ended_at: null, end_reason: null },
+      { started_at: 100, model_config: JSON.stringify({ _branched_from: "root" }) },
+    )).toBe("branch")
+  })
+  test("delegate and tool children of compression parents are not continuations", () => {
+    expect(kind(
+      { ended_at: 100, end_reason: "compression" },
+      { started_at: 200, model_config: JSON.stringify({ _delegate_from: "root" }) },
+    )).toBe("subagent")
+    expect(kind({ ended_at: 100, end_reason: "compression" }, { started_at: 200, source: "tool" }))
+      .toBe("subagent")
   })
   test("parent ended normally, child after → subagent (degenerate: orphaned child)", () => {
     expect(kind({ ended_at: 100, end_reason: "exit" }, { started_at: 200 })).toBe("subagent")

--- a/test/hermes-home-sessions.test.ts
+++ b/test/hermes-home-sessions.test.ts
@@ -247,6 +247,32 @@ describe("queryRecentSessions (gsk.13: root-only + subagent_count + tip projecti
     expect(rows[0].last_active).toBe(1700099999)   // tip's
   })
 
+  test("orders compression chains by effective activity before limiting", () => {
+    const db = seed()
+    sess(db, "oldroot", "tui", 100, {
+      ended_at: 200,
+      end_reason: "compression",
+      title: "Old root",
+    })
+    sess(db, "oldtip", "tui", 300, {
+      parent_session_id: "oldroot",
+      title: "Active tip",
+    })
+    msg(db, "oldtip", "user", "fresh work", 999999)
+    Array.from({ length: 35 }, (_, i) => {
+      sess(db, `new${i}`, "tui", 1000 + i, { title: `New ${i}` })
+    })
+    db.close()
+
+    const rows = queryRecentSessions(30)
+    expect(rows).toHaveLength(30)
+    expect(rows[0].id).toBe("oldtip")
+    expect(rows[0].started_at).toBe(100)
+    expect(rows[0].last_active).toBe(999999)
+    expect(rows.some(r => r.id === "oldtip")).toBe(true)
+    expect(lastReal()?.id).toBe("oldtip")
+  })
+
   test("projects compression root to a continuation inserted before parent ended_at", () => {
     const db = seed()
     sess(db, "root", "tui", 1700000000,

--- a/test/hermes-home-sessions.test.ts
+++ b/test/hermes-home-sessions.test.ts
@@ -273,6 +273,22 @@ describe("queryRecentSessions (gsk.13: root-only + subagent_count + tip projecti
     expect(lastReal()?.id).toBe("oldtip")
   })
 
+  test("hides parentless delegate-marker rows from recent roots and resume target", () => {
+    const db = seed()
+    sess(db, "normal", "tui", 100, { message_count: 1, title: "Normal" })
+    sess(db, "delegated", "tui", 200, {
+      message_count: 1,
+      title: "Delegated",
+      model_config: JSON.stringify({ _delegate_from: "__orphaned__" }),
+    })
+    msg(db, "normal", "user", "normal work", 100)
+    msg(db, "delegated", "user", "delegated work", 300)
+    db.close()
+
+    expect(queryRecentSessions(10).map(r => r.id)).toEqual(["normal"])
+    expect(lastReal()?.id).toBe("normal")
+  })
+
   test("projects compression root to a continuation inserted before parent ended_at", () => {
     const db = seed()
     sess(db, "root", "tui", 1700000000,


### PR DESCRIPTION
## Context
Herm's session list and resume seed need to match current Hermes Agent semantics around compression lineages and delegate markers. Delegate marker sessions are bookkeeping rows and should not appear as real recent session roots or win resume selection.

## Summary
- Aligns session lineage queries with Hermes listability behavior, including branch, delegate, and compression continuation handling.
- Filters `model_config._delegate_from` rows out of listable roots and last-real session selection.
- Adds state.db fixture coverage and session regressions for delegate markers, branch markers, and compression ordering.