### PR TITLE
fix(session): preserve durable session identity

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -106,6 +106,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [ready, setReady] = useState(false)
   const [sid, setSid] = useState("")
   const sidRef = useRef(sid); sidRef.current = sid
+  const [durable, setDurable] = useState("")
+  const durableRef = useRef(durable); durableRef.current = durable
   const [starting, setStarting] = useState(false)
   const startRef = useRef(starting); startRef.current = starting
   const active = turn.streaming || starting
@@ -141,7 +143,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   // emits the mode-reset blob. Mount-once: gw/renderer identity is stable.
   useEffect(() => {
     process.removeAllListeners("SIGINT")
-    process.on("SIGINT", () => quit(renderer, sidRef.current, titleRef.current, gw))
+    process.on("SIGINT", () => quit(renderer, durableRef.current || sidRef.current, titleRef.current, gw))
   }, [renderer, gw])
   // CONTROL=1 binds 127.0.0.1 by default; if the user overrode
   // CONTROL_BIND to a non-loopback host, the HTTP server is exposed to
@@ -199,8 +201,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const creating = useRef(false)
   const [composing, setComposing] = useState(false)
   const splashLast = useMemo(
-    () => launch.mode === "new" ? lastReal() : undefined,
-    [launch.mode],
+    () => launch0.mode === "new" ? lastReal() : undefined,
+    [launch0.mode],
   )
   // Stable Splash props — inline `{…}` in JSX is a fresh reference per
   // AppInner render (= per key event) and defeats Splash's memo().
@@ -269,7 +271,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   useEffect(() => {
     const restart = (mode: "resume" | "new" = "resume") => {
-      const sid = sidRef.current
+      const sid = durableRef.current || sidRef.current
       if (mode === "resume" && sid) launchRef.current = { mode: "resume", sid, splash: false }
       gw.setSession("")
       setReady(false)
@@ -279,7 +281,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     }
     const exit = (code: number | null) => {
       const text = `gateway exited${code === null ? "" : ` (${code})`}`
-      const sid = sidRef.current
+      const sid = durableRef.current || sidRef.current
       if (sid) launchRef.current = { mode: "resume", sid, splash: false }
       gw.setSession("")
       setReady(false)
@@ -390,7 +392,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
-    setSid, setInfo, setReady, setTitle, setBusy, setStarting, setUsage, setStatus, setSkin, setErrorPulse, settle,
+    setSid, setDurable, setInfo, setReady, setTitle, setBusy, setStarting, setUsage, setStatus, setSkin, setErrorPulse, settle,
     onVoiceStatus: state => {
       voice.setRecording(state === "listening" || state === "recording")
       voice.setProcessing(state === "transcribing" || state === "processing")
@@ -441,6 +443,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       const r = await session.create()
       reset()
       setSid(r.id)
+      setDurable(r.key)
+      launchRef.current = { mode: "resume", sid: r.key, splash: false }
       if (r.info) { setInfo(r.info); setUsage(r.info.usage) }
       setReady(true)
       setStarting(false)
@@ -460,6 +464,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const switchSession = useCallback(async (target: string) => {
     const prev = sidRef.current
+    const old = durableRef.current
     // Keep splash visible while the resume RPC lands so the user sees
     // the ornate frame instead of the empty-transcript welcome. summoned
     // suppresses the continue-prompt (we've already chosen a session);
@@ -474,6 +479,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       const res = await session.resume(target)
       reset()
       setSid(res.id)
+      setDurable(res.key)
+      launchRef.current = { mode: "resume", sid: res.key, splash: false }
       if (res.info) {
         setInfo(res.info)
         setUsage(res.info.usage)
@@ -492,6 +499,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       if (prev) {
         gw.setSession(prev)
         setSid(prev)
+        setDurable(old)
         setReady(true)
       }
       dispatch({ kind: "system", text: `Failed to resume: ${err instanceof Error ? err.message : String(err)}` })
@@ -510,6 +518,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const activateSession = useCallback(async (target: string) => {
     const prev = sidRef.current
+    const old = durableRef.current
     summoned.current = true
     setSplash(true)
     setSwitching(true)
@@ -520,6 +529,8 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       const res = await session.activate(target)
       reset()
       setSid(res.id)
+      setDurable(res.key)
+      launchRef.current = { mode: "resume", sid: res.key, splash: false }
       if (res.info) {
         setInfo(res.info)
         setUsage(res.info.usage)
@@ -536,6 +547,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       if (prev) {
         gw.setSession(prev)
         setSid(prev)
+        setDurable(old)
         setReady(true)
       }
       dispatch({ kind: "system", text: `Failed to activate: ${err instanceof Error ? err.message : String(err)}` })
@@ -557,6 +569,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     reset()
     gw.setSession("")
     setSid("")
+    setDurable("")
     setInfo(null)
     setSkin(deriveSkin(undefined))
     // Fresh gateway boots behind the splash (same as cold launch); the
@@ -612,7 +625,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const sendRef = useRef<(raw: string) => void>(() => {})
   const slash = useSlash({
     dispatch, session, turnRef, queueRef, sendRef, composer, summoned, undone,
-    capabilities, info, sid, title: caption, skin,
+    capabilities, info, sid, resumeId: durable || sid, title: caption, skin,
     setQueue, setFocusRegion, setSplash, setAttachments: updateAttachments, setInfo, setUsage, setTitle,
     newSession, switchSession, activateSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
   })
@@ -621,7 +634,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     // Bare exit/quit/:q — pass through as literals so a
     // reflex `exit⏎` works without the leading slash.
     if (["exit", "quit", ":q", ":q!", ":wq"].includes(raw.trim()))
-      return quit(renderer, sidRef.current, titleRef.current, gw)
+      return quit(renderer, durableRef.current || sidRef.current, titleRef.current, gw)
     if (detaching.current > 0) {
       if (raw.trim()) composer.current?.set(raw)
       setStatus("detaching image…")
@@ -830,7 +843,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       hold.current = true
       interrupt()
     },
-    onQuit: () => quit(renderer, sid, caption, gw),
+    onQuit: () => quit(renderer, durable || sid, caption, gw),
     onQuitArm: (label) =>
       toast.show({ variant: "info", message: `${label} again to quit` }),
     onInterruptNotice: () => {

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -62,6 +62,7 @@ export type SlashCtx = {
   capabilities: SessionCapabilities
   info: SessionInfo | null
   sid: string
+  resumeId: string
   title: string
   skin: SkinState
 
@@ -400,7 +401,7 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
             })
             .catch((e: Error) => toast.show({ variant: "error", message: e.message }))
           return
-        case "quit": quit(renderer, x.sid, x.title, gw); return
+        case "quit": quit(renderer, x.resumeId || x.sid, x.title, gw); return
         case "queue":
           if (!arg) { x.dispatch({ kind: "system", text: `${x.queueRef.current.length} queued` }); return }
           x.setQueue(q => [...q, arg]); return

--- a/src/app/useSession.ts
+++ b/src/app/useSession.ts
@@ -38,9 +38,9 @@ type CompressResult = {
   }
 }
 
-type Booted = { id: string; messages: Message[]; note?: string; info?: SessionInfo }
-type Resumed = { id: string; messages: Message[]; info?: SessionInfo }
-type Activated = { id: string; messages: Message[]; info?: SessionInfo; running: boolean; status?: string; startedAt?: number }
+type Booted = { id: string; key: string; messages: Message[]; note?: string; info?: SessionInfo }
+type Resumed = { id: string; key: string; messages: Message[]; info?: SessionInfo }
+type Activated = { id: string; key: string; messages: Message[]; info?: SessionInfo; running: boolean; status?: string; startedAt?: number }
 type Agents = { processes?: Array<{ status?: string }> }
 type Close = { preserveBackground?: boolean }
 
@@ -50,7 +50,7 @@ export const normalize = (sid: string): string =>
 type SessionOps = {
   /** Establish the initial session per launch intent. */
   boot: (launch: Launch) => Promise<Booted>
-  create: () => Promise<{ id: string; info?: SessionInfo }>
+  create: () => Promise<{ id: string; key: string; info?: SessionInfo }>
   resume: (sid: string) => Promise<Resumed>
   activate: (sid: string) => Promise<Activated>
   /** Finalize a gateway session (best-effort — swallows errors). */
@@ -80,10 +80,11 @@ export function useSession(): SessionOps {
     const target = normalize(sid)
     const res = await gw.request<SessionResumeResponse>("session.resume", { session_id: target })
     const id = res.session_id
+    const key = res.session_key ?? res.resumed ?? target
     gw.setSession(id)
-    preferences.set("lastSessionId", res.resumed ?? target)
+    preferences.set("lastSessionId", key)
     const messages = res.messages?.length ? transcriptToMessages(res.messages) : []
-    return { id, messages, info: res.info }
+    return { id, key, messages, info: res.info }
   }, [gw])
 
   // No `cols` param and no `terminal.resize` RPC on SIGWINCH: herm renders
@@ -94,20 +95,24 @@ export function useSession(): SessionOps {
   // checkpoint diff RPC — both default-80 is fine for our flow.
   const create = useCallback(async () => {
     const res = await gw.request<SessionCreateResponse>("session.create", {})
+    const key = res.stored_session_id ?? res.session_id
     gw.setSession(res.session_id)
-    return { id: res.session_id, info: res.info }
+    preferences.set("lastSessionId", key)
+    return { id: res.session_id, key, info: res.info }
   }, [gw])
 
   const activate = useCallback(async (sid: string): Promise<Activated> => {
     const target = normalize(sid)
     const res = await gw.request<SessionActivateResponse>("session.activate", { session_id: target })
     const id = res.session_id
+    const key = res.session_key ?? id
     gw.setSession(id)
-    preferences.set("lastSessionId", res.session_key ?? id)
+    preferences.set("lastSessionId", key)
     const history = res.messages?.length ? transcriptToMessages(res.messages) : []
     const running = Boolean(res.running || res.status === "working" || res.status === "waiting")
     return {
       id,
+      key,
       info: res.info,
       messages: [...history, ...inflightMessages(res.inflight)],
       running,

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -29,6 +29,7 @@ type Ctx = {
   goalHook: { check: (sid: string) => void }
 
   setSid: (id: string) => void
+  setDurable: (id: string) => void
   setInfo: (i: SessionInfo) => void
   setReady: (r: boolean) => void
   setTitle: (t: string) => void
@@ -85,6 +86,14 @@ export function useStream(c: Ctx) {
   // action flushes synchronously first so part ordering is preserved.
   const deltas = useRef({ text: "", think: "", timer: null as ReturnType<typeof setTimeout> | null })
 
+  const store = useCallback((key?: string, id?: string) => {
+    const sid = key ?? id
+    if (!sid) return
+    ctx.current.setDurable(sid)
+    ctx.current.launchRef.current = { mode: "resume", sid, splash: false }
+    preferences.set("lastSessionId", sid)
+  }, [])
+
   const flush = useCallback(() => {
     const d = deltas.current
     if (d.timer) { clearTimeout(d.timer); d.timer = null }
@@ -99,7 +108,7 @@ export function useStream(c: Ctx) {
       .then(r => {
         if (ctx.current.sidRef.current !== sid) return
         ctx.current.setTitle(r.title ?? "")
-        if (r.session_key) preferences.set("lastSessionId", r.session_key)
+        store(r.session_key)
       })
       .catch(() => {})
     if (ms <= 0) return run()
@@ -140,6 +149,7 @@ export function useStream(c: Ctx) {
       onReady: () => {
         x.session.boot(x.launchRef.current).then((r) => {
           x.setSid(r.id)
+          store(r.key, r.id)
           if (r.info) { x.setInfo(r.info); x.setUsage(r.info.usage) }
           x.sessionStart.current = Date.now()
           if (r.messages.length) x.dispatch({ kind: "load", messages: r.messages })
@@ -163,6 +173,7 @@ export function useStream(c: Ctx) {
           x.setStatus("")
         }
         if (si.session_id) x.setSid(si.session_id)
+        if (si.stored_session_id) store(si.stored_session_id, si.session_id ?? ev.session_id)
         x.settle()
         // Use title from session.info directly — avoids a redundant
         // session.title RPC that would re-emit session.info and create

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -167,6 +167,7 @@ export type SessionInfo = {
   model?: string
   cwd?: string
   session_id?: string
+  stored_session_id?: string
   /**
    * Live tool catalog from gateway session.info. state.db is canonical for
    * historical sessions, while legacy sessions/session_*.json snapshots are
@@ -218,12 +219,14 @@ export type SessionInfo = {
 
 export type SessionCreateResponse = {
   session_id: string
+  stored_session_id?: string
   info?: SessionInfo & { credential_warning?: string }
 }
 
 export type SessionResumeResponse = {
   session_id: string
   resumed?: string
+  session_key?: string
   messages: TranscriptMessage[]
   message_count?: number
   info?: SessionInfo

--- a/test/session-identity.test.tsx
+++ b/test/session-identity.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import * as preferences from "../src/context/preferences"
+import { MockGateway, mount, until } from "./harness"
+
+describe("session identity", () => {
+  test("live routing stays live while reconnect and process-loss resume use durable id", async () => {
+    let n = 0
+    const gw = new MockGateway({
+      "session.create": () => ({
+        session_id: "live-create",
+        stored_session_id: "dur-create",
+        info: { model: "m", session_id: "live-create", stored_session_id: "dur-create", tools: {}, skills: {} },
+      }),
+      "session.resume": p => ({
+        session_id: `live-resume-${++n}`,
+        resumed: p.session_id,
+        session_key: p.session_id,
+        messages: [],
+        info: { model: "m", session_id: `live-resume-${n}`, stored_session_id: p.session_id as string, tools: {}, skills: {} },
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "new", splash: false } })
+    await until(t, () => gw.last("session.create") !== undefined)
+
+    expect(preferences.get("lastSessionId")).toBe("dur-create")
+
+    await act(async () => { await t.keys.typeText("hello") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => gw.last("prompt.submit") !== undefined)
+    expect(gw.last("prompt.submit")?.params.session_id).toBe("live-create")
+
+    act(() => gw.push({ type: "gateway.ready" }))
+    await until(t, () => gw.calls.some(c => c.method === "session.resume" && c.params.session_id === "dur-create"))
+    expect(gw.calls.filter(c => c.method === "session.resume").at(-1)?.params.session_id).toBe("dur-create")
+
+    act(() => {
+      gw.emit("exit", 1)
+      gw.push({ type: "gateway.ready" })
+    })
+    await until(t, () => gw.calls.filter(c => c.method === "session.resume" && c.params.session_id === "dur-create").length >= 2)
+    expect(gw.calls.filter(c => c.method === "session.resume").at(-1)?.params.session_id).toBe("dur-create")
+
+    t.destroy()
+  })
+
+  test("session.info durable rotation updates the next resume target", async () => {
+    const gw = new MockGateway({
+      "session.create": () => ({
+        session_id: "live-a",
+        stored_session_id: "dur-a",
+        info: { model: "m", session_id: "live-a", stored_session_id: "dur-a", tools: {}, skills: {} },
+      }),
+      "session.resume": p => ({
+        session_id: "live-b",
+        resumed: p.session_id,
+        session_key: p.session_id,
+        messages: [],
+        info: { model: "m", session_id: "live-b", stored_session_id: p.session_id as string, tools: {}, skills: {} },
+      }),
+    })
+    const t = await mount({ gw, launch: { mode: "new", splash: false } })
+    await until(t, () => gw.last("session.create") !== undefined)
+
+    act(() => gw.push({
+      type: "session.info",
+      session_id: "live-a",
+      payload: { model: "m", session_id: "live-a", stored_session_id: "dur-b", tools: {}, skills: {} },
+    }))
+    await until(t, () => preferences.get("lastSessionId") === "dur-b")
+
+    act(() => gw.push({ type: "gateway.ready" }))
+    await until(t, () => gw.calls.some(c => c.method === "session.resume" && c.params.session_id === "dur-b"))
+    expect(gw.last("session.resume")?.params.session_id).toBe("dur-b")
+
+    t.destroy()
+  })
+})


### PR DESCRIPTION
## Context
STAB-3 fixes Herm session identity handling so live gateway IDs and durable stored session IDs remain separate across create, resume, activate, gateway restart, WebSocket reconnect, and session.info updates.

## Summary
- Preserves durable session ids separately from live routing ids
- Routes live RPCs with the live id while persisting and resuming durable ids
- Adds focused regression coverage for reconnect, process-loss resume, and durable rotation
