### PR TITLE
fix(profile): atomically reset profile-owned state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,8 +1,10 @@
 import { useRenderer, useTerminalDimensions } from "@opentui/react"
+import { homedir } from "node:os"
+import { join } from "node:path"
 import { Profiler, useState, useEffect, useRef, useCallback, useMemo, useReducer, useSyncExternalStore } from "react"
 import * as perf from "./utils/perf"
 import { hasInterp, interpolate } from "./utils/interpolate"
-import { GatewayProvider, useGateway, useGatewayRestart, type Gateway } from "./context/gateway"
+import { GatewayProvider, useGateway, type Gateway } from "./context/gateway"
 import type { SessionInfo, ImageAttachResponse, ImageDetachResponse } from "./context/wire"
 import type { Message, Usage } from "./types/message"
 import { text as msgText } from "./types/message"
@@ -68,31 +70,69 @@ type AppProps = {
   plugins?: ReadonlyArray<HermPlugin>
 }
 
+type Runtime = {
+  home: string
+  seq: number
+  launch: Launch
+}
+
 const BUSY_RE = /session busy|waiting for model response/i
+const profileHome = () => process.env.HERMES_HOME || join(process.env.HOME || homedir(), ".hermes")
 
 export const App = (props: AppProps) => (
   <ThemeProvider initial={props.initialTheme}>
-    <GatewayProvider client={props.gateway}>
-      <ToastProvider>
-        <KeysProvider overrides={props.keyOverrides}>
-          <DialogProvider>
-            <CommandProvider>
-              <PluginProvider plugins={props.plugins}>
-                <BackgroundProvider>
-                  <AppInner launch={props.launch ?? { mode: "new" }} />
-                </BackgroundProvider>
-              </PluginProvider>
-            </CommandProvider>
-          </DialogProvider>
-        </KeysProvider>
-      </ToastProvider>
-    </GatewayProvider>
+    <ToastProvider>
+      <KeysProvider overrides={props.keyOverrides}>
+        <AppShell {...props} />
+      </KeysProvider>
+    </ToastProvider>
   </ThemeProvider>
 )
 
-const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
+const AppShell = (props: AppProps) => {
+  const toast = useToast()
+  const [runtime, setRuntime] = useState<Runtime>(() => ({
+    home: profileHome(),
+    seq: 0,
+    launch: props.launch ?? { mode: "new" },
+  }))
+  const current = useRef(runtime.home); current.current = runtime.home
+
+  const switchProfile = useCallback((newHome: string, name: string) => {
+    const prev = current.current
+    try {
+      rehome(newHome)
+    } catch (err) {
+      try { rehome(prev) } catch { /* best-effort rollback to the last coherent home */ }
+      const msg = err instanceof Error ? err.message : String(err)
+      toast.show({ variant: "error", message: `Profile switch failed: ${msg}` })
+      return
+    }
+    current.current = newHome
+    setRuntime(r => ({ home: newHome, seq: r.seq + 1, launch: { mode: "new", splash: true } }))
+    toast.show({ variant: "info", message: `Switching to '${name}'…` })
+  }, [toast])
+
+  return (
+    <GatewayProvider key={`${runtime.home}:${runtime.seq}`} client={props.gateway}>
+      <DialogProvider>
+        <CommandProvider>
+          <PluginProvider plugins={props.plugins}>
+            <BackgroundProvider>
+              <AppInner launch={runtime.launch} onSwitchProfile={switchProfile} />
+            </BackgroundProvider>
+          </PluginProvider>
+        </CommandProvider>
+      </DialogProvider>
+    </GatewayProvider>
+  )
+}
+
+const AppInner = ({ launch: launch0, onSwitchProfile }: {
+  launch: Launch
+  onSwitchProfile: (newHome: string, name: string) => void
+}) => {
   const gw = useGateway()
-  const gwRestart = useGatewayRestart()
   const dialog = useDialog()
   const dialogOpen = useDialogOpen()
   const themeCtx = useTheme()
@@ -401,7 +441,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
-    setSid, setDurable, setInfo: recordInfo, setReady, setTitle, setBusy, setStarting, setUsage, setStatus, setSkin, setErrorPulse, settle,
+    setSid, setDurable, setInfo: recordInfo, setReady, setTitle, setBusy, setStarting, setUsage, setStatus, setSkin, setSplash, setErrorPulse, settle,
     onVoiceStatus: state => {
       voice.setRecording(state === "listening" || state === "recording")
       voice.setProcessing(state === "transcribing" || state === "processing")
@@ -568,32 +608,6 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setSwitching(false)
     }
   }, [reset, session, goToTab, toast, gw])
-  // Rebind every HERMES_HOME reader, respawn the gateway subprocess
-  // under the new env, and re-run the boot path. prefs.reload (inside
-  // rehome) retints theme/eikon/keys via usePref; home.reset repaints
-  // tabs. The session is NOT preserved — it belongs to the old
-  // profile's state.db. Confirm step lives in the Agents tab.
-  const switchProfile = useCallback((newHome: string, name: string) => {
-    voice.reset()
-    rehome(newHome)
-    reset()
-    gw.setSession("")
-    setSid("")
-    setDurable("")
-    recordInfo(null)
-    setSkin(deriveSkin(undefined))
-    // Fresh gateway boots behind the splash (same as cold launch); the
-    // respawned process emits gateway.ready → session.info → onSend
-    // dismisses. `summoned` suppresses the continue-prompt — the
-    // outgoing profile's lastReal() is the wrong db.
-    summoned.current = true
-    setSplash(true)
-    launchRef.current = { mode: "new", splash: true }
-    toast.show({ variant: "info", message: `Switching to '${name}'…` })
-    goToTab(CHAT_TAB)
-    gwRestart("new")
-  }, [reset, goToTab, gwRestart, toast, gw])
-
   const loadEikon = useCallback((path: string) => {
     try { setEikon(parseEikonFile(path)) }
     catch { setEikon(undefined) }
@@ -949,7 +963,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
         case AUTOMATION_TAB: return <Automation focused={contentFocused}
                                                 sub={subTabs[AUTOMATION_TAB] ?? 0}
                                                 setSub={autoSub}
-                                                sessionId={sid} onSwitchProfile={switchProfile} />
+                                                sessionId={sid} onSwitchProfile={onSwitchProfile} />
         case CONFIG_TAB: return <ConfigGroup focused={contentFocused}
                                              sub={subTabs[CONFIG_TAB] ?? 0}
                                              setSub={cfgSub} />

--- a/src/app/spawnHistory.ts
+++ b/src/app/spawnHistory.ts
@@ -55,6 +55,10 @@ export function trail(id: string): ReadonlyArray<{ name: string; preview?: strin
   return acc.get(id)?.trail ?? []
 }
 
+export function clear(): void {
+  acc.clear()
+}
+
 /** Persist the turn's tree (best-effort) and clear the accumulator. */
 export function flush(gw: Gateway, sessionId: string): void {
   if (acc.size === 0) return

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -38,6 +38,7 @@ type Ctx = {
   setUsage: (u: Usage | undefined) => void
   setStatus: (s: string) => void
   setSkin: (s: SkinState) => void
+  setSplash: (v: boolean) => void
   setErrorPulse: (v: boolean) => void
   onVoiceStatus: (state: string) => void
   onVoiceTranscript: (text: string, noSpeechLimit: boolean) => void
@@ -156,8 +157,11 @@ export function useStream(c: Ctx) {
           if (r.note) toast.show({ variant: "info", message: r.note })
         }).catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err)
+          gw.setSession("")
+          x.setSid("")
           x.setReady(false)
           x.setStarting(false)
+          x.setSplash(false)
           x.setStatus(`session boot failed: ${msg}`)
           x.setErrorPulse(true)
           x.dispatch({ kind: "system", text: `Failed to start session: ${msg}` })

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -10,7 +10,7 @@ import { useKeys, toBindings } from "../../keys"
 import { useGateway } from "../../context/gateway"
 import type { ImageAttachResponse, DropDetectResponse } from "../../context/wire"
 import { looksLikePath } from "../../utils/drop"
-import type { SlashCommand } from "../../app/slashCommands"
+import { resolve as resolveSlash, type SlashCommand } from "../../app/slashCommands"
 import { replaceSlashToken, useSlashPopover } from "../../app/useSlashPopover"
 import { useAtRefPopover, atWordAt } from "../../app/useAtRefPopover"
 import { acceptCompletion, useCompletion } from "../../app/useCompletion"
@@ -304,9 +304,14 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
       return
     }
     const text = exp.text.trim()
+    const local = text.startsWith("/") && (() => {
+      const name = text.match(/^\/(\S+)/)?.[1] ?? ""
+      const r = resolveSlash(live.current.props.cmds, name)
+      return "hit" in r && r.hit.target === "local"
+    })()
     if (live.current.props.streaming) {
       if (!text) return
-      if (!live.current.props.canSubmitPrompt) { live.current.props.onSubmitBlocked?.(); return }
+      if (!live.current.props.canSubmitPrompt && !local) { live.current.props.onSubmitBlocked?.(); return }
       hist.push({ input: text, parts: exp.parts })
       write("")
       // Slash-shaped input routes through onSend so send() → slash()
@@ -319,7 +324,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     }
     const hasAtt = (live.current.props.attachments?.length ?? 0) > 0
     if (!text && !hasAtt) { live.current.props.onEmptyEnter?.(); return }
-    if (!live.current.props.canSubmitPrompt) { live.current.props.onSubmitBlocked?.(); return }
+    if (!live.current.props.canSubmitPrompt && !local) { live.current.props.onSubmitBlocked?.(); return }
     if (text) hist.push({ input: text, parts: exp.parts })
     write("")
     live.current.props.onSend(text, exp.parts)

--- a/src/context/gateway.tsx
+++ b/src/context/gateway.tsx
@@ -54,9 +54,11 @@ export const GatewayProvider = ({ client, children }: { client?: Gateway; childr
     }
     c.on("event", onEvent)
     c.on("exit", onExit)
+    let dead = false
     c.start()
-    c.drain()
+    queueMicrotask(() => { if (!dead) c.drain() })
     return () => {
+      dead = true
       c.off("event", onEvent)
       c.off("exit", onExit)
       if (retry.current.timer) clearTimeout(retry.current.timer)

--- a/src/home/rehome.ts
+++ b/src/home/rehome.ts
@@ -22,8 +22,10 @@ import { setHome as setHermesHome } from "../service/hermes-home"
 import { setHome as setDbHome } from "../service/sessions-db"
 import { cache as analyticsCache } from "../service/hermes-analytics"
 import { resetKanban } from "../service/hermes-kanban"
+import { close as closeIo } from "../io"
 import { close as closeKanbanWorker } from "../io/kanban"
 import { prefs } from "../context/preferences"
+import { clear as clearSpawnHistory } from "../app/spawnHistory"
 import { home } from "./store"
 
 /** Rebind all HERMES_HOME readers to `newHome` and refresh reactive
@@ -33,6 +35,8 @@ export function rehome(newHome: string): void {
   setHermesHome(newHome)
   setDbHome(newHome)
   analyticsCache.clear()
+  closeIo()
+  clearSpawnHistory()
   resetKanban()
   closeKanbanWorker()
   prefs.reload()

--- a/src/tabs/Sessions.tsx
+++ b/src/tabs/Sessions.tsx
@@ -538,7 +538,8 @@ type Props = {
 // Module-level cache so revisiting the tab paints the previous list on
 // frame 1 while load() refreshes in place. Tests that inject `io` don't
 // write here (see `cached` guard in load) — keeps suites independent.
-const last = { rows: [] as Row[], kids: new Map<string, Row[]>() }
+const cacheHome = () => process.env.HERMES_HOME ?? ""
+const last = { home: "", rows: [] as Row[], kids: new Map<string, Row[]>() }
 
 export const Sessions = memo((props: Props) => {
   const theme = useTheme().theme
@@ -558,7 +559,8 @@ export const Sessions = memo((props: Props) => {
     rename: props.io?.rename ?? sdb.rename,
   }), [props.io])
 
-  const [rows, setRows] = useState<Row[]>(cached ? last.rows : [])
+  const fresh = cached && last.home === cacheHome()
+  const [rows, setRows] = useState<Row[]>(fresh ? last.rows : [])
   const [liveRows, setLiveRows] = useState<Row[]>([])
   const [warn, setWarn] = useState("")
   const [searchErr, setSearchErr] = useState("")
@@ -724,7 +726,7 @@ export const Sessions = memo((props: Props) => {
     const local = new Map(disk.map(r => [r.id, r]))
     const diskRows = disk.filter(keep).map(toRow)
     setRows(diskRows)
-    if (cached) last.rows = diskRows
+    if (cached) { last.home = cacheHome(); last.rows = diskRows }
 
     const [a, r] = await Promise.all([active, rpc])
     if (gen.current !== current) return
@@ -750,7 +752,7 @@ export const Sessions = memo((props: Props) => {
       ]
       final = merged
       setRows(merged)
-      if (cached) last.rows = merged
+      if (cached) { last.home = cacheHome(); last.rows = merged }
       const found = new Map(merged.map(s => [s.id, s]))
       if (live.length) setLiveRows(live.map(s => toLiveRow(s, pick(local, s), pick(found, s))))
     }
@@ -766,7 +768,7 @@ export const Sessions = memo((props: Props) => {
       if (gen.current !== current) return
       const next = new Map(parents.map((row, i) => [row.id, children[i].map(toRow)]))
       setKids(next)
-      if (cached) last.kids = next
+      if (cached) { last.home = cacheHome(); last.kids = next }
     } catch (err) {
       kidsError = err instanceof Error ? err.message : String(err)
     }

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -132,7 +132,7 @@ export class MockGateway extends EventEmitter implements Gateway {
     for (const ev of this.buf.splice(0)) this.emit("event", ev)
   }
 
-  kill() {}
+  kill() { this.sub = false }
 
   tail(n = 200) { return this.logs.slice(-n).join("\n") }
 

--- a/test/profile-switch-boundary.test.tsx
+++ b/test/profile-switch-boundary.test.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test"
+import { act } from "react"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { mount, until, MockGateway } from "./harness"
+import { rehome } from "../src/home/rehome"
+import type { HermPlugin } from "../src/plugins/types"
+
+const base = () => join(process.env.HOME || homedir(), ".hermes")
+
+type Fx = {
+  root: string
+  coder: string
+  home?: string
+  cfg?: string
+}
+
+function write(root: string, rel: string, body: string) {
+  const file = join(root, rel)
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, body)
+}
+
+function profile(root: string, name: string) {
+  const dir = name === "default" ? root : join(root, "profiles", name)
+  mkdirSync(join(dir, "skills"), { recursive: true })
+  write(dir, "config.yaml", "model:\n  default: test-model\n  provider: test\n")
+  write(dir, "SOUL.md", `${name} soul\n`)
+  return dir
+}
+
+function setup(): Fx {
+  const fx = {
+    root: mkdtempSync(join(tmpdir(), "herm-profile-boundary-")),
+    coder: "",
+    home: process.env.HERMES_HOME,
+    cfg: process.env.HERM_CONFIG_DIR,
+  }
+  profile(fx.root, "default")
+  fx.coder = profile(fx.root, "coder")
+  write(fx.root, "herm/tui.json", JSON.stringify({ plugin: { enabled: { "profile.switch": true } } }))
+  write(fx.coder, "herm/tui.json", JSON.stringify({ plugin: { enabled: { "profile.switch": false } } }))
+  delete process.env.HERM_CONFIG_DIR
+  rehome(fx.root)
+  return fx
+}
+
+function restore(fx: Fx) {
+  if (fx.cfg) process.env.HERM_CONFIG_DIR = fx.cfg
+  else delete process.env.HERM_CONFIG_DIR
+  rehome(fx.home ?? base())
+  if (!fx.home) delete process.env.HERMES_HOME
+  rmSync(fx.root, { recursive: true, force: true })
+}
+
+function catalog() {
+  return { pairs: [["/profiles", "Profiles"]] }
+}
+
+function cfg() {
+  return {
+    home: process.env.HERMES_HOME,
+    display: process.env.HERMES_HOME?.endsWith("/profiles/coder") ? "coder" : "default",
+  }
+}
+
+async function openProfiles(t: Awaited<ReturnType<typeof mount>>) {
+  await act(async () => { await t.keys.typeText("/profiles") })
+  act(() => t.keys.pressEnter())
+  await until(t, () => t.frame().includes("Profiles (2)"))
+}
+
+async function switchToCoder(t: Awaited<ReturnType<typeof mount>>) {
+  await openProfiles(t)
+  act(() => t.keys.pressArrow("down"))
+  await until(t, () => t.frame().includes("coder"))
+  await act(async () => { await t.keys.typeText("s") })
+  await until(t, () => t.frame().includes("Switch to 'coder'?"))
+  await act(async () => { await t.keys.typeText("y") })
+}
+
+describe("profile switch runtime boundary", () => {
+  test("remounts profile-owned providers and respects the new profile preferences", async () => {
+    const fx = setup()
+    let aborts = 0
+    let boots = 0
+    let kills = 0
+    const plugin: HermPlugin = {
+      id: "profile.switch",
+      enabled: false,
+      tui(api) {
+        api.lifecycle.signal.addEventListener("abort", () => { aborts++ })
+        api.route.register([{ name: "OldPlugin", render: () => <text>old plugin body</text> }])
+      },
+    }
+    const gw = new MockGateway({
+      "commands.catalog": catalog,
+      "config.get": p => p.key === "profile" ? cfg() : p.key === "busy" ? { value: "queue" } : { config: {} },
+      "session.create": () => ({ session_id: `sid-${++boots}` }),
+    })
+    const start = gw.start.bind(gw)
+    const kill = gw.kill.bind(gw)
+    gw.start = () => { start() }
+    gw.kill = () => { kills++; kill() }
+
+    try {
+      await using t = await mount({ gw, plugins: [plugin], launch: { mode: "new", splash: false }, width: 200 })
+      await until(t, () => t.frame().includes("Ready") && t.frame().includes("OldPlugin"))
+      expect(boots).toBe(1)
+
+      await switchToCoder(t)
+      await until(t, () => process.env.HERMES_HOME === fx.coder && boots === 2 && t.frame().includes("Ready"))
+
+      expect(aborts).toBeGreaterThan(0)
+      expect(kills).toBeGreaterThan(0)
+      expect(t.frame()).not.toContain("OldPlugin")
+      await act(async () => { await t.keys.typeText("new profile prompt") })
+      act(() => t.keys.pressEnter())
+      await until(t, () => gw.last("prompt.submit")?.params.text === "new profile prompt")
+      expect(gw.last("prompt.submit")?.params.session_id).toBe("sid-2")
+    } finally {
+      restore(fx)
+    }
+  })
+
+  test("failed post-switch boot leaves a fresh new-profile runtime", async () => {
+    const fx = setup()
+    let aborts = 0
+    let boots = 0
+    const plugin: HermPlugin = {
+      id: "profile.switch",
+      enabled: false,
+      tui(api) {
+        api.lifecycle.signal.addEventListener("abort", () => { aborts++ })
+        api.route.register([{ name: "OldPlugin", render: () => <text>old plugin body</text> }])
+      },
+    }
+    const gw = new MockGateway({
+      "commands.catalog": catalog,
+      "config.get": p => p.key === "profile" ? cfg() : p.key === "busy" ? { value: "queue" } : { config: {} },
+      "session.create": () => {
+        boots++
+        if (boots === 1) return { session_id: "sid-old" }
+        throw new Error("boot exploded")
+      },
+    })
+
+    try {
+      await using t = await mount({ gw, plugins: [plugin], launch: { mode: "new", splash: false }, width: 200 })
+      await until(t, () => t.frame().includes("Ready") && t.frame().includes("OldPlugin"))
+
+      await switchToCoder(t)
+      await until(t, () => process.env.HERMES_HOME === fx.coder && t.frame().includes("Failed to start session: boot exploded"))
+
+      expect(aborts).toBeGreaterThan(0)
+      expect(t.frame()).not.toContain("OldPlugin")
+      await act(async () => { await t.keys.typeText("should not submit") })
+      act(() => t.keys.pressEnter())
+      await t.settle()
+      expect(gw.calls.filter(c => c.method === "prompt.submit")).toHaveLength(0)
+    } finally {
+      restore(fx)
+    }
+  })
+})

--- a/test/rehome.test.ts
+++ b/test/rehome.test.ts
@@ -155,6 +155,26 @@ describe("rehome", () => {
     }
   })
 
+  test("closes the state-db worker", async () => {
+    const dbio = await import("../src/io")
+    const close = spyOn(dbio, "close")
+    try {
+      rehome(A)
+      expect(close).toHaveBeenCalledTimes(1)
+    } finally {
+      close.mockRestore()
+    }
+  })
+
+  test("clears pending spawn history before the next profile session", async () => {
+    const hist = await import("../src/app/spawnHistory")
+    const calls: unknown[] = []
+    hist.record("start", { subagent_id: "old", task_index: 0, goal: "old work" })
+    rehome(B)
+    hist.flush({ request: (_method: string, params?: unknown) => { calls.push(params); return Promise.resolve({}) } } as never, "new-sid")
+    expect(calls).toEqual([])
+  })
+
   test("preferences.reload notifies usePref subscribers", async () => {
     const prefs = await import("../src/context/preferences")
     let rev = -1


### PR DESCRIPTION
## Context
Switching Herm profiles needs to replace every profile-owned runtime surface together. If gateway, dialogs, command palette state, plugins, background hooks, or direct Hermes home readers survive a profile switch, prompts and UI state can leak across profiles or keep talking to stale workers.

## Summary
- Remounts the Gateway/Dialog/Command/Plugin/Background/App runtime under a keyed profile boundary.
- Rebinds direct Hermes-home readers with `rehome()` and closes worker, spawn-history, and session caches during profile switches.
- Keeps failed post-switch boot in a coherent new-profile failure state instead of allowing stale-profile prompt submission.