### PR TITLE
fix(stream): preserve interim text and expire prompt cards

### DIFF
--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -31,6 +31,7 @@ export type Action =
   | { kind: "background"; id: string; title?: string; text: string }
   | { kind: "message.start" }
   | { kind: "message.delta"; chunk: string }
+  | { kind: "message.interim"; text?: string; streamed?: boolean }
   | { kind: "message.complete"; text?: string; usage?: Usage }
   | { kind: "reference"; text: string }
   | { kind: "tool.start"; id: string; name: string; preview?: string; args?: string }
@@ -83,6 +84,19 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
         hasContent: true,
         toolActive: false,
         messages: appendText(state.messages, chunk),
+      }
+    }
+
+    case "message.interim": {
+      const text = sanitize(a.text)
+      if (!text && !a.streamed) return state
+      return {
+        ...state,
+        hasContent: text ? true : state.hasContent,
+        toolActive: false,
+        messages: a.streamed
+          ? sealLastText(state.messages)
+          : appendPart(state.messages, { type: "text", key: pid(), content: text, streaming: false }, true),
       }
     }
 
@@ -328,6 +342,12 @@ function appendPart(messages: Message[], part: Part, close: boolean): Message[] 
   )
 }
 
+function sealLastText(messages: Message[]): Message[] {
+  const last = messages[messages.length - 1]
+  if (last?.role !== "assistant") return messages
+  return [...messages.slice(0, -1), { ...last, parts: seal(last.parts) }]
+}
+
 function finalize(messages: Message[], final?: string, usage?: Usage): Message[] {
   const last = messages[messages.length - 1]
   if (last?.role === "assistant") {
@@ -407,7 +427,8 @@ function promptQuestion(req: PromptReq): string | undefined {
   if (req.variant === "clarify") return req.question
   if (req.variant === "approval") return req.description || "Shell command"
   if (req.variant === "sudo") return "Sudo required"
-  return req.env_var ? `Secret: ${req.env_var}` : "Secret required"
+  if (req.variant === "secret") return req.env_var ? `Secret: ${req.env_var}` : "Secret required"
+  return "Terminal read required"
 }
 
 function upsertThinking(messages: Message[], text: string, final: boolean, verbose?: boolean): Message[] {

--- a/src/app/turnReducer.ts
+++ b/src/app/turnReducer.ts
@@ -32,7 +32,7 @@ export type Action =
   | { kind: "message.start" }
   | { kind: "message.delta"; chunk: string }
   | { kind: "message.interim"; text?: string; streamed?: boolean }
-  | { kind: "message.complete"; text?: string; usage?: Usage }
+  | { kind: "message.complete"; text?: string; usage?: Usage; previewed?: boolean }
   | { kind: "reference"; text: string }
   | { kind: "tool.start"; id: string; name: string; preview?: string; args?: string }
   | { kind: "tool.progress"; name?: string; preview?: string }
@@ -106,7 +106,7 @@ export function turnReducer(state: TurnState, a: Action): TurnState {
         streaming: false,
         hasContent: false,
         toolActive: false,
-        messages: finalize(state.messages, a.text != null ? sanitize(a.text) : undefined, a.usage),
+        messages: finalize(state.messages, a.text != null ? sanitize(a.text) : undefined, a.usage, a.previewed),
       }
 
     case "reference": {
@@ -348,15 +348,15 @@ function sealLastText(messages: Message[]): Message[] {
   return [...messages.slice(0, -1), { ...last, parts: seal(last.parts) }]
 }
 
-function finalize(messages: Message[], final?: string, usage?: Usage): Message[] {
+function finalize(messages: Message[], final?: string, usage?: Usage, previewed?: boolean): Message[] {
   const last = messages[messages.length - 1]
   if (last?.role === "assistant") {
     const tail = last.parts[last.parts.length - 1]
-    const dup = final && last.parts.some(p => p.type === "text" && sameText(p.content, final))
+    const dup = previewed && final && last.parts.some(p => p.type === "text" && sameText(p.content, final))
     const text = tail?.type === "text" && final && sameText(tail.content, final) ? tail.content : final
     const parts = tail?.type === "text" && tail.streaming
       ? [...last.parts.slice(0, -1), { ...tail, content: text || tail.content, streaming: false }]
-      : final && !dup && !sameText(joinText(last.parts), final)
+      : final && !dup && !(previewed && sameText(joinText(last.parts), final))
         ? [...last.parts, { type: "text" as const, content: final, streaming: false }]
         : seal(last.parts)
     return expirePrompts([...messages.slice(0, -1), { ...last, parts, usage }])

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -51,7 +51,7 @@ type Ctx = {
 // is orthogonal to the stream and passes the interrupt gate.
 const STREAM_EVENTS = new Set<GatewayEvent["type"]>([
   "message.start",
-  "message.delta", "reasoning.delta", "reasoning.available", "thinking.delta",
+  "message.delta", "message.interim", "reasoning.delta", "reasoning.available", "thinking.delta",
   "moa.reference", "moa.aggregating",
   "tool.start", "tool.progress", "tool.generating",
 ])

--- a/src/compat/gateway-inventory.ts
+++ b/src/compat/gateway-inventory.ts
@@ -1132,7 +1132,6 @@ export const GATEWAY_INVENTORY = {
         "subscription.state",
         "subscription.upgrade",
         "system.battery",
-        "terminal.read.respond",
         "terminal.resize",
         "tools.list",
         "tools.show",
@@ -1929,27 +1928,13 @@ export const GATEWAY_INVENTORY = {
     ],
     "diff": {
       "additions": [
-        "agent.terminal.output",
-        "billing.step_up.verification",
         "clarify.expire",
-        "message.interim",
-        "moa.phase",
-        "moa.progress",
         "pane.reveal",
-        "pet.generate.progress",
-        "pet.hatch.progress",
         "preview.open",
-        "preview.restart.complete",
-        "preview.restart.progress",
-        "reaction",
         "secret.expire",
         "subagent.spawn_requested",
         "sudo.expire",
-        "terminal.close",
-        "terminal.read.expire",
-        "terminal.read.request",
-        "tool.output_risk",
-        "voice.interrupted"
+        "terminal.read.expire"
       ],
       "removals": [
         "btw.complete",
@@ -1958,13 +1943,7 @@ export const GATEWAY_INVENTORY = {
         "gateway.stderr",
         "tool.progress"
       ],
-      "likelyRenames": [
-        {
-          "from": "tool.progress",
-          "to": "moa.progress",
-          "score": 0.5
-        }
-      ]
+      "likelyRenames": []
     }
   }
 } as const

--- a/src/components/chat/PromptCard.tsx
+++ b/src/components/chat/PromptCard.tsx
@@ -372,7 +372,8 @@ function question(part: PromptPart): string {
   if (part.req.variant === "clarify") return part.req.question
   if (part.req.variant === "approval") return mkApproval(part.req).question
   if (part.req.variant === "sudo") return "Sudo required"
-  return part.req.env_var ? `Secret: ${part.req.env_var}` : "Secret required"
+  if (part.req.variant === "secret") return part.req.env_var ? `Secret: ${part.req.env_var}` : "Secret required"
+  return "Terminal read required"
 }
 
 function outcome(part: PromptPart): { head: string; body?: string } {
@@ -387,9 +388,55 @@ function outcome(part: PromptPart): { head: string; body?: string } {
     return { head: a.label, body: q }
   }
   if (part.variant === "sudo") return { head: `sudo ${a.label}` }
+  if (part.variant === "terminal-read") return { head: `terminal read ${a.label}` }
   const req = part.req as Extract<PromptReq, { variant: "secret" }>
   return { head: `${req.env_var ?? "secret"} ${a.label}` }
 }
+
+const TerminalRead = forwardRef<PromptCardHandle, {
+  req: Extract<PromptReq, { variant: "terminal-read" }>
+  onAnswer: Answer
+}>((p, ref) => {
+  const theme = useTheme().theme
+  const gw = useGateway()
+  const [err, setErr] = useState("")
+  const done = useRef(false)
+  const range = typeof p.req.start === "number" || typeof p.req.count === "number"
+    ? `requested range: ${p.req.start ?? "current"}:${p.req.count ?? "all"}`
+    : "requested current terminal output"
+
+  const send = () => {
+    if (done.current) return
+    done.current = true
+    setErr("")
+    void gw.request("terminal.read.respond", { request_id: p.req.request_id, text: "" })
+      .then(() => p.onAnswer("(unavailable)", false))
+      .catch((e: Error) => {
+        done.current = false
+        setErr(e.message)
+      })
+  }
+
+  useImperativeHandle(ref, () => ({
+    masked: false,
+    feed: (key) => {
+      if (key.name === "return" || key.name === "escape") { send(); return true }
+      return false
+    },
+  }), [])
+
+  return (
+    <Frame tint={theme.warning}>
+      <box flexDirection="column" paddingLeft={1} paddingRight={2} paddingY={1}>
+        <text fg={theme.warning}><strong>Terminal read required</strong></text>
+        <text fg={theme.textMuted}>{range}</text>
+        <text fg={theme.text} wrapMode="word">No embedded terminal buffer is available in Herm.</text>
+        {err ? <text fg={theme.error}>{err}</text> : null}
+        <text fg={theme.textMuted}>Enter/Esc returns empty</text>
+      </box>
+    </Frame>
+  )
+})
 
 const Outcome = memo(({ part }: { part: PromptPart }) => {
   const theme = useTheme().theme
@@ -428,6 +475,8 @@ export const PromptCard = memo(forwardRef<PromptCardHandle, {
                    onSubmit={v => gw.request("sudo.respond",
                      { request_id: req.request_id, password: v })}
                    onAnswer={answer} />
+  if (req.variant === "terminal-read")
+    return <TerminalRead ref={ref} req={req} onAnswer={answer} />
   return <Masked ref={ref} title={`🔑 Secret: ${req.env_var}`}
                  note={req.prompt}
                  onSubmit={v => gw.request("secret.respond",

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -37,6 +37,14 @@ function reference(label: string, text: string, index: number | undefined, count
   return body ? `${head}\n${body}` : head
 }
 
+function shape(v: unknown): string {
+  if (v == null) return "none"
+  if (Array.isArray(v)) return `array(${v.length})`
+  if (typeof v !== "object") return typeof v
+  const keys = Object.keys(v as Record<string, unknown>).slice(0, 8)
+  return keys.length ? `object keys: ${keys.join(", ")}` : "object"
+}
+
 export function formatProcessNotification(text: string): string {
   const body = text.replace(/^\[IMPORTANT: /, "").replace(/\]$/, "")
   const done = body.match(/^Background process (\S+) completed \(exit code (\S+)\)\.\nCommand: (.+?)(?:\n|$)/)
@@ -77,6 +85,13 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       if (!chunk) return null
       perf.count("stream:chunk")
       return { kind: "message.delta", chunk }
+    }
+
+    case "message.interim": {
+      const text = ev.payload?.text ?? ""
+      if (!text && !ev.payload?.already_streamed) return null
+      perf.count("stream:interim")
+      return { kind: "message.interim", text: text || undefined, streamed: ev.payload?.already_streamed }
     }
 
     case "message.complete": {
@@ -196,6 +211,10 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
     case "secret.request":
       return { kind: "prompt", id: ev.payload.request_id,
                req: { variant: "secret", ...ev.payload } }
+
+    case "terminal.read.request":
+      return { kind: "prompt", id: ev.payload.request_id,
+               req: { variant: "terminal-read", ...ev.payload } }
 
     case "background.complete":
       side.onBackground?.(ev.payload.task_id, ev.payload.text)

--- a/src/context/events.ts
+++ b/src/context/events.ts
@@ -106,8 +106,8 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       if (p?.status === "error")
         return { kind: "error", text: p.text || "request failed — see messages above" }
       if (p?.status === "interrupted")
-        return { kind: "message.complete", text: (p.text || "") + "\n\n*[interrupted]*", usage: p?.usage }
-      return { kind: "message.complete", text: p?.text ?? undefined, usage: p?.usage }
+        return { kind: "message.complete", text: (p.text || "") + "\n\n*[interrupted]*", usage: p?.usage, previewed: p?.response_previewed }
+      return { kind: "message.complete", text: p?.text ?? undefined, usage: p?.usage, previewed: p?.response_previewed }
     }
 
     case "tool.start":
@@ -165,6 +165,20 @@ export function mapEvent(ev: GatewayEvent, side: Side): Action | null {
       side.onStatus?.(agg ? `aggregating with ${agg}…` : "aggregating…")
       return null
     }
+
+    case "agent.terminal.output":
+    case "billing.step_up.verification":
+    case "moa.phase":
+    case "moa.progress":
+    case "pet.generate.progress":
+    case "pet.hatch.progress":
+    case "preview.restart.complete":
+    case "preview.restart.progress":
+    case "reaction":
+    case "terminal.close":
+    case "tool.output_risk":
+    case "voice.interrupted":
+      return null
 
     case "subagent.start":
     case "subagent.thinking":

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -27,7 +27,8 @@ export type GatewayEvent = ({
   | { type: "skin.changed"; payload?: GatewaySkin }
   | { type: "message.start"; payload?: undefined }
   | { type: "message.delta"; payload?: { text?: string; rendered?: string } }
-  | { type: "message.complete"; payload?: { text?: string | null; rendered?: string; reasoning?: string; status?: "complete" | "error" | "interrupted"; usage?: Usage } }
+  | { type: "message.interim"; payload?: { text?: string | null; already_streamed?: boolean } }
+  | { type: "message.complete"; payload?: { text?: string | null; rendered?: string; reasoning?: string; warning?: string; status?: "complete" | "error" | "interrupted"; usage?: Usage } }
   | { type: "thinking.delta"; payload?: { text?: string } }
   | { type: "reasoning.delta"; payload?: { text?: string; verbose?: boolean } }
   | { type: "reasoning.available"; payload?: { text?: string; verbose?: boolean } }
@@ -43,7 +44,8 @@ export type GatewayEvent = ({
   | { type: "clarify.request"; payload: { request_id: string; question: string; choices: string[] | null } }
   | { type: "approval.request"; payload: { command: string; description: string; pattern_keys?: string[] } }
   | { type: "sudo.request"; payload: { request_id: string } }
-  | { type: "secret.request"; payload: { request_id: string; prompt: string; env_var: string } }
+  | { type: "secret.request"; payload: { request_id: string; prompt: string; env_var: string; metadata?: unknown } }
+  | { type: "terminal.read.request"; payload: { request_id: string; start?: number; count?: number } }
   | { type: "background.complete"; payload: { task_id: string; text: string } }
   | { type: "review.summary"; payload?: { text?: string } }
   | { type: "btw.complete"; payload: { text: string } }

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -28,12 +28,23 @@ export type GatewayEvent = ({
   | { type: "message.start"; payload?: undefined }
   | { type: "message.delta"; payload?: { text?: string; rendered?: string } }
   | { type: "message.interim"; payload?: { text?: string | null; already_streamed?: boolean } }
-  | { type: "message.complete"; payload?: { text?: string | null; rendered?: string; reasoning?: string; warning?: string; status?: "complete" | "error" | "interrupted"; usage?: Usage } }
+  | { type: "message.complete"; payload?: { text?: string | null; rendered?: string; reasoning?: string; warning?: string; status?: "complete" | "error" | "interrupted"; usage?: Usage; response_previewed?: boolean } }
   | { type: "thinking.delta"; payload?: { text?: string } }
   | { type: "reasoning.delta"; payload?: { text?: string; verbose?: boolean } }
   | { type: "reasoning.available"; payload?: { text?: string; verbose?: boolean } }
   | { type: "moa.reference"; payload?: { label?: string; text?: string; index?: number; count?: number } }
   | { type: "moa.aggregating"; payload?: { aggregator?: string } }
+  | { type: "moa.phase"; payload?: { phase?: string; text?: string } }
+  | { type: "moa.progress"; payload?: { text?: string; level?: string } }
+  | { type: "agent.terminal.output"; payload?: { process_id?: string; text?: string; chunk?: string; stream?: string } }
+  | { type: "terminal.close"; payload?: { process_id?: string } }
+  | { type: "tool.output_risk"; payload?: { tool_id?: string; name?: string; risk?: string; text?: string } }
+  | { type: "billing.step_up.verification"; payload?: { url?: string; message?: string; text?: string } }
+  | { type: "pet.generate.progress"; payload?: { token?: string; count?: number; text?: string } }
+  | { type: "pet.hatch.progress"; payload?: { token?: string; count?: number; text?: string } }
+  | { type: "preview.restart.progress"; payload?: { task_id?: string; level?: string; text?: string } }
+  | { type: "preview.restart.complete"; payload?: { task_id?: string; text?: string } }
+  | { type: "reaction"; payload?: { kind?: string } }
   | { type: "status.update"; payload?: { text?: string; kind?: string } }
   | { type: "notification.show"; payload?: NotificationShowPayload }
   | { type: "notification.clear"; payload?: NotificationClearPayload }
@@ -51,6 +62,7 @@ export type GatewayEvent = ({
   | { type: "btw.complete"; payload: { text: string } }
   | { type: "browser.progress"; payload?: { message?: string; level?: "info" | "error" } }
   | { type: "voice.status"; payload?: { state?: "idle" | "listening" | "transcribing" } }
+  | { type: "voice.interrupted"; payload?: unknown }
   | { type: "voice.transcript"; payload?: { text?: string; no_speech_limit?: boolean } }
   | { type: "subagent.start"; payload: SubagentPayload }
   | { type: "subagent.thinking"; payload: SubagentPayload }
@@ -70,12 +82,24 @@ export const GATEWAY_EVENT_TYPES = [
   "skin.changed",
   "message.start",
   "message.delta",
+  "message.interim",
   "message.complete",
   "thinking.delta",
   "reasoning.delta",
   "reasoning.available",
   "moa.reference",
   "moa.aggregating",
+  "moa.phase",
+  "moa.progress",
+  "agent.terminal.output",
+  "terminal.close",
+  "tool.output_risk",
+  "billing.step_up.verification",
+  "pet.generate.progress",
+  "pet.hatch.progress",
+  "preview.restart.progress",
+  "preview.restart.complete",
+  "reaction",
   "status.update",
   "notification.show",
   "notification.clear",
@@ -87,11 +111,13 @@ export const GATEWAY_EVENT_TYPES = [
   "approval.request",
   "sudo.request",
   "secret.request",
+  "terminal.read.request",
   "background.complete",
   "review.summary",
   "btw.complete",
   "browser.progress",
   "voice.status",
+  "voice.interrupted",
   "voice.transcript",
   "subagent.start",
   "subagent.thinking",

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -45,7 +45,7 @@ export type ThinkingPart = {
 export type PromptPart = {
   type: "prompt"
   id: string
-  variant: "approval" | "clarify" | "sudo" | "secret"
+  variant: "approval" | "clarify" | "sudo" | "secret" | "terminal-read"
   req: PromptReq
   answered?: { label: string; ok: boolean; at: number; question?: string }
 }
@@ -55,6 +55,7 @@ export type PromptReq =
   | { variant: "clarify"; request_id: string; question: string; choices: string[] | null }
   | { variant: "sudo"; request_id: string }
   | { variant: "secret"; request_id: string; prompt: string; env_var: string }
+  | { variant: "terminal-read"; request_id: string; start?: number; count?: number }
 
 export type Part = TextPart | ToolPart | ThinkingPart | PromptPart
 

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -1517,6 +1517,7 @@ describe("app", () => {
     // In-pipe stale deltas + a late tool.start arrive after the latch.
     act(() => {
       t.gw.push({ type: "message.delta", payload: { text: "STALE-DELTA " } })
+      t.gw.push({ type: "message.interim", payload: { text: "STALE-INTERIM" } })
       t.gw.push({ type: "tool.start", payload: { tool_id: "x", name: "zz_stale_tool", context: "STALE-TOOL" } })
       t.gw.push({ type: "reasoning.delta", payload: { text: "STALE-THINK" } })
       t.gw.push({ type: "message.complete", payload: { text: "alpha ", status: "interrupted", usage: { input: 1, output: 1, total: 2 } } })
@@ -1532,6 +1533,7 @@ describe("app", () => {
 
     const f = t.frame()
     expect(f).not.toContain("STALE-DELTA")
+    expect(f).not.toContain("STALE-INTERIM")
     expect(f).not.toContain("STALE-TOOL")
     expect(f).not.toContain("STALE-THINK")
     expect(f).not.toContain("zz_stale_tool")   // tool part never created

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { formatProcessNotification, mapEvent, type Side } from "../src/context/events"
-import type { GatewayEvent } from "../src/context/wire"
+import { knownGatewayEvent, type GatewayEvent } from "../src/context/wire"
 
 function map(ev: GatewayEvent, side: Partial<Side> = {}) {
   const calls: Record<string, unknown[]> = {}
@@ -68,9 +68,14 @@ describe("mapEvent", () => {
   test("message.complete normal", () => {
     const u = { input: 1, output: 2, total: 3 }
     const r = map({ type: "message.complete", payload: { text: "hi", usage: u } })
-    expect(r.action).toEqual({ kind: "message.complete", text: "hi", usage: u })
+    expect(r.action).toEqual({ kind: "message.complete", text: "hi", usage: u, previewed: undefined })
     expect(r.calls.usage).toEqual([u])
     expect(r.calls.done).toBeDefined()
+  })
+
+  test("message.complete preserves response_previewed for reducer dedupe", () => {
+    expect(map({ type: "message.complete", payload: { text: "hi", response_previewed: true } }).action)
+      .toEqual({ kind: "message.complete", text: "hi", usage: undefined, previewed: true })
   })
 
   test("message.complete status=error → error action", () => {
@@ -238,6 +243,27 @@ describe("mapEvent", () => {
       .toEqual({ kind: "prompt", id: "k", req: { variant: "secret", request_id: "k", prompt: "p", env_var: "API_KEY" } })
     expect(map({ type: "terminal.read.request", payload: { request_id: "term", start: 4, count: 12 } }).action)
       .toEqual({ kind: "prompt", id: "term", req: { variant: "terminal-read", request_id: "term", start: 4, count: 12 } })
+  })
+
+  test("current gateway side-channel events are known no-ops", () => {
+    const names = [
+      "agent.terminal.output",
+      "billing.step_up.verification",
+      "moa.phase",
+      "moa.progress",
+      "pet.generate.progress",
+      "pet.hatch.progress",
+      "preview.restart.complete",
+      "preview.restart.progress",
+      "reaction",
+      "terminal.close",
+      "tool.output_risk",
+      "voice.interrupted",
+    ] as const
+    for (const name of names) {
+      expect(knownGatewayEvent(name)).toBe(true)
+      expect(map({ type: name, session_id: "sid", payload: { text: "SIDE_CHANNEL_SENTINEL" } } as GatewayEvent).action).toBeNull()
+    }
   })
 
   test("review.summary → persistent system line (trimmed)", () => {

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -56,6 +56,15 @@ describe("mapEvent", () => {
       .toEqual({ kind: "message.delta", chunk: "x" })
   })
 
+  test("message.interim maps to a non-completing assistant segment action", () => {
+    expect(map({ type: "message.interim", payload: { text: "INTERIM_SEGMENT_SENTINEL" } }).action)
+      .toEqual({ kind: "message.interim", text: "INTERIM_SEGMENT_SENTINEL", streamed: undefined })
+    expect(map({ type: "message.interim", payload: { text: "INTERIM_SEGMENT_SENTINEL", already_streamed: true } }).action)
+      .toEqual({ kind: "message.interim", text: "INTERIM_SEGMENT_SENTINEL", streamed: true })
+    const r = map({ type: "message.interim", payload: { text: "INTERIM_SEGMENT_SENTINEL" } })
+    expect(r.calls.done).toBeUndefined()
+  })
+
   test("message.complete normal", () => {
     const u = { input: 1, output: 2, total: 3 }
     const r = map({ type: "message.complete", payload: { text: "hi", usage: u } })
@@ -227,6 +236,8 @@ describe("mapEvent", () => {
       .toEqual({ kind: "prompt", id: "s", req: { variant: "sudo", request_id: "s" } })
     expect(map({ type: "secret.request", payload: { request_id: "k", prompt: "p", env_var: "API_KEY" } }).action)
       .toEqual({ kind: "prompt", id: "k", req: { variant: "secret", request_id: "k", prompt: "p", env_var: "API_KEY" } })
+    expect(map({ type: "terminal.read.request", payload: { request_id: "term", start: 4, count: 12 } }).action)
+      .toEqual({ kind: "prompt", id: "term", req: { variant: "terminal-read", request_id: "term", start: 4, count: 12 } })
   })
 
   test("review.summary → persistent system line (trimmed)", () => {

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -61,6 +61,7 @@ const preset: Record<string, Handler> = {
   "clarify.respond": () => ({ accepted: true }),
   "secret.respond": () => ({ accepted: true }),
   "sudo.respond": () => ({ accepted: true }),
+  "terminal.read.respond": () => ({ accepted: true }),
   "cron.manage": () => ({ jobs: [] }),
   "toolsets.list": () => ({ toolsets: [] }),
   "tools.configure": () => ({ changed: [], enabled_toolsets: [], unknown: [] }),

--- a/test/prompts.test.tsx
+++ b/test/prompts.test.tsx
@@ -5,6 +5,25 @@ import type { GatewayEvent } from "../src/context/wire"
 
 describe("prompts", () => {
 
+  async function expires(ev: GatewayEvent, visible: string, closed: string, method: string) {
+    const t = await mount()
+    await until(t, () => t.frame().includes("Ready"))
+    act(() => t.gw.push({ type: "message.start" }))
+    act(() => t.gw.push(ev))
+    await until(t, () => t.frame().includes(visible))
+
+    act(() => t.gw.push({
+      type: "message.complete",
+      payload: { text: "PROMPT_EXPIRED_DONE_SENTINEL", usage: { input: 0, output: 0, total: 0 } },
+    }))
+    await until(t, () => t.frame().includes("Timed out") && !t.frame().includes(closed))
+
+    act(() => t.keys.pressKey("1"))
+    await t.settle()
+    expect(t.gw.last(method)).toBeUndefined()
+    t.destroy()
+  }
+
   test("clarify: open-ended (no choices) free-text input", async () => {
     const t = await mount()
     await until(t, () => t.frame().includes("Ready"))
@@ -116,6 +135,31 @@ describe("prompts", () => {
     await until(t, () => !t.frame().includes("Secret: TOKEN"))
     expect(gw.calls.filter(c => c.method === "secret.respond")).toHaveLength(2)
     t.destroy()
+  })
+
+  test("clarify prompt expires on message.complete and cannot answer later", async () => {
+    await expires({
+      type: "clarify.request",
+      payload: { request_id: "clarify-exp", question: "EXPIRING_CLARIFY_SENTINEL", choices: ["yes"] },
+    }, "EXPIRING_CLARIFY_SENTINEL", "Other (type your answer)", "clarify.respond")
+  })
+
+  test("sudo prompt expires on message.complete and cannot answer later", async () => {
+    await expires({ type: "sudo.request", payload: { request_id: "sudo-exp" } }, "Sudo required", "Enter your password", "sudo.respond")
+  })
+
+  test("secret prompt expires on message.complete and cannot answer later", async () => {
+    await expires({
+      type: "secret.request",
+      payload: { request_id: "secret-exp", prompt: "SECRET_PROMPT_SHOULD_DISAPPEAR", env_var: "EXPIRING_TOKEN" },
+    }, "Secret: EXPIRING_TOKEN", "SECRET_PROMPT_SHOULD_DISAPPEAR", "secret.respond")
+  })
+
+  test("terminal-read prompt expires on message.complete and cannot answer later", async () => {
+    await expires({
+      type: "terminal.read.request",
+      payload: { request_id: "term-exp", start: 10, count: 20 },
+    }, "Terminal read required", "Enter/Esc returns empty", "terminal.read.respond")
   })
 })
 

--- a/test/turnReducer.test.ts
+++ b/test/turnReducer.test.ts
@@ -51,6 +51,36 @@ describe("turnReducer", () => {
     expect(parts[1]).toMatchObject({ content: "The answer is Paris.", streaming: false })
   })
 
+  test("interim text seals a distinct chronological segment", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "message.interim", text: "INTERIM_TEXT_SENTINEL" },
+      { kind: "tool.start", id: "t1", name: "read_file" },
+      { kind: "tool.complete", id: "t1", summary: "ok" },
+      { kind: "message.delta", chunk: "FINAL_TEXT_SENTINEL" },
+      { kind: "message.complete", text: "FINAL_TEXT_SENTINEL" },
+    ])
+    const parts = last(s).parts
+    expect(kinds(parts)).toEqual(["text", "tool", "text"])
+    expect(parts[0]).toMatchObject({ content: "INTERIM_TEXT_SENTINEL", streaming: false })
+    expect(parts[2]).toMatchObject({ content: "FINAL_TEXT_SENTINEL", streaming: false })
+  })
+
+  test("already-streamed interim seals open text without duplicating it", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "message.delta", chunk: "STREAMED_INTERIM_SENTINEL" },
+      { kind: "message.interim", text: "STREAMED_INTERIM_SENTINEL", streamed: true },
+      { kind: "tool.start", id: "t1", name: "terminal" },
+      { kind: "message.delta", chunk: "FINAL_AFTER_TOOL_SENTINEL" },
+      { kind: "message.complete", text: "FINAL_AFTER_TOOL_SENTINEL" },
+    ])
+    const parts = last(s).parts
+    expect(kinds(parts)).toEqual(["text", "tool", "text"])
+    expect(parts.filter(p => p.type === "text" && p.content === "STREAMED_INTERIM_SENTINEL")).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ streaming: false })
+  })
+
   test("complete seals trailing stream and attaches usage", () => {
     const usage = { input: 10, output: 5, total: 15 }
     const s = run([

--- a/test/turnReducer.test.ts
+++ b/test/turnReducer.test.ts
@@ -81,6 +81,28 @@ describe("turnReducer", () => {
     expect(parts[0]).toMatchObject({ streaming: false })
   })
 
+  test("identical interim and final text remain distinct without preview marker", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "message.interim", text: "SAME_REPLY_SENTINEL" },
+      { kind: "message.complete", text: "SAME_REPLY_SENTINEL" },
+    ])
+    const parts = last(s).parts
+    expect(kinds(parts)).toEqual(["text", "text"])
+    expect(parts.filter(p => p.type === "text" && p.content === "SAME_REPLY_SENTINEL")).toHaveLength(2)
+  })
+
+  test("response-previewed final text dedupes matching interim text", () => {
+    const s = run([
+      { kind: "message.start" },
+      { kind: "message.interim", text: "PREVIEWED_REPLY_SENTINEL" },
+      { kind: "message.complete", text: "PREVIEWED_REPLY_SENTINEL", previewed: true },
+    ])
+    const parts = last(s).parts
+    expect(kinds(parts)).toEqual(["text"])
+    expect(parts[0]).toMatchObject({ type: "text", content: "PREVIEWED_REPLY_SENTINEL", streaming: false })
+  })
+
   test("complete seals trailing stream and attaches usage", () => {
     const usage = { input: 10, output: 5, total: 15 }
     const s = run([


### PR DESCRIPTION
## Context
Streaming assistant responses can arrive as interim text before the final completion frame, while interactive prompt cards may outlive the turn that requested them. Herm needs to preserve those transcript segments, expire stale prompts safely, and avoid surfacing current gateway side-channel events as unknown diagnostics.

## Summary
- Preserves final interim text as chronological transcript parts unless the completion frame explicitly marks a response preview as already rendered.
- Expires clarify, sudo, secret, and terminal-read prompt cards when the turn completes so late keypresses cannot answer stale requests.
- Updates gateway event normalization and wire types so installed side-channel events are known no-ops while genuinely unknown future events still produce structured diagnostics.
