### PR TITLE
fix(gateway): log unknown event diagnostics

### DIFF
--- a/src/app/bridge.ts
+++ b/src/app/bridge.ts
@@ -11,6 +11,7 @@ import { useRenderer } from "@opentui/react"
 import { CHAT_TAB } from "./tabs"
 import type { Action, TurnState } from "./turnReducer"
 import type { ComposerHandle } from "../components/chat/Composer"
+import type { GatewayEvent } from "../context/wire"
 
 type Region = "input" | "content"
 
@@ -61,7 +62,11 @@ export function useBridge(o: {
       renderer: () => renderer,
       logs: (n?: number) => gw.tail(n),
       plugin: (id, on) => on ? plugins.activate(id) : plugins.deactivate(id),
-      push: ev => (gw as unknown as { emit: (t: string, e: unknown) => void }).emit("event", ev),
+      push: ev => {
+        const e = ev as GatewayEvent
+        gw.diagnose?.(e, "control")
+        gw.emit("event", e)
+      },
     })
   }, [gw, renderer, plugins])
 }

--- a/src/context/gateway-client.ts
+++ b/src/context/gateway-client.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from "events"
 import { homedir } from "os"
 import { resolve, delimiter } from "path"
 import { existsSync } from "fs"
-import type { GatewayEvent } from "./wire"
+import { knownGatewayEvent, type GatewayEvent } from "./wire"
 import { encode } from "../utils/unicode"
 
 const LOG_MAX = 200
@@ -17,6 +17,14 @@ const WS_OPEN = 1
 const WS_CLOSING = 2
 const WS_CLOSED = 3
 const decoder = new TextDecoder()
+
+export type GatewayEventSource = "stdio" | "websocket" | "control" | "internal"
+
+type Diag = {
+  count: number
+  index: number
+  line: (count: number) => string
+}
 
 /** Locate the hermes-agent source tree (gateway + hermes_cli live here).
  *  Default: ~/.hermes/hermes-agent (where `hermes update` installs it).
@@ -101,6 +109,56 @@ function text(raw: unknown): string | null {
   return null
 }
 
+function rec(v: unknown): Record<string, unknown> | null {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>
+  return null
+}
+
+function crop(s: string): string {
+  return s.length > LOG_PREVIEW ? `${s.slice(0, LOG_PREVIEW)}…` : s
+}
+
+function clean(v: unknown, depth: number, seen: WeakSet<object>): unknown {
+  if (v === null || typeof v === "number" || typeof v === "boolean") return v
+  if (typeof v === "string") return crop(v)
+  if (v === undefined) return "[undefined]"
+  if (typeof v !== "object") return `[${typeof v}]`
+  if (seen.has(v)) return "[circular]"
+  if (depth >= 3) return "[depth]"
+  seen.add(v)
+  if (Array.isArray(v)) {
+    const vals = v.slice(0, 6).map(x => clean(x, depth + 1, seen))
+    return v.length > vals.length ? [...vals, `…+${v.length - vals.length}`] : vals
+  }
+  const out: Record<string, unknown> = {}
+  for (const [key, val] of Object.entries(v).slice(0, 12)) {
+    out[key] = /token|secret|password|credential|authorization|api[_-]?key|cookie|private[_-]?key/i.test(key)
+      ? "[redacted]"
+      : clean(val, depth + 1, seen)
+  }
+  const extra = Object.keys(v).length - Object.keys(out).length
+  if (extra > 0) out["…"] = `+${extra}`
+  return out
+}
+
+function payload(ev: GatewayEvent): string {
+  const obj = rec(ev)
+  if (!obj || !("payload" in obj)) return "(none)"
+  try { return crop(JSON.stringify(clean(obj.payload, 0, new WeakSet()))) }
+  catch { return "[unserializable]" }
+}
+
+function contract(ev: GatewayEvent): string {
+  const obj = rec(ev)
+  const body = rec(obj?.payload)
+  const raw = obj?.contract_version
+    ?? obj?.contractVersion
+    ?? body?.contract_version
+    ?? body?.contractVersion
+    ?? rec(body?.contract)?.version
+  return raw === undefined || raw === null ? "unknown" : crop(String(raw))
+}
+
 // Read lines from a ReadableStream (Bun subprocess stdout/stderr)
 async function lines(stream: ReadableStream<Uint8Array>, cb: (line: string) => void) {
   const reader = stream.getReader()
@@ -131,6 +189,7 @@ export class GatewayClient extends EventEmitter {
   private target: string | null = null
   private id = 0
   private logs: string[] = []
+  private unknown = new Map<string, Diag>()
   private pending = new Map<string, Pending>()
   private buf: GatewayEvent[] = []
   private exit: number | null | undefined
@@ -140,7 +199,8 @@ export class GatewayClient extends EventEmitter {
 
   private root(): string { return hermesAgentRoot() }
 
-  private push(ev: GatewayEvent) {
+  private push(ev: GatewayEvent, source: GatewayEventSource = "internal") {
+    this.diagnose(ev, source)
     if (ev.type === "gateway.ready") {
       this.ok = true
       if (this.timer) { clearTimeout(this.timer); this.timer = null }
@@ -149,11 +209,36 @@ export class GatewayClient extends EventEmitter {
     this.buf.push(ev)
   }
 
-  private log(line: string) {
-    if (this.logs.push(line) > LOG_MAX) this.logs.splice(0, this.logs.length - LOG_MAX)
+  private log(line: string): number {
+    if (this.logs.push(line) > LOG_MAX) {
+      const cut = this.logs.length - LOG_MAX
+      this.logs.splice(0, cut)
+      for (const d of this.unknown.values()) d.index -= cut
+    }
+    return this.logs.length - 1
   }
 
-  private dispatch(msg: Record<string, unknown>) {
+  diagnose(ev: GatewayEvent, source: GatewayEventSource = "control") {
+    try {
+      if (knownGatewayEvent(ev.type)) return
+      const version = contract(ev)
+      const key = `${source}\u0000${version}\u0000${ev.type}`
+      const old = this.unknown.get(key)
+      if (old && old.index >= 0 && old.index < this.logs.length) {
+        old.count++
+        this.logs[old.index] = old.line(old.count)
+        return
+      }
+      const summary = payload(ev)
+      const line = (count: number) => `[event unknown] type=${ev.type} source=${source} contract=${version} count=${count} payload=${summary}`
+      this.unknown.set(key, { count: 1, index: this.log(line(1)), line })
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err)
+      this.log(`[event diagnostic_failed] source=${source} error=${crop(text)}`)
+    }
+  }
+
+  private dispatch(msg: Record<string, unknown>, source: GatewayEventSource = "stdio") {
     const id = msg.id as string | undefined
     const p = id ? this.pending.get(id) : undefined
 
@@ -170,7 +255,7 @@ export class GatewayClient extends EventEmitter {
 
     if (msg.method === "event") {
       const ev = asEvent(msg.params)
-      if (ev) this.push(ev)
+      if (ev) this.push(ev, source)
     }
   }
 
@@ -243,7 +328,7 @@ export class GatewayClient extends EventEmitter {
       if (this.ws !== ws) return
       const raw = text(event.data)
       if (!raw) return
-      try { this.dispatch(JSON.parse(raw)) }
+      try { this.dispatch(JSON.parse(raw), "websocket") }
       catch {
         const preview = raw.trim().slice(0, LOG_PREVIEW) || "(empty)"
         this.log(`[protocol] malformed websocket: ${preview}`)
@@ -349,7 +434,7 @@ export class GatewayClient extends EventEmitter {
       lines(proc.stdout as ReadableStream<Uint8Array>, raw => {
         if (this.proc !== proc) return
         try {
-          this.dispatch(JSON.parse(raw))
+          this.dispatch(JSON.parse(raw), "stdio")
         } catch {
           const preview = raw.trim().slice(0, LOG_PREVIEW) || "(empty)"
           this.log(`[protocol] malformed: ${preview}`)

--- a/src/context/gateway.tsx
+++ b/src/context/gateway.tsx
@@ -5,7 +5,7 @@
 import { createContext, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react"
 import type { ReactNode } from "react"
 import { EventEmitter } from "events"
-import { GatewayClient } from "../context/gateway-client"
+import { GatewayClient, type GatewayEventSource } from "../context/gateway-client"
 import type { GatewayEvent } from "../context/wire"
 
 /** Minimal surface consumers depend on. GatewayClient satisfies this. */
@@ -16,6 +16,7 @@ export interface Gateway extends EventEmitter {
   drain(): void
   kill(): void
   tail(n?: number): string
+  diagnose?(ev: GatewayEvent, source?: GatewayEventSource): void
   readonly ready: boolean
 }
 

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -58,6 +58,53 @@ export type GatewayEvent = ({
   | { type: "error"; payload?: { message?: string } }
 ))
 
+export const GATEWAY_EVENT_TYPES = [
+  "gateway.ready",
+  "gateway.stderr",
+  "gateway.start_timeout",
+  "gateway.protocol_error",
+  "session.info",
+  "session.title",
+  "skin.changed",
+  "message.start",
+  "message.delta",
+  "message.complete",
+  "thinking.delta",
+  "reasoning.delta",
+  "reasoning.available",
+  "moa.reference",
+  "moa.aggregating",
+  "status.update",
+  "notification.show",
+  "notification.clear",
+  "tool.start",
+  "tool.progress",
+  "tool.generating",
+  "tool.complete",
+  "clarify.request",
+  "approval.request",
+  "sudo.request",
+  "secret.request",
+  "background.complete",
+  "review.summary",
+  "btw.complete",
+  "browser.progress",
+  "voice.status",
+  "voice.transcript",
+  "subagent.start",
+  "subagent.thinking",
+  "subagent.tool",
+  "subagent.progress",
+  "subagent.complete",
+  "error",
+] as const satisfies readonly GatewayEvent["type"][]
+
+const EVENT_TYPES = new Set<string>(GATEWAY_EVENT_TYPES)
+
+export function knownGatewayEvent(type: string): type is GatewayEvent["type"] {
+  return EVENT_TYPES.has(type)
+}
+
 export type SubagentPayload = {
   task_index: number
   goal: string

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { delimiter, join, resolve } from "path"
 import { tmpdir } from "os"
 import { GatewayClient, gatewayUrl, hermesAgentRoot, python, websocketUrl } from "../src/context/gateway-client"
+import type { GatewayEvent } from "../src/context/wire"
 
 class FakeSocket extends EventTarget {
   static list: FakeSocket[] = []
@@ -532,5 +533,62 @@ describe("GatewayClient websocket attach mode", () => {
       .toBe("ws://127.0.0.1:9119/api/ws?token=abc")
     expect(() => websocketUrl("ftp://gateway.test/?token=abc"))
       .toThrow("unsupported gateway URL protocol: ftp:")
+  })
+})
+
+const ev = (value: unknown) => value as GatewayEvent
+
+describe("GatewayClient diagnostics", () => {
+  test("unknown gateway events enter structured redacted diagnostics", () => {
+    const gw = new GatewayClient()
+    gw.diagnose(ev({
+      type: "future.event",
+      contract_version: 4,
+      payload: {
+        text: "visible",
+        token: "SECRET_TOKEN_SENTINEL",
+        nested: { password: "SECRET_PASSWORD_SENTINEL" },
+      },
+    }), "stdio")
+
+    const log = gw.tail(5)
+    expect(log).toContain("[event unknown]")
+    expect(log).toContain("type=future.event")
+    expect(log).toContain("source=stdio")
+    expect(log).toContain("contract=4")
+    expect(log).toContain("count=1")
+    expect(log).toContain("visible")
+    expect(log).toContain("[redacted]")
+    expect(log).not.toContain("SECRET_TOKEN_SENTINEL")
+    expect(log).not.toContain("SECRET_PASSWORD_SENTINEL")
+  })
+
+  test("repeated unknown events update the first diagnostic with aggregate count", () => {
+    const gw = new GatewayClient()
+    gw.diagnose(ev({ type: "future.repeat", payload: { marker: "FIRST_PAYLOAD" } }), "websocket")
+    gw.diagnose(ev({ type: "future.repeat", payload: { marker: "SECOND_PAYLOAD" } }), "websocket")
+    gw.diagnose(ev({ type: "future.repeat", payload: { marker: "THIRD_PAYLOAD" } }), "websocket")
+
+    const rows = gw.tail(10).split("\n").filter(Boolean)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toContain("count=3")
+    expect(rows[0]).toContain("FIRST_PAYLOAD")
+    expect(rows[0]).not.toContain("SECOND_PAYLOAD")
+    expect(rows[0]).not.toContain("THIRD_PAYLOAD")
+  })
+
+  test("known intentionally ignored events are not classified as unknown", () => {
+    const gw = new GatewayClient()
+    gw.diagnose(ev({ type: "session.title", payload: { session_id: "s", title: "t" } }), "control")
+    gw.diagnose(ev({ type: "voice.status", payload: { state: "idle" } }), "control")
+    expect(gw.tail(10)).not.toContain("[event unknown]")
+  })
+
+  test("diagnostics cannot crash on circular payloads", () => {
+    const payload: Record<string, unknown> = { text: "safe" }
+    payload.self = payload
+    const gw = new GatewayClient()
+    expect(() => gw.diagnose(ev({ type: "future.circular", payload }), "control")).not.toThrow()
+    expect(gw.tail(5)).toContain("[circular]")
   })
 })

--- a/test/gatewayEvents.test.ts
+++ b/test/gatewayEvents.test.ts
@@ -180,6 +180,12 @@ describe("mapEvent", () => {
       .toEqual({ kind: "system", text: "protocol error: bad" })
   })
 
+  test("unknown event is diagnostic-only for transcript/session mapping", () => {
+    const r = map({ type: "future.event", payload: { text: "ignored" } } as unknown as GatewayEvent)
+    expect(r.action).toBeNull()
+    expect(r.calls).toEqual({})
+  })
+
   test("thinking.delta is status-only; reasoning.* → thinking action", () => {
     const r = map({ type: "thinking.delta", payload: { text: "(•_•) formulating" } })
     expect(r.action).toBeNull()


### PR DESCRIPTION
## Context
Unknown gateway event frames were being ignored silently, which made backend/client protocol drift hard to diagnose from Herm logs.

## Summary
- Adds structured diagnostics for unknown gateway events without changing transcript or session handling
- Tracks the first unknown payload with bounded redaction and increments repeat counts
- Keeps known intentionally ignored event types out of the unknown-event diagnostic path
