### PR TITLE
feat: track Hermes backend contract

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -58,6 +58,7 @@ import { sessionCapabilities } from "./app/sessionCapabilities"
 import { useGitBranch } from "./utils/git"
 import type { HermPlugin } from "./plugins/types"
 import { useMessageActions } from "./app/useMessageActions"
+import { backend } from "./context/backend-contract"
 
 type AppProps = {
   initialTheme?: string
@@ -111,7 +112,6 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [starting, setStarting] = useState(false)
   const startRef = useRef(starting); startRef.current = starting
   const active = turn.streaming || starting
-  const capabilities = sessionCapabilities({ sid, ready, streaming: active })
   const [tab, setTab] = useState(CHAT_TAB)
   // Sub-tab per group — Chat has none, so key 0 is unused.
   // Defensive clamp lives inside each group (SessionsGroup/Automation/
@@ -132,6 +132,15 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const [hideSidebar, setHideSidebar] = useState(false)
   const [usage, setUsage] = useState<Usage | undefined>(undefined)
   const [info, setInfo] = useState<SessionInfo | null>(null)
+  const [contract, setContract] = useState(() => backend.backendContract(null))
+  const recordInfo = useCallback((next: SessionInfo | null) => {
+    setInfo(next)
+    setContract(prev => {
+      const state = backend.backendContract(next)
+      return state.reason === "missing" && prev.supported ? prev : state
+    })
+  }, [])
+  const capabilities = sessionCapabilities({ sid, ready, streaming: active, contract })
   const [title, setTitle] = useState("")
   const caption = title.trim()
   const titleRef = useRef(caption); titleRef.current = caption
@@ -392,7 +401,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
 
   const stream = useStream({
     dispatch, session, launchRef, sidRef, sessionStart, goalHook,
-    setSid, setDurable, setInfo, setReady, setTitle, setBusy, setStarting, setUsage, setStatus, setSkin, setErrorPulse, settle,
+    setSid, setDurable, setInfo: recordInfo, setReady, setTitle, setBusy, setStarting, setUsage, setStatus, setSkin, setErrorPulse, settle,
     onVoiceStatus: state => {
       voice.setRecording(state === "listening" || state === "recording")
       voice.setProcessing(state === "transcribing" || state === "processing")
@@ -446,7 +455,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setSid(r.id)
       setDurable(r.key)
       launchRef.current = { mode: "resume", sid: r.key, splash: false }
-      if (r.info) { setInfo(r.info); setUsage(r.info.usage) }
+      if (r.info) { recordInfo(r.info); setUsage(r.info.usage) }
       setReady(true)
       setStarting(false)
       setStatus("")
@@ -483,7 +492,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setDurable(res.key)
       launchRef.current = { mode: "resume", sid: res.key, splash: false }
       if (res.info) {
-        setInfo(res.info)
+        recordInfo(res.info)
         setUsage(res.info.usage)
       }
       setReady(true)
@@ -533,7 +542,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
       setDurable(res.key)
       launchRef.current = { mode: "resume", sid: res.key, splash: false }
       if (res.info) {
-        setInfo(res.info)
+        recordInfo(res.info)
         setUsage(res.info.usage)
       }
       sessionStart.current = res.startedAt ?? Date.now()
@@ -571,7 +580,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
     gw.setSession("")
     setSid("")
     setDurable("")
-    setInfo(null)
+    recordInfo(null)
     setSkin(deriveSkin(undefined))
     // Fresh gateway boots behind the splash (same as cold launch); the
     // respawned process emits gateway.ready → session.info → onSend
@@ -627,7 +636,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   const slash = useSlash({
     dispatch, session, turnRef, queueRef, sendRef, composer, summoned, undone,
     capabilities, info, sid, resumeId: durable || sid, title: caption, skin,
-    setQueue, setFocusRegion, setSplash, setAttachments: updateAttachments, setInfo, setUsage, setTitle,
+    setQueue, setFocusRegion, setSplash, setAttachments: updateAttachments, setInfo: recordInfo, setUsage, setTitle,
     newSession, switchSession, activateSession, rewind, goTo, attachClipboard, voiceToggle: voice.toggle,
   })
   const send = useCallback(async (raw: string) => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -734,6 +734,14 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
   }, [gw, slash, toast, updateAttachments])
   sendRef.current = send
 
+  const blocked = useCallback(() => {
+    const msg = capabilities.contractMessage
+    if (!msg) return
+    const text = `${msg} Blocked prompt.submit.`
+    dispatch({ kind: "system", text: `submit failed: ${text}` })
+    toast.show({ variant: "error", message: text })
+  }, [capabilities.contractMessage, toast])
+
   // Shell mode submit — `shell.exec` is a plain subprocess (no pty,
   // 30s cap, gateway cwd) with detect_dangerous_command blocklist.
   // Output lands in the transcript as $ cmd / stdout system messages,
@@ -1011,6 +1019,7 @@ const AppInner = ({ launch: launch0 }: { launch: Launch }) => {
                 onAttachClipboard={attachClipboard}
                 onEnqueue={onEnqueue}
                 onDequeue={dequeue}
+                onSubmitBlocked={blocked}
                 onDirty={setComposing}
                 onEmptyEnter={onEmptyEnter}
               />

--- a/src/app/sessionCapabilities.ts
+++ b/src/app/sessionCapabilities.ts
@@ -1,12 +1,21 @@
+import { backend, type BackendContract } from "../context/backend-contract"
+
 export type SessionCapabilityInput = {
   sid?: string | null
   ready: boolean
   streaming: boolean
+  contract?: BackendContract | null
 }
 
 export type SessionCapabilities = {
   sessionConnected: boolean
   metadataHydrated: boolean
+  minContract: number
+  maxContract: number
+  observedContract?: number
+  contractSupported: boolean
+  contractReason: BackendContract["reason"]
+  contractMessage?: string
   canSubmitPrompt: boolean
   canDispatchGatewayCommand: boolean
   canDrainQueue: boolean
@@ -15,12 +24,20 @@ export type SessionCapabilities = {
 export function sessionCapabilities(input: SessionCapabilityInput): SessionCapabilities {
   const sessionConnected = Boolean(input.sid)
   const metadataHydrated = input.ready
+  const contract = input.contract ?? backend.backendContract(null)
+  const ok = contract.supported
 
   return {
     sessionConnected,
     metadataHydrated,
-    canSubmitPrompt: sessionConnected,
-    canDispatchGatewayCommand: sessionConnected,
-    canDrainQueue: sessionConnected && !input.streaming,
+    minContract: contract.minContract,
+    maxContract: contract.maxContract,
+    observedContract: contract.observedContract,
+    contractSupported: ok,
+    contractReason: contract.reason,
+    contractMessage: ok ? undefined : backend.contractMessage(contract),
+    canSubmitPrompt: sessionConnected && ok,
+    canDispatchGatewayCommand: sessionConnected && ok,
+    canDrainQueue: sessionConnected && ok && !input.streaming,
   }
 }

--- a/src/app/slash.tsx
+++ b/src/app/slash.tsx
@@ -584,7 +584,15 @@ export function useSlash(c: SlashCtx): (cmd: SlashCommand, arg?: string) => void
           return
       }
     }
-    if (c.target !== "gateway" || !x.capabilities.canDispatchGatewayCommand) return
+    if (c.target !== "gateway") return
+    if (!x.capabilities.canDispatchGatewayCommand) {
+      const msg = x.capabilities.contractMessage
+      if (!msg) return
+      const text = `${msg} Blocked slash.exec.`
+      x.dispatch({ kind: "system", text: `error: ${text}` })
+      toast.show({ variant: "error", message: text })
+      return
+    }
     const jump = TAB_SLASH[c.name]
     if (jump !== undefined && !arg) { x.goTo(jump.tab, jump.sub); return }
     const full = `/${c.name}${arg ? " " + arg : ""}`

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -76,6 +76,7 @@ type Props = {
   onAttachClipboard?: () => void
   onEnqueue?: (text: string) => void
   onDequeue?: (i: number) => void
+  onSubmitBlocked?: () => void
   /** Enter pressed with an empty buffer. Return true to consume. */
   onEmptyEnter?: () => boolean
   /** Fires on the empty↔non-empty edge of the input buffer. */
@@ -304,7 +305,8 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     }
     const text = exp.text.trim()
     if (live.current.props.streaming) {
-      if (!text || !live.current.props.canSubmitPrompt) return
+      if (!text) return
+      if (!live.current.props.canSubmitPrompt) { live.current.props.onSubmitBlocked?.(); return }
       hist.push({ input: text, parts: exp.parts })
       write("")
       // Slash-shaped input routes through onSend so send() → slash()
@@ -317,7 +319,7 @@ export const Composer = memo(forwardRef<ComposerHandle, Props>((props, ref) => {
     }
     const hasAtt = (live.current.props.attachments?.length ?? 0) > 0
     if (!text && !hasAtt) { live.current.props.onEmptyEnter?.(); return }
-    if (!live.current.props.canSubmitPrompt) return
+    if (!live.current.props.canSubmitPrompt) { live.current.props.onSubmitBlocked?.(); return }
     if (text) hist.push({ input: text, parts: exp.parts })
     write("")
     live.current.props.onSend(text, exp.parts)

--- a/src/context/backend-contract.ts
+++ b/src/context/backend-contract.ts
@@ -1,0 +1,128 @@
+export const MIN_BACKEND_CONTRACT = 4
+export const MAX_BACKEND_CONTRACT = 5
+
+export type BackendContractReason = "missing" | "malformed" | "older" | "supported" | "newer"
+
+export type BackendContract = {
+  minContract: number
+  maxContract: number
+  observedContract?: number
+  sourceRevision?: string
+  version?: string
+  releaseDate?: string
+  updateBehind?: number | null
+  updateCommand?: string
+  supported: boolean
+  reason: BackendContractReason
+}
+
+const BOOT = new Set([
+  "session.create",
+  "session.resume",
+  "session.activate",
+])
+
+const READ = new Set([
+  "agents.list",
+  "commands.catalog",
+  "complete.path",
+  "complete.slash",
+  "config.get",
+  "context.list",
+  "delegation.status",
+  "input.detect_drop",
+  "learning.detail",
+  "learning.frames",
+  "model.options",
+  "paste.collapse",
+  "rollback.diff",
+  "rollback.list",
+  "session.active_list",
+  "session.context_breakdown",
+  "session.history",
+  "session.list",
+  "session.title",
+  "session.usage",
+  "skills.manage",
+  "spawn_tree.list",
+  "spawn_tree.load",
+  "toolsets.list",
+])
+
+function obj(raw: unknown): Record<string, unknown> | null {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) return raw as Record<string, unknown>
+  return null
+}
+
+function text(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined
+  const v = raw.trim()
+  return v || undefined
+}
+
+function revision(raw: Record<string, unknown>): string | undefined {
+  return text(raw.source_revision)
+    ?? text(raw.source_rev)
+    ?? text(raw.revision)
+    ?? text(raw.commit)
+    ?? text(raw.git_sha)
+}
+
+export function backendContract(raw: unknown): BackendContract {
+  const r = obj(raw)
+  const n = r?.desktop_contract
+  const version = text(r?.version)
+  const releaseDate = text(r?.release_date)
+  const updateCommand = text(r?.update_command)
+  const updateBehind = typeof r?.update_behind === "number" || r?.update_behind === null
+    ? r.update_behind
+    : undefined
+  const base = {
+    minContract: MIN_BACKEND_CONTRACT,
+    maxContract: MAX_BACKEND_CONTRACT,
+    sourceRevision: r ? revision(r) : undefined,
+    version,
+    releaseDate,
+    updateBehind,
+    updateCommand,
+  }
+
+  if (!r || n === undefined || n === null) return { ...base, supported: false, reason: "missing" }
+  if (typeof n !== "number" || !Number.isFinite(n) || !Number.isInteger(n))
+    return { ...base, supported: false, reason: "malformed" }
+  if (n < MIN_BACKEND_CONTRACT)
+    return { ...base, observedContract: n, supported: false, reason: "older" }
+  if (n > MAX_BACKEND_CONTRACT)
+    return { ...base, observedContract: n, supported: false, reason: "newer" }
+  return { ...base, observedContract: n, supported: true, reason: "supported" }
+}
+
+export function contractMessage(state: BackendContract): string {
+  const seen = state.observedContract === undefined ? state.reason : String(state.observedContract)
+  const rev = state.sourceRevision ? ` · rev ${state.sourceRevision}` : ""
+  const update = state.updateCommand ? ` Update with: ${state.updateCommand}` : ""
+  if (state.reason === "newer")
+    return `Hermes backend contract ${seen} is newer than Herm supports (${state.minContract}-${state.maxContract})${rev}. Update Herm before sending mutating commands.`
+  if (state.reason === "older")
+    return `Hermes backend contract ${seen} is older than Herm requires (${state.minContract})${rev}.${update}`
+  if (state.reason === "malformed")
+    return `Hermes backend contract payload is malformed; Herm requires ${state.minContract}-${state.maxContract} before mutating commands.${update}`
+  return `Hermes backend contract is missing; Herm requires ${state.minContract}-${state.maxContract} before mutating commands.${update}`
+}
+
+export function mutates(method: string, params: Record<string, unknown> = {}): boolean {
+  if (BOOT.has(method)) return false
+  if (method === "session.title") return "title" in params
+  if (method === "skills.manage") return params.action !== "list" && params.action !== "search"
+  if (method === "cron.manage") return params.action !== "list"
+  if (READ.has(method)) return false
+  return true
+}
+
+export function contractError(method: string, state: BackendContract, params: Record<string, unknown> = {}): Error | null {
+  if (!mutates(method, params)) return null
+  if (state.supported) return null
+  return new Error(`${contractMessage(state)} Blocked ${method}.`)
+}
+
+export * as backend from "./backend-contract"

--- a/src/context/gateway-client.ts
+++ b/src/context/gateway-client.ts
@@ -6,6 +6,7 @@ import { homedir } from "os"
 import { resolve, delimiter } from "path"
 import { existsSync } from "fs"
 import { knownGatewayEvent, type GatewayEvent } from "./wire"
+import { backend } from "./backend-contract"
 import { encode } from "../utils/unicode"
 
 const LOG_MAX = 200
@@ -192,6 +193,7 @@ export class GatewayClient extends EventEmitter {
   private unknown = new Map<string, Diag>()
   private pending = new Map<string, Pending>()
   private buf: GatewayEvent[] = []
+  private contract = backend.backendContract(null)
   private exit: number | null | undefined
   private ok = false
   private timer: ReturnType<typeof setTimeout> | null = null
@@ -238,24 +240,37 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
+  private observe(raw: unknown) {
+    const next = backend.backendContract(raw)
+    this.contract = next.reason === "missing" && this.contract.supported ? this.contract : next
+  }
+
   private dispatch(msg: Record<string, unknown>, source: GatewayEventSource = "stdio") {
     const id = msg.id as string | undefined
     const p = id ? this.pending.get(id) : undefined
 
     if (p) {
       this.pending.delete(id!)
+      const res = msg.result
+      const info = res && typeof res === "object" && !Array.isArray(res)
+        ? (res as { info?: unknown }).info
+        : undefined
+      if (info) this.observe(info)
       if (msg.error) {
         const err = msg.error as { message?: unknown }
         p.reject(new Error(typeof err?.message === "string" ? err.message : "request failed"))
       } else {
-        p.resolve(msg.result)
+        p.resolve(res)
       }
       return
     }
 
     if (msg.method === "event") {
       const ev = asEvent(msg.params)
-      if (ev) this.push(ev, source)
+      if (ev) {
+        if (ev.type === "session.info") this.observe(ev.payload)
+        this.push(ev, source)
+      }
     }
   }
 
@@ -368,6 +383,7 @@ export class GatewayClient extends EventEmitter {
     // Reset state
     this.ok = false
     this.buf = []
+    this.contract = backend.backendContract(null)
     this.exit = undefined
 
     let restarted = false
@@ -488,6 +504,8 @@ export class GatewayClient extends EventEmitter {
   }
 
   request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    const blocked = backend.contractError(method, this.contract, params)
+    if (blocked) return Promise.reject(blocked)
     const raw = gatewayUrl()
     if (raw) return this.remote<T>(raw, method, params)
     if (!this.proc || this.proc.exitCode !== null) this.start()
@@ -527,6 +545,8 @@ export class GatewayClient extends EventEmitter {
   }
 
   private remote<T>(raw: string, method: string, params: Record<string, unknown>): Promise<T> {
+    const blocked = backend.contractError(method, this.contract, params)
+    if (blocked) return Promise.reject(blocked)
     try { websocketUrl(raw) }
     catch (err) { return Promise.reject(err instanceof Error ? err : new Error(String(err))) }
     if (this.target !== raw || !this.ws || this.ws.readyState === WS_CLOSING || this.ws.readyState === WS_CLOSED)

--- a/src/context/wire.ts
+++ b/src/context/wire.ts
@@ -223,6 +223,8 @@ export type SessionInfo = {
    */
   tools?: Record<string, string[]>
   skills?: Record<string, string[]>
+  desktop_contract?: number
+  source_revision?: string
   version?: string
   /**
    * Live active-agent system prompt from `agent._cached_system_prompt`

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -13,6 +13,7 @@ import type { GatewayEvent } from "../src/context/wire"
 describe("app", () => {
   const mount = (opts: Parameters<typeof mountApp>[0] = {}) =>
     mountApp({ keyOverrides: {}, ...opts })
+  const bad = { model: "bad-model", session_id: "bad-sid", tools: {}, skills: {}, desktop_contract: 99 }
 
   const clearKeyPrefs = () => {
     prefs.set("keys", undefined)
@@ -33,6 +34,50 @@ describe("app", () => {
     // boot() resumes lastSessionId if set by an earlier test, else creates
     expect(t.gw.last("session.create") ?? t.gw.last("session.resume")).toBeDefined()
 
+    t.destroy()
+  })
+
+  test("unsupported backend contract reports blocked prompt submit", async () => {
+    const gw = new MockGateway({
+      "session.create": () => ({ session_id: "bad-sid", info: bad }),
+    })
+    gw.start = () => {
+      gw.ok = true
+      gw.push({ type: "gateway.ready" })
+    }
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("bad-model"))
+
+    await act(async () => { await t.keys.typeText("blocked prompt") })
+    act(() => t.keys.pressEnter())
+    await until(t, () => t.frame().includes("Blocked prompt.submit."))
+
+    expect(t.frame()).toContain("Hermes backend contract 99 is newer")
+    expect(t.gw.last("prompt.submit")).toBeUndefined()
+    t.destroy()
+  })
+
+  test("unsupported backend contract reports blocked gateway slash command", async () => {
+    const gw = new MockGateway({
+      "session.create": () => ({ session_id: "bad-sid", info: bad }),
+    })
+    gw.start = () => {
+      gw.ok = true
+      gw.push({ type: "gateway.ready" })
+    }
+    const t = await mount({ gw })
+    await until(t, () => t.frame().includes("bad-model"))
+
+    await act(async () => { await t.keys.typeText("/go") })
+    await until(t, () => t.frame().includes("/goal"))
+    const rows = t.frame().split("\n")
+    const y = rows.findIndex(row => row.includes("/goal"))
+    await act(async () => { await t.mouse.pressDown(rows[y].indexOf("/goal"), y) })
+    await until(t, () => t.frame().includes("Blocked slash.exec."))
+
+    expect(t.frame()).toContain("Hermes backend contract 99 is newer")
+    expect(t.gw.last("slash.exec")).toBeUndefined()
+    expect(t.gw.last("command.dispatch")).toBeUndefined()
     t.destroy()
   })
 

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -136,6 +136,20 @@ describe("python", () => {
 })
 
 describe("GatewayClient", () => {
+  test("unsupported backend contract blocks mutations before transport writes", async () => {
+    const prev = Bun.spawn
+    let spawns = 0
+    ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = (() => { spawns++; throw new Error("should not spawn") }) as typeof Bun.spawn
+    const gw = new GatewayClient()
+
+    try {
+      await expect(gw.request("prompt.submit", { text: "hi" })).rejects.toThrow("Blocked prompt.submit")
+      expect(spawns).toBe(0)
+    } finally {
+      ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = prev
+    }
+  })
+
   test("synchronous spawn failure reports exit without throwing", () => {
     const prev = Bun.spawn
     ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = (() => {
@@ -311,7 +325,7 @@ describe("GatewayClient", () => {
     const gw = new GatewayClient()
     try {
       gw.start()
-      const old = gw.request("test.pending").then(
+      const old = gw.request("config.get", { key: "pending" }).then(
         () => "resolved",
         (e: Error) => e.message,
       )

--- a/test/harness.tsx
+++ b/test/harness.tsx
@@ -36,13 +36,14 @@ type RuleOpts = {
 type Rule = { method: string; calls: number; min: number; max: number }
 
 const preset: Record<string, Handler> = {
-  "session.resume": p => ({ session_id: p.session_id ?? "test-sid", messages: [] }),
+  "session.resume": p => ({ session_id: p.session_id ?? "test-sid", messages: [], info: { desktop_contract: 4 } }),
   "session.list": () => ({ sessions: [] }),
   "session.active_list": () => ({ sessions: [] }),
-  "session.activate": p => ({ session_id: p.session_id ?? "test-sid", messages: [], status: "idle" }),
+  "session.activate": p => ({ session_id: p.session_id ?? "test-sid", messages: [], status: "idle", info: { desktop_contract: 4 } }),
   "agents.list": () => ({ processes: [] }),
   "delegation.status": () => ({ active: [], paused: false, max_spawn_depth: 2, max_concurrent_children: 3 }),
   "complete.path": () => ({ items: [] }),
+  "complete.slash": () => ({ items: [] }),
   "paste.collapse": p => ({
     placeholder: `[Pasted text #1: ${String(p.text).split("\n").length} lines → /tmp/p.txt]`,
     path: "/tmp/p.txt",
@@ -90,7 +91,7 @@ export class MockGateway extends EventEmitter implements Gateway {
     const env = process.env.HERM_MOCK_GATEWAY_MODE
     this.mode = opts.mode ?? (env === "compat" || env === "audit" ? env : "strict")
     // Sane defaults so <App> boots without hanging.
-    this.on$("session.create", () => ({ session_id: "test-sid" }))
+    this.on$("session.create", () => ({ session_id: "test-sid", info: { desktop_contract: 4 } }))
     this.on$("config.get", p => p.key === "full" ? { config: {} } : {})
     this.on$("commands.catalog", () => ({ pairs: [] }))
     for (const [m, h] of Object.entries(handlers)) this.on$(m, h)
@@ -122,7 +123,7 @@ export class MockGateway extends EventEmitter implements Gateway {
   start() {
     this.ok = true
     this.push({ type: "gateway.ready" })
-    this.push({ type: "session.info", payload: { model: "test-model", session_id: "test-sid", tools: {}, skills: {} } })
+    this.push({ type: "session.info", payload: { model: "test-model", session_id: "test-sid", tools: {}, skills: {}, desktop_contract: 4 } })
   }
 
   drain() {

--- a/test/lazy-session-ready.test.tsx
+++ b/test/lazy-session-ready.test.tsx
@@ -7,7 +7,7 @@ describe("lazy session startup", () => {
     const gw = new MockGateway({
       "session.create": () => ({
         session_id: "lazy-sid",
-        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true },
+        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true, desktop_contract: 4 },
       }),
       "prompt.submit": () => ({ status: "streaming" }),
     })
@@ -34,7 +34,7 @@ describe("lazy session startup", () => {
     const gw = new MockGateway({
       "session.create": () => ({
         session_id: "lazy-sid",
-        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true },
+        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true, desktop_contract: 4 },
       }),
       "commands.catalog": () => ({ pairs: [["/review", "Review with skill"]] }),
       "slash.exec": () => { throw new Error("fall through") },
@@ -73,7 +73,7 @@ describe("lazy session startup", () => {
     const gw = new MockGateway({
       "session.create": () => ({
         session_id: "lazy-sid",
-        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true },
+        info: { model: "lazy-model", session_id: "lazy-sid", tools: {}, skills: {}, lazy: true, desktop_contract: 4 },
       }),
       "prompt.submit": () => ({ status: "streaming" }),
     })

--- a/test/sessionCapabilities.test.ts
+++ b/test/sessionCapabilities.test.ts
@@ -1,19 +1,95 @@
 import { describe, expect, test } from "bun:test"
+import { backend } from "../src/context/backend-contract"
 import { sessionCapabilities } from "../src/app/sessionCapabilities"
 
-describe("sessionCapabilities", () => {
-  test("session id enables actions before metadata hydration", () => {
-    expect(sessionCapabilities({ sid: "lazy-sid", ready: false, streaming: false })).toEqual({
+const info = (desktop_contract: unknown, extra: Record<string, unknown> = {}) =>
+  backend.backendContract({ desktop_contract, ...extra })
+
+describe("backend contract", () => {
+  test("missing session.info contract fails closed before mutating RPCs", () => {
+    const state = backend.backendContract({ version: "0.19.0", update_command: "hermes update" })
+
+    expect(state).toMatchObject({
+      minContract: 4,
+      maxContract: 5,
+      supported: false,
+      reason: "missing",
+      version: "0.19.0",
+      updateCommand: "hermes update",
+    })
+    expect(backend.contractError("prompt.submit", state)?.message).toContain("Blocked prompt.submit")
+    expect(backend.contractError("config.get", state)).toBeNull()
+  })
+
+  test("malformed contract fails closed with an explainable reason", () => {
+    const state = info("4")
+
+    expect(state).toMatchObject({ supported: false, reason: "malformed" })
+    expect(state.observedContract).toBeUndefined()
+    expect(backend.contractError("session.steer", state)?.message).toContain("malformed")
+  })
+
+  test("older producer contract blocks mutating RPCs", () => {
+    const state = info(3, { source_revision: "abc123" })
+
+    expect(state).toMatchObject({
+      observedContract: 3,
+      sourceRevision: "abc123",
+      supported: false,
+      reason: "older",
+    })
+    expect(backend.contractError("approval.respond", state)?.message).toContain("older")
+  })
+
+  test("current supported producer contract enables session capabilities", () => {
+    const cap = sessionCapabilities({
+      sid: "lazy-sid",
+      ready: true,
+      streaming: false,
+      contract: info(4),
+    })
+
+    expect(cap).toMatchObject({
       sessionConnected: true,
-      metadataHydrated: false,
+      metadataHydrated: true,
+      minContract: 4,
+      maxContract: 5,
+      observedContract: 4,
+      contractSupported: true,
+      contractReason: "supported",
       canSubmitPrompt: true,
       canDispatchGatewayCommand: true,
       canDrainQueue: true,
     })
   })
 
-  test("queue drain waits for idle but not session.info", () => {
-    expect(sessionCapabilities({ sid: "lazy-sid", ready: false, streaming: true })).toMatchObject({
+  test("newer producer contract is surfaced as unsupported", () => {
+    const state = info(6)
+
+    expect(state).toMatchObject({
+      observedContract: 6,
+      supported: false,
+      reason: "newer",
+    })
+    expect(backend.contractError("prompt.submit", state)?.message).toContain("newer than Herm supports")
+  })
+})
+
+describe("sessionCapabilities", () => {
+  test("session id alone does not enable mutations before contract hydration", () => {
+    expect(sessionCapabilities({ sid: "lazy-sid", ready: false, streaming: false })).toMatchObject({
+      sessionConnected: true,
+      metadataHydrated: false,
+      contractSupported: false,
+      contractReason: "missing",
+      canSubmitPrompt: false,
+      canDispatchGatewayCommand: false,
+      canDrainQueue: false,
+    })
+  })
+
+  test("queue drain waits for idle and supported contract", () => {
+    expect(sessionCapabilities({ sid: "lazy-sid", ready: true, streaming: true, contract: info(5) })).toMatchObject({
       canSubmitPrompt: true,
       canDispatchGatewayCommand: true,
       canDrainQueue: false,
@@ -21,9 +97,10 @@ describe("sessionCapabilities", () => {
   })
 
   test("missing session id disables session actions even if metadata is marked ready", () => {
-    expect(sessionCapabilities({ sid: "", ready: true, streaming: false })).toEqual({
+    expect(sessionCapabilities({ sid: "", ready: true, streaming: false, contract: info(4) })).toMatchObject({
       sessionConnected: false,
       metadataHydrated: true,
+      contractSupported: true,
       canSubmitPrompt: false,
       canDispatchGatewayCommand: false,
       canDrainQueue: false,


### PR DESCRIPTION
## Context
Herm needs to avoid sending mutating RPCs to Hermes backends that do not implement the expected desktop contract. Without an explicit contract gate, prompt submits and gateway slash commands can fail silently or mutate state against an incompatible backend.

## Summary
- Tracks the observed Hermes desktop backend contract from session metadata, including revision and update hints when present.
- Classifies supported, missing, malformed, older, and newer contract states and exposes the current compatibility status to the app.
- Blocks mutating gateway RPCs fail-closed when the backend contract is unsupported while keeping read/startup calls available.
- Reports blocked Composer prompt submits and gateway slash commands visibly in the transcript/toast without sending blocked mutating RPC writes.
- Adds regression coverage for contract parsing, gateway blocking, lazy session readiness, prompt submits, and slash command gates.
