### PR TITLE
feat(config): report semantic schema drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ jobs:
           git -C "${root}" checkout --detach FETCH_HEAD
           HERMES_AGENT_ROOT="${root}" bun run gen-schema:check
           HERMES_AGENT_ROOT="${root}" bun run gen-gateway-inventory:check
+      - name: report pinned config drift
+        run: |
+          root="${RUNNER_TEMP}/hermes-agent-contracts"
+          HERMES_AGENT_ROOT="${root}" bun run config-drift -- --pinned-root "${root}"
+      - name: report current config drift
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          pinned="${RUNNER_TEMP}/hermes-agent-contracts"
+          root="${RUNNER_TEMP}/hermes-agent-main"
+          git init -q "${root}"
+          git -C "${root}" remote add origin https://github.com/NousResearch/hermes-agent.git
+          git -C "${root}" fetch --depth=1 origin main
+          git -C "${root}" checkout --detach FETCH_HEAD
+          HERMES_AGENT_ROOT="${pinned}" bun run config-drift -- --pinned-root "${pinned}" --current-root "${root}" --current-ref refs/heads/main --warn-current
       - run: bun run test:check:strict
       - run: bunx tsc --noEmit
       - run: bun test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
           git -C "${root}" checkout --detach FETCH_HEAD
           HERMES_AGENT_ROOT="${root}" bun run gen-schema:check
 
+      - name: report pinned config drift
+        run: |
+          root="${RUNNER_TEMP}/hermes-agent-schema"
+          HERMES_AGENT_ROOT="${root}" bun run config-drift -- --pinned-root "${root}"
+
       - run: bun run test:check:strict
 
       - run: bunx tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gen-schema:check": "bun scripts/gen-schema.ts --check",
     "gen-gateway-inventory": "bun scripts/gen-gateway-inventory.ts",
     "gen-gateway-inventory:check": "bun scripts/gen-gateway-inventory.ts --check",
+    "config-drift": "bun scripts/config-drift.ts",
     "gen-theme": "bun scripts/gen-theme-manifest.ts",
     "build": "bun scripts/build.ts",
     "start": "bun run dist/index.js",

--- a/scripts/config-drift.ts
+++ b/scripts/config-drift.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env bun
+import { existsSync, readFileSync } from "node:fs"
+import { pathToFileURL } from "node:url"
+import { join, resolve } from "node:path"
+import { RULES } from "../src/config/rules"
+import { RPC_ALIAS, route } from "../src/config/lane"
+import { MERGE, SELECTS } from "../src/config/semantics"
+import { findRoot, generate, remote, schemaTarget, type Entry } from "./schema-source"
+
+type Base = {
+  SCHEMA: Record<string, Entry>
+  SCHEMA_KEYS?: string[]
+  APPROVAL_MODES: readonly string[]
+}
+
+type Source = {
+  kind: "pinned" | "current_upstream"
+  root: string
+  sha: string
+  remote_url: string
+  reproducible: boolean
+  schema_source_sha?: string
+  workflow_shas?: string[]
+  ref?: string
+  resolved_sha?: string
+}
+
+type Cmp = {
+  added: string[]
+  removed: string[]
+  changed: { key: string; fields: string[] }[]
+}
+
+type Finding = {
+  id: string
+  provenance: "pinned" | "current_upstream"
+  category: string
+  severity: "blocking" | "warning" | "info"
+  key?: string
+  producer?: Entry | null
+  generated?: Entry | null
+  classification?: Record<string, unknown>
+  evidence: string[]
+}
+
+const arg = (name: string) => {
+  const pos = Bun.argv.indexOf(name)
+  return pos >= 0 ? Bun.argv[pos + 1] : undefined
+}
+
+const has = (name: string) => Bun.argv.includes(name)
+
+const sort = <T>(xs: T[], f = (x: T) => String(x)) => [...xs].sort((a, b) => f(a).localeCompare(f(b)))
+
+const same = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b)
+
+const stamp = () => process.env.SOURCE_DATE_EPOCH
+  ? new Date(Number(process.env.SOURCE_DATE_EPOCH) * 1000).toISOString()
+  : new Date().toISOString()
+
+const hermSha = () => {
+  const proc = Bun.spawnSync(["git", "-C", join(import.meta.dir, ".."), "rev-parse", "HEAD"])
+  return proc.exitCode === 0 ? new TextDecoder().decode(proc.stdout).trim() : "unknown"
+}
+
+const load = async (path: string): Promise<Base> => {
+  const url = `${pathToFileURL(resolve(path)).href}?v=${Date.now()}`
+  return await import(url) as Base
+}
+
+const shaOf = (path: string) => {
+  if (!existsSync(path)) return "unknown"
+  const m = readFileSync(path, "utf8").match(/Source: hermes-agent@([^\s]+) hermes_cli\/config\.py/)
+  return m?.[1] ?? "unknown"
+}
+
+const workflows = () => sort(["ci.yml", "release.yml"].flatMap(file => {
+  const path = join(import.meta.dir, "..", ".github", "workflows", file)
+  if (!existsSync(path)) return []
+  return [...readFileSync(path, "utf8").matchAll(/fetch --depth=1 origin ([0-9a-f]{40})/g)].map(m => m[1])
+})).filter((v, i, xs) => xs.indexOf(v) === i)
+
+const fields = (a: Entry, b: Entry) => ["type", "default", "doc", "group", "effect"]
+  .filter(k => !same(a[k as keyof Entry], b[k as keyof Entry]))
+
+const compare = (base: Record<string, Entry>, next: Record<string, Entry>): Cmp => {
+  const bk = Object.keys(base)
+  const nk = Object.keys(next)
+  const bs = new Set(bk)
+  const ns = new Set(nk)
+  return {
+    added: sort(nk.filter(k => !bs.has(k))),
+    removed: sort(bk.filter(k => !ns.has(k))),
+    changed: sort(bk.filter(k => ns.has(k)).flatMap(k => {
+      const f = fields(base[k], next[k])
+      return f.length ? [{ key: k, fields: f }] : []
+    }), x => x.key),
+  }
+}
+
+const mode = (base: readonly string[], next: readonly string[]) => ({
+  generated: [...base],
+  producer: [...next],
+  status: same(base, next) ? "match" : "drift",
+})
+
+const raw = (key: string, entry?: Entry) => entry?.group ?? (key.includes(".") ? key.split(".")[0] : "general")
+
+const note = (key: string, entry?: Entry) => {
+  const lane = route(key)
+  return {
+    select_options: key === "display.skin" ? "dynamic" : SELECTS[key] ?? null,
+    validation_rule: !!RULES[key],
+    lane: lane.via,
+    rpc_alias: lane.via === "rpc" ? lane.alias : null,
+    raw_group: raw(key, entry),
+    group: MERGE[raw(key, entry)] ?? raw(key, entry),
+    effect: entry?.effect ?? null,
+  }
+}
+
+const id = (prov: string, category: string, key: string) =>
+  `cfg-${prov}-${category}-${key}`.replace(/[^a-z0-9]+/gi, "-").toLowerCase().replace(/^-|-$/g, "")
+
+const findings = (prov: "pinned" | "current_upstream", cmp: Cmp, base: Base, next: ReturnType<typeof generate>) => {
+  const out: Finding[] = []
+  for (const key of cmp.added) {
+    out.push({
+      id: id(prov, "added-key", key), provenance: prov, category: "added_key", severity: prov === "pinned" ? "blocking" : "info", key,
+      producer: next.entries[key], generated: null, classification: note(key, next.entries[key]), evidence: [`${prov}:schema:${key}`],
+    })
+    out.push({
+      id: id(prov, "review-required", key), provenance: prov, category: "review_required", severity: prov === "pinned" ? "warning" : "info", key,
+      producer: next.entries[key], generated: null,
+      classification: { ...note(key, next.entries[key]), requires_review: true, reason: "new key needs select/rule/lane/effect/group review" },
+      evidence: [`${prov}:schema:${key}`],
+    })
+  }
+  for (const key of cmp.removed) out.push({
+    id: id(prov, "removed-key", key), provenance: prov, category: "removed_key", severity: prov === "pinned" ? "blocking" : "warning", key,
+    producer: null, generated: base.SCHEMA[key], classification: note(key, base.SCHEMA[key]), evidence: [`generated:schema:${key}`],
+  })
+  for (const ch of cmp.changed) {
+    if (ch.fields.includes("default")) out.push({
+      id: id(prov, "default-changed", ch.key), provenance: prov, category: "default_changed", severity: prov === "pinned" ? "blocking" : "info", key: ch.key,
+      producer: next.entries[ch.key], generated: base.SCHEMA[ch.key], classification: note(ch.key, next.entries[ch.key]), evidence: [`${prov}:schema:${ch.key}`],
+    })
+    if (ch.fields.some(f => f === "type" || f === "effect" || f === "group")) out.push({
+      id: id(prov, "classification-changed", ch.key), provenance: prov, category: "classification_changed", severity: "warning", key: ch.key,
+      producer: next.entries[ch.key], generated: base.SCHEMA[ch.key], classification: { ...note(ch.key, next.entries[ch.key]), fields: ch.fields }, evidence: [`${prov}:schema:${ch.key}`],
+    })
+  }
+  const modes = mode(base.APPROVAL_MODES, next.approvalModes)
+  if (modes.status === "drift") out.push({
+    id: id(prov, "enum-changed", "approval-modes"), provenance: prov, category: "enum_changed", severity: prov === "pinned" ? "blocking" : "warning",
+    producer: null, generated: null, classification: { key: "approvals.mode", ...modes }, evidence: [`${prov}:approval_modes`],
+  })
+  return out
+}
+
+const annotations = (schema: Record<string, Entry>, added: string[]) => {
+  const keys = new Set(Object.keys(schema))
+  const roots = new Set(Object.keys(schema).map(k => raw(k, schema[k])))
+  return {
+    missing_review: added.map(key => ({ key, reason: "new key needs reviewed select/rule/lane/effect/group classification" })),
+    stale_review: sort([
+      ...Object.keys(SELECTS).filter(key => key !== "display.skin" && !keys.has(key)).map(key => ({ kind: "select", key })),
+      ...Object.keys(RULES).filter(key => !keys.has(key)).map(key => ({ kind: "rule", key })),
+      ...Object.keys(RPC_ALIAS).filter(key => !keys.has(key)).map(key => ({ kind: "lane", key })),
+      ...Object.keys(MERGE).filter(key => !roots.has(key)).map(key => ({ kind: "group", key })),
+    ], x => `${x.kind}:${x.key}`),
+  }
+}
+
+const status = (cmp: Cmp, modes: ReturnType<typeof mode>) =>
+  cmp.added.length || cmp.removed.length || cmp.changed.length || modes.status === "drift" ? "drift" : "clean"
+
+function makeReport(base: Base, pinned: ReturnType<typeof generate>, current?: ReturnType<typeof generate>, baseline = schemaTarget()) {
+  const pc = compare(base.SCHEMA, pinned.entries)
+  const pm = mode(base.APPROVAL_MODES, pinned.approvalModes)
+  const cc = current ? compare(base.SCHEMA, current.entries) : undefined
+  const cm = current ? mode(base.APPROVAL_MODES, current.approvalModes) : undefined
+  const found = [
+    ...findings("pinned", pc, base, pinned),
+    ...(current && cc ? findings("current_upstream", cc, base, current) : []),
+  ]
+  return {
+    schema_version: 1,
+    generated_at: stamp(),
+    tool: { name: "herm-config-drift", herm_sha: hermSha() },
+    sources: {
+      pinned: { kind: "pinned", root: pinned.root, sha: pinned.sha, remote_url: remote(pinned.root), schema_source_sha: shaOf(baseline), workflow_shas: workflows(), reproducible: true } satisfies Source,
+      ...(current ? { current_upstream: { kind: "current_upstream", root: current.root, remote_url: remote(current.root), ref: arg("--current-ref") ?? "refs/heads/main", sha: current.sha, resolved_sha: current.sha, reproducible: false } satisfies Source } : {}),
+    },
+    summary: {
+      pinned: { status: status(pc, pm), keys: pinned.keys.length, added: pc.added.length, removed: pc.removed.length, changed: pc.changed.length, approval_modes: pinned.approvalModes },
+      ...(current && cc && cm ? { current_upstream: { status: status(cc, cm), keys: current.keys.length, added: cc.added.length, removed: cc.removed.length, changed: cc.changed.length, approval_modes: current.approvalModes } } : {}),
+    },
+    findings: sort(found, x => `${x.provenance}:${x.category}:${x.key ?? ""}`),
+    comparisons: {
+      keys: { added: current && cc ? cc.added : pc.added, removed: current && cc ? cc.removed : pc.removed },
+      entries: { changed: current && cc ? cc.changed.filter(x => x.fields.includes("default")) : pc.changed.filter(x => x.fields.includes("default")) },
+      approval_modes: { pinned: pm, ...(cm ? { current_upstream: cm } : {}) },
+      annotations: annotations(current?.entries ?? pinned.entries, current && cc ? cc.added : pc.added),
+    },
+  }
+}
+
+type Report = ReturnType<typeof makeReport>
+
+const human = (report: Report) => {
+  const lines = [
+    `Pinned schema: ${report.summary.pinned.status} (${report.sources.pinned.sha})`,
+    report.sources.current_upstream
+      ? `Current upstream: ${report.summary.current_upstream?.status} (${report.sources.current_upstream.resolved_sha})`
+      : "Current upstream: not checked",
+  ]
+  const cur = report.summary.current_upstream
+  if (cur) lines.push(`keys +${cur.added} / -${cur.removed} / Δ${cur.changed}`)
+  lines.push(`approval modes: ${report.comparisons.approval_modes.current_upstream?.status ?? report.comparisons.approval_modes.pinned.status}`)
+  const review = report.comparisons.annotations.missing_review.map(x => x.key)
+  lines.push(`review needed: ${review.length ? `${review.slice(0, 8).join(", ")}${review.length > 8 ? ` +${review.length - 8} more` : ""}` : "none"}`)
+  return `${lines.join("\n")}\n`
+}
+
+try {
+  const baseline = arg("--baseline") ?? schemaTarget()
+  const base = await load(baseline)
+  const pinned = generate(findRoot(arg("--pinned-root")))
+  const cur = arg("--current-root")
+  const current = cur ? generate(findRoot(cur)) : undefined
+  const out = makeReport(base, pinned, current, baseline)
+  if (has("--json")) console.log(JSON.stringify(out, null, 2))
+  else console.log(human(out))
+  const curStatus = out.summary.current_upstream?.status
+  process.exit(out.summary.pinned.status === "clean" && (!curStatus || curStatus === "clean" || has("--warn-current")) ? 0 : 1)
+} catch (e) {
+  console.error("config-drift:", e instanceof Error ? e.message : String(e))
+  process.exit(1)
+}

--- a/scripts/gen-schema.ts
+++ b/scripts/gen-schema.ts
@@ -1,282 +1,32 @@
 #!/usr/bin/env bun
-/**
- * gen-schema — derive src/config/schema.ts from the installed Hermes agent's
- * DEFAULT_CONFIG literal in hermes_cli/config.py.
- *
- * The literal is the de-facto schema: it names every key, gives a default
- * (which implies the type), and most leaves carry a #-comment doc either on
- * the preceding lines or trailing the value. We scrape all three.
- *
- * Python does the heavy lifting (ast.literal_eval + line-walk for docs) so
- * this script doesn't re-implement a Python parser. Output is a committed
- * .ts file — regenerate with `bun scripts/gen-schema.ts` after an agent pull.
- */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"
-import { dirname, join, resolve } from "path"
+import { existsSync, readFileSync } from "node:fs"
+import { findRoot, generate, schemaTarget, write } from "./schema-source"
 
-const HOME = process.env.HOME!
-const HERMES_HOME = process.env.HERMES_HOME || join(HOME, ".hermes")
-
-// Same discovery order as the app (see src/context/gateway-client.ts):
-// HERMES_AGENT_ROOT overrides; otherwise look under HERMES_HOME.
-const CANDIDATES = [
-  process.env.HERMES_AGENT_ROOT,
-  join(HERMES_HOME, "hermes-agent"),
-].filter(Boolean) as string[]
-
-const agentRoot = CANDIDATES.find(p => existsSync(join(p, "hermes_cli", "config.py")))
-if (!agentRoot) {
-  console.error("gen-schema: could not locate hermes_cli/config.py under any of:", CANDIDATES)
-  process.exit(1)
-}
-const configPy = join(agentRoot, "hermes_cli", "config.py")
-const serverPy = join(agentRoot, "tui_gateway", "server.py")
-const src = readFileSync(configPy, "utf8")
-const tls = src.includes("ssl_ca_cert") && src.includes("ssl_verify")
-const sha = (() => {
-  if (process.env.HERMES_AGENT_SHA) return process.env.HERMES_AGENT_SHA
-  const p = Bun.spawnSync(["git", "-C", agentRoot, "rev-parse", "HEAD"])
-  return p.exitCode === 0 ? new TextDecoder().decode(p.stdout).trim() : "unknown"
-})()
-const sourceLabel = `hermes-agent@${sha} hermes_cli/config.py`
-
-// ─── extract via python3 ─────────────────────────────────────────────
-
-const py = `
-import ast, json, re, sys
-
-path = ${JSON.stringify(configPy)}
-server_path = ${JSON.stringify(serverPy)}
-with open(path, encoding="utf-8") as f:
-    src = f.read()
-with open(server_path, encoding="utf-8") as f:
-    server = f.read()
-lines = src.splitlines()
-
-mode_match = re.search(r"^_APPROVAL_MODES\\s*=\\s*frozenset\\((\\{.*?\\})\\)", server, re.M | re.S)
-if not mode_match:
-    raise RuntimeError("could not find tui_gateway.server _APPROVAL_MODES")
-approval_modes = re.findall(r'"([^"]+)"', mode_match.group(1))
-
-# locate DEFAULT_CONFIG = { ... } by brace balance
-start = next(i for i, l in enumerate(lines) if re.match(r"^DEFAULT_CONFIG\\s*=\\s*{", l))
-depth, end = 0, start
-for i in range(start, len(lines)):
-    depth += lines[i].count("{") - lines[i].count("}")
-    if depth == 0:
-        end = i
-        break
-block = "\\n".join(lines[start:end + 1]).split("=", 1)[1].strip()
-# ast.literal_eval rejects arithmetic (e.g. 24 * 7), which upstream uses
-# in defaults. Safe-eval literals + constant arithmetic ourselves.
-import operator
-_BIN = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
-        ast.Div: operator.truediv, ast.FloorDiv: operator.floordiv,
-        ast.Mod: operator.mod, ast.Pow: operator.pow}
-_UNA = {ast.UAdd: operator.pos, ast.USub: operator.neg}
-def ev(n):
-    if isinstance(n, ast.Constant): return n.value
-    if isinstance(n, ast.Dict): return {ev(k): ev(v) for k, v in zip(n.keys, n.values)}
-    if isinstance(n, (ast.List, ast.Tuple)): return [ev(e) for e in n.elts]
-    if isinstance(n, ast.Set): return {ev(e) for e in n.elts}
-    if isinstance(n, ast.BinOp) and type(n.op) in _BIN: return _BIN[type(n.op)](ev(n.left), ev(n.right))
-    if isinstance(n, ast.UnaryOp) and type(n.op) in _UNA: return _UNA[type(n.op)](ev(n.operand))
-    if isinstance(n, ast.Name) and n.id in ("True", "False", "None"):
-        return {"True": True, "False": False, "None": None}[n.id]
-    raise ValueError(f"unsupported node: {ast.dump(n)[:80]}")
-tree = ev(ast.parse(block, mode="eval").body)
-
-# doc map: dotted-path -> text. Walk lines tracking key stack via indent+braces.
-KEY = re.compile(r'^(\\s*)"([^"]+)"\\s*:\\s*(.*)$')
-docs: dict[str, str] = {}
-stack: list[tuple[int, str]] = []   # (indent, key)
-pending: list[str] = []             # accumulated #-lines above next key
-last_key: str = ""
-last_ind: int = -1
-
-def strip_hash(s: str) -> str:
-    return re.sub(r"^#\\s?", "", s.strip())
-
-for raw in lines[start + 1:end]:
-    stripped = raw.strip()
-    if not stripped:
-        pending.clear(); continue
-    if stripped.startswith("#"):
-        ind = len(raw) - len(raw.lstrip())
-        # deeper indent than the key just seen → trailing-comment continuation, not preceding doc
-        if last_key and ind > last_ind:
-            docs[last_key] = (docs.get(last_key, "") + " " + strip_hash(stripped)).strip()
-        else:
-            pending.append(strip_hash(stripped))
-        continue
-    m = KEY.match(raw)
-    if not m:
-        # closing brace or list item — drop stack frames shallower than this indent on '}'
-        if stripped.startswith(("}", "},")):
-            ind = len(raw) - len(raw.lstrip())
-            while stack and stack[-1][0] >= ind:
-                stack.pop()
-        pending.clear(); continue
-    ind, key, rest = len(m.group(1)), m.group(2), m.group(3)
-    while stack and stack[-1][0] >= ind:
-        stack.pop()
-    dotted = ".".join([k for _, k in stack] + [key])
-    # trailing same-line comment (outside string literal — crude but DEFAULT_CONFIG has no '#' inside strings)
-    trail = ""
-    h = rest.find("#")
-    if h >= 0 and rest[:h].count('"') % 2 == 0:
-        trail = strip_hash(rest[h:])
-    doc = " ".join(pending).strip() or trail
-    if doc:
-        docs[dotted] = doc
-    pending.clear()
-    last_key, last_ind = dotted, ind
-    # does this key open a nested dict literal?
-    body = (rest[:h] if h >= 0 and trail else rest).rstrip(",").strip()
-    if body.endswith("{") and not body.endswith("{}"):
-        stack.append((ind, key))
-        last_key = ""
-
-def walk(node, prefix=""):
-    for k, v in node.items():
-        p = f"{prefix}.{k}" if prefix else k
-        if isinstance(v, dict) and v:
-            yield from walk(v, p)
-        else:
-            if isinstance(v, bool): t = "bool"
-            elif isinstance(v, int): t = "int"
-            elif isinstance(v, float): t = "float"
-            elif isinstance(v, str): t = "str"
-            elif isinstance(v, list): t = "list"
-            elif isinstance(v, dict): t = "dict"
-            elif v is None: t = "null"
-            else: t = "str"
-            yield p, {"type": t, "default": v, "doc": docs.get(p, "")}
-
-out = dict(walk(tree))
-json.dump({"source": path, "entries": out, "approval_modes": approval_modes}, sys.stdout)
-`
-
-const proc = Bun.spawnSync(["python3", "-c", py])
-if (proc.exitCode !== 0) {
-  console.error("gen-schema: python extraction failed")
-  console.error(new TextDecoder().decode(proc.stderr))
-  process.exit(1)
-}
-const extracted = JSON.parse(new TextDecoder().decode(proc.stdout)) as {
-  source: string
-  entries: Record<string, { type: string; default: unknown; doc: string }>
-  approval_modes: string[]
+const arg = (name: string) => {
+  const pos = Bun.argv.indexOf(name)
+  return pos >= 0 ? Bun.argv[pos + 1] : undefined
 }
 
-// ─── augment ─────────────────────────────────────────────────────────
-
-/** Keys read by the agent that aren't in DEFAULT_CONFIG (user-adds-only). */
-const EXTRA: Record<string, { type: string; default: unknown; doc: string }> = {
-  custom_providers: { type: "dict", default: {}, doc: `OpenAI-compatible provider definitions keyed by name.${tls ? " Entries support ssl_ca_cert and ssl_verify." : ""}` },
-  mcp_servers: { type: "dict", default: {}, doc: "MCP server definitions keyed by name." },
-  fallback_model: { type: "dict", default: null, doc: "Fallback model (dict) or chain (list of dicts) for provider failover." },
-  "agent.reasoning_effort": { type: "str", default: "", doc: "Reasoning effort for the main agent: none | minimal | low | medium | high | xhigh." },
-  "agent.system_prompt": { type: "str", default: "", doc: "System-prompt override applied by the active personality." },
-  custom_prompt: { type: "str", default: "", doc: "Ad-hoc system-prompt addendum set via /prompt." },
-  provider: { type: "str", default: "", doc: "Default model provider." },
-  "display.details_mode": { type: "str", default: "collapsed", doc: "Tool-progress section fold state: hidden | collapsed | expanded." },
-  "display.thinking_mode": { type: "str", default: "collapsed", doc: "Reasoning display: collapsed | truncated | full." },
-  "display.tool_progress": { type: "str", default: "all", doc: "Tool-progress verbosity: off | new | all | verbose." },
-  "display.tui_compact": { type: "bool", default: false, doc: "Ink-TUI compact layout." },
-  "display.tui_statusbar": { type: "str", default: "top", doc: "Ink-TUI statusbar placement: top | bottom | off." },
-  "display.tui_mouse": { type: "bool", default: true, doc: "Ink-TUI mouse support." },
-  "openrouter.min_coding_score": { type: "float", default: 0.65, doc: "Coding-score floor (0.0-1.0) for openrouter/pareto-code. Only applied when model is openrouter/pareto-code; ignored otherwise. Lower = cheaper model, higher = stronger coder." },
-}
-
-const RPC_LIVE = new Set([
-  "model", "provider",
-  "agent.service_tier", "agent.reasoning_effort",
-  "display.show_reasoning", "display.tool_progress", "display.personality",
-])
-
-type Effect = "live" | "session" | "restart"
-const effectOf = (key: string): Effect => {
-  if (RPC_LIVE.has(key)) return "live"
-  const root = key.split(".")[0]
-  if (root === "terminal" || key === "toolsets" || key === "mcp_servers" || key === "skills.external_dirs")
-    return "restart"
-  if (root === "agent" || root === "auxiliary" || root === "memory" || root === "delegation")
-    return "session"
-  return "live"
-}
-
-type Entry = {
-  type: "bool" | "int" | "float" | "str" | "list" | "dict" | "null"
-  default: unknown
-  doc: string
-  group: string
-  effect: Effect
-}
-
-const all: Record<string, Entry> = {}
-for (const [k, v] of Object.entries({ ...extracted.entries, ...EXTRA })) {
-  if (k.startsWith("_")) continue // _config_version etc.
-  all[k] = {
-    type: v.type as Entry["type"],
-    default: v.default,
-    doc: v.doc,
-    group: k.includes(".") ? k.split(".")[0] : "general",
-    effect: effectOf(k),
-  }
-}
-
-if (tls && all.providers)
-  all.providers.doc = "Provider definitions keyed by name. Custom/OpenAI-compatible entries support ssl_ca_cert and ssl_verify."
-
-const keys = Object.keys(all).sort()
-
-// ─── emit ────────────────────────────────────────────────────────────
-
-const pos = Bun.argv.indexOf("--out")
-if (pos >= 0 && !Bun.argv[pos + 1]) {
+const out = arg("--out")
+if (Bun.argv.includes("--out") && !out) {
   console.error("gen-schema: --out requires a path")
   process.exit(2)
 }
-const target = pos >= 0
-  ? resolve(Bun.argv[pos + 1])
-  : join(import.meta.dir, "..", "src", "config", "schema.ts")
-mkdirSync(dirname(target), { recursive: true })
 
-const body = [
-  `// Generated by scripts/gen-schema.ts — do not edit by hand.`,
-  `// Source: ${sourceLabel}`,
-  `// Keys: ${keys.length}`,
-  ``,
-  `export type ConfigType = "bool" | "int" | "float" | "str" | "list" | "dict" | "null"`,
-  `export type ConfigEffect = "live" | "session" | "restart"`,
-  ``,
-  `export interface ConfigSchemaEntry {`,
-  `  type: ConfigType`,
-  `  default: unknown`,
-  `  doc: string`,
-  `  group: string`,
-  `  effect: ConfigEffect`,
-  `}`,
-  ``,
-  `export const SCHEMA: Record<string, ConfigSchemaEntry> = {`,
-  ...keys.map(k => `  ${JSON.stringify(k)}: ${JSON.stringify(all[k])},`),
-  `}`,
-  ``,
-  `export const SCHEMA_KEYS = Object.keys(SCHEMA)`,
-  ``,
-  `export const APPROVAL_MODES = ${JSON.stringify(extracted.approval_modes)} as const`,
-  ``,
-].join("\n")
-
-if (Bun.argv.includes("--check")) {
-  if (existsSync(target) && readFileSync(target, "utf8") === body) {
-    console.error(`gen-schema: ${target} is current (${keys.length} keys)`)
-    process.exit(0)
+try {
+  const gen = generate(findRoot())
+  const target = schemaTarget(out)
+  if (Bun.argv.includes("--check")) {
+    if (existsSync(target) && readFileSync(target, "utf8") === gen.body) {
+      console.error(`gen-schema: ${target} is current (${gen.keys.length} keys)`)
+      process.exit(0)
+    }
+    console.error(`gen-schema: ${target} is stale`)
+    process.exit(1)
   }
-  console.error(`gen-schema: ${target} is stale`)
+  write(target, gen.body)
+  console.error(`gen-schema: wrote ${target} (${gen.keys.length} keys) from ${gen.root}`)
+} catch (e) {
+  console.error("gen-schema:", e instanceof Error ? e.message : String(e))
   process.exit(1)
 }
-
-writeFileSync(target, body)
-console.error(`gen-schema: wrote ${target} (${keys.length} keys) from ${agentRoot}`)

--- a/scripts/schema-source.ts
+++ b/scripts/schema-source.ts
@@ -1,0 +1,234 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+
+export type Effect = "live" | "session" | "restart"
+export type Entry = {
+  type: "bool" | "int" | "float" | "str" | "list" | "dict" | "null"
+  default: unknown
+  doc: string
+  group: string
+  effect: Effect
+}
+
+type Raw = Record<string, { type: string; default: unknown; doc: string }>
+
+export const home = () => process.env.HERMES_HOME || join(process.env.HOME!, ".hermes")
+
+export const findRoot = (root?: string): string => {
+  const candidates = [root, process.env.HERMES_AGENT_ROOT, join(home(), "hermes-agent")].filter(Boolean) as string[]
+  const hit = candidates.find(p => existsSync(join(p, "hermes_cli", "config.py")))
+  if (hit) return hit
+  throw new Error(`could not locate hermes_cli/config.py under any of: ${candidates.join(", ")}`)
+}
+
+export const gitSha = (root: string, env = process.env.HERMES_AGENT_SHA): string => {
+  if (env) return env
+  const proc = Bun.spawnSync(["git", "-C", root, "rev-parse", "HEAD"])
+  return proc.exitCode === 0 ? new TextDecoder().decode(proc.stdout).trim() : "unknown"
+}
+
+export const remote = (root: string): string => {
+  const proc = Bun.spawnSync(["git", "-C", root, "config", "--get", "remote.origin.url"])
+  const out = new TextDecoder().decode(proc.stdout).trim()
+  return proc.exitCode === 0 && out ? out : "unknown"
+}
+
+const extract = (root: string) => {
+  const config = join(root, "hermes_cli", "config.py")
+  const server = join(root, "tui_gateway", "server.py")
+  const src = readFileSync(config, "utf8")
+  const tls = src.includes("ssl_ca_cert") && src.includes("ssl_verify")
+  const py = `
+import ast, json, re, sys
+path = ${JSON.stringify(config)}
+server_path = ${JSON.stringify(server)}
+approval_path = ${JSON.stringify(join(root, "tools", "approval.py"))}
+with open(path, encoding="utf-8") as f:
+    src = f.read()
+with open(server_path, encoding="utf-8") as f:
+    server = f.read()
+lines = src.splitlines()
+mode_match = re.search(r"^_APPROVAL_MODES\\s*=\\s*frozenset\\((\\{.*?\\})\\)", server, re.M | re.S)
+if mode_match:
+    approval_modes = re.findall(r'"([^"]+)"', mode_match.group(1))
+else:
+    with open(approval_path, encoding="utf-8") as f:
+        approval_src = f.read()
+    valid_match = re.search(r"_VALID_MODES\\s*=\\s*\\((.*?)\\)", approval_src, re.S)
+    if not valid_match:
+        raise RuntimeError("could not find canonical approval modes")
+    approval_modes = re.findall(r'"([^"]+)"', valid_match.group(1))
+start = next(i for i, l in enumerate(lines) if re.match(r"^DEFAULT_CONFIG\\s*=\\s*{", l))
+depth, end = 0, start
+for i in range(start, len(lines)):
+    depth += lines[i].count("{") - lines[i].count("}")
+    if depth == 0:
+        end = i
+        break
+block = "\\n".join(lines[start:end + 1]).split("=", 1)[1].strip()
+import operator
+_BIN = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+        ast.Div: operator.truediv, ast.FloorDiv: operator.floordiv,
+        ast.Mod: operator.mod, ast.Pow: operator.pow}
+_UNA = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+def ev(n):
+    if isinstance(n, ast.Constant): return n.value
+    if isinstance(n, ast.Dict): return {ev(k): ev(v) for k, v in zip(n.keys, n.values)}
+    if isinstance(n, (ast.List, ast.Tuple)): return [ev(e) for e in n.elts]
+    if isinstance(n, ast.Set): return {ev(e) for e in n.elts}
+    if isinstance(n, ast.BinOp) and type(n.op) in _BIN: return _BIN[type(n.op)](ev(n.left), ev(n.right))
+    if isinstance(n, ast.UnaryOp) and type(n.op) in _UNA: return _UNA[type(n.op)](ev(n.operand))
+    if isinstance(n, ast.Name) and n.id in ("True", "False", "None"):
+        return {"True": True, "False": False, "None": None}[n.id]
+    raise ValueError(f"unsupported node: {ast.dump(n)[:80]}")
+tree = ev(ast.parse(block, mode="eval").body)
+KEY = re.compile(r'^(\\s*)"([^"]+)"\\s*:\\s*(.*)$')
+docs: dict[str, str] = {}
+stack: list[tuple[int, str]] = []
+pending: list[str] = []
+last_key: str = ""
+last_ind: int = -1
+def strip_hash(s: str) -> str:
+    return re.sub(r"^#\\s?", "", s.strip())
+for raw in lines[start + 1:end]:
+    stripped = raw.strip()
+    if not stripped:
+        pending.clear(); continue
+    if stripped.startswith("#"):
+        ind = len(raw) - len(raw.lstrip())
+        if last_key and ind > last_ind:
+            docs[last_key] = (docs.get(last_key, "") + " " + strip_hash(stripped)).strip()
+        else:
+            pending.append(strip_hash(stripped))
+        continue
+    m = KEY.match(raw)
+    if not m:
+        if stripped.startswith(("}", "},")):
+            ind = len(raw) - len(raw.lstrip())
+            while stack and stack[-1][0] >= ind:
+                stack.pop()
+        pending.clear(); continue
+    ind, key, rest = len(m.group(1)), m.group(2), m.group(3)
+    while stack and stack[-1][0] >= ind:
+        stack.pop()
+    dotted = ".".join([k for _, k in stack] + [key])
+    trail = ""
+    h = rest.find("#")
+    if h >= 0 and rest[:h].count('"') % 2 == 0:
+        trail = strip_hash(rest[h:])
+    doc = " ".join(pending).strip() or trail
+    if doc:
+        docs[dotted] = doc
+    pending.clear()
+    last_key, last_ind = dotted, ind
+    body = (rest[:h] if h >= 0 and trail else rest).rstrip(",").strip()
+    if body.endswith("{") and not body.endswith("{}"):
+        stack.append((ind, key))
+        last_key = ""
+def walk(node, prefix=""):
+    for k, v in node.items():
+        p = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict) and v:
+            yield from walk(v, p)
+        else:
+            if isinstance(v, bool): t = "bool"
+            elif isinstance(v, int): t = "int"
+            elif isinstance(v, float): t = "float"
+            elif isinstance(v, str): t = "str"
+            elif isinstance(v, list): t = "list"
+            elif isinstance(v, dict): t = "dict"
+            elif v is None: t = "null"
+            else: t = "str"
+            yield p, {"type": t, "default": v, "doc": docs.get(p, "")}
+out = dict(walk(tree))
+json.dump({"source": path, "entries": out, "approval_modes": approval_modes}, sys.stdout)
+`
+  const proc = Bun.spawnSync(["python3", "-c", py])
+  if (proc.exitCode !== 0) throw new Error(`python extraction failed\n${new TextDecoder().decode(proc.stderr)}`)
+  return { ...JSON.parse(new TextDecoder().decode(proc.stdout)) as { source: string; entries: Raw; approval_modes: string[] }, tls }
+}
+
+export const extras = (tls: boolean): Raw => ({
+  custom_providers: { type: "dict", default: {}, doc: `OpenAI-compatible provider definitions keyed by name.${tls ? " Entries support ssl_ca_cert and ssl_verify." : ""}` },
+  mcp_servers: { type: "dict", default: {}, doc: "MCP server definitions keyed by name." },
+  fallback_model: { type: "dict", default: null, doc: "Fallback model (dict) or chain (list of dicts) for provider failover." },
+  "agent.reasoning_effort": { type: "str", default: "", doc: "Reasoning effort for the main agent: none | minimal | low | medium | high | xhigh." },
+  "agent.system_prompt": { type: "str", default: "", doc: "System-prompt override applied by the active personality." },
+  custom_prompt: { type: "str", default: "", doc: "Ad-hoc system-prompt addendum set via /prompt." },
+  provider: { type: "str", default: "", doc: "Default model provider." },
+  "display.details_mode": { type: "str", default: "collapsed", doc: "Tool-progress section fold state: hidden | collapsed | expanded." },
+  "display.thinking_mode": { type: "str", default: "collapsed", doc: "Reasoning display: collapsed | truncated | full." },
+  "display.tool_progress": { type: "str", default: "all", doc: "Tool-progress verbosity: off | new | all | verbose." },
+  "display.tui_compact": { type: "bool", default: false, doc: "Ink-TUI compact layout." },
+  "display.tui_statusbar": { type: "str", default: "top", doc: "Ink-TUI statusbar placement: top | bottom | off." },
+  "display.tui_mouse": { type: "bool", default: true, doc: "Ink-TUI mouse support." },
+  "openrouter.min_coding_score": { type: "float", default: 0.65, doc: "Coding-score floor (0.0-1.0) for openrouter/pareto-code. Only applied when model is openrouter/pareto-code; ignored otherwise. Lower = cheaper model, higher = stronger coder." },
+})
+
+const RPC_LIVE = new Set([
+  "model", "provider",
+  "agent.service_tier", "agent.reasoning_effort",
+  "display.show_reasoning", "display.tool_progress", "display.personality",
+])
+
+export const effectOf = (key: string): Effect => {
+  if (RPC_LIVE.has(key)) return "live"
+  const root = key.split(".")[0]
+  if (root === "terminal" || key === "toolsets" || key === "mcp_servers" || key === "skills.external_dirs") return "restart"
+  if (root === "agent" || root === "auxiliary" || root === "memory" || root === "delegation") return "session"
+  return "live"
+}
+
+export const generate = (root = findRoot()) => {
+  const sha = gitSha(root)
+  const out = extract(root)
+  const all: Record<string, Entry> = {}
+  for (const [k, v] of Object.entries({ ...out.entries, ...extras(out.tls) })) {
+    if (k.startsWith("_")) continue
+    all[k] = {
+      type: v.type as Entry["type"],
+      default: v.default,
+      doc: v.doc,
+      group: k.includes(".") ? k.split(".")[0] : "general",
+      effect: effectOf(k),
+    }
+  }
+  if (out.tls && all.providers)
+    all.providers.doc = "Provider definitions keyed by name. Custom/OpenAI-compatible entries support ssl_ca_cert and ssl_verify."
+  const keys = Object.keys(all).sort()
+  const body = [
+    `// Generated by scripts/gen-schema.ts — do not edit by hand.`,
+    `// Source: hermes-agent@${sha} hermes_cli/config.py`,
+    `// Keys: ${keys.length}`,
+    ``,
+    `export type ConfigType = "bool" | "int" | "float" | "str" | "list" | "dict" | "null"`,
+    `export type ConfigEffect = "live" | "session" | "restart"`,
+    ``,
+    `export interface ConfigSchemaEntry {`,
+    `  type: ConfigType`,
+    `  default: unknown`,
+    `  doc: string`,
+    `  group: string`,
+    `  effect: ConfigEffect`,
+    `}`,
+    ``,
+    `export const SCHEMA: Record<string, ConfigSchemaEntry> = {`,
+    ...keys.map(k => `  ${JSON.stringify(k)}: ${JSON.stringify(all[k])},`),
+    `}`,
+    ``,
+    `export const SCHEMA_KEYS = Object.keys(SCHEMA)`,
+    ``,
+    `export const APPROVAL_MODES = ${JSON.stringify(out.approval_modes)} as const`,
+    ``,
+  ].join("\n")
+  return { root, sha, source: out.source, entries: all, keys, approvalModes: out.approval_modes, body }
+}
+
+export const schemaTarget = (arg?: string) => arg ? resolve(arg) : join(import.meta.dir, "..", "src", "config", "schema.ts")
+
+export const write = (target: string, body: string) => {
+  mkdirSync(dirname(target), { recursive: true })
+  writeFileSync(target, body)
+}
+
+export * as schemaSource from "./schema-source"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,7 @@
 import { skins } from "../context/skin"
-import { APPROVAL_MODES, SCHEMA, SCHEMA_KEYS, type ConfigEffect } from "./schema"
-import { route, TOOL_PROGRESS } from "./lane"
+import { SCHEMA, SCHEMA_KEYS, type ConfigEffect } from "./schema"
+import { route } from "./lane"
+import { MERGE, SELECTS } from "./semantics"
 
 export type FieldType = "boolean" | "select" | "number" | "string" | "readonly"
 
@@ -14,27 +15,7 @@ export type Field = {
   set: boolean
   doc: string
   effect: ConfigEffect
-  options?: string[]
-}
-
-// Enum-valued string fields the schema doesn't carry options for.
-// Kept minimal — most enums are validated by rules.ts on commit; these
-// are the ones worth cycling with [h/l] instead of free-typing.
-const SELECTS: Record<string, string[]> = {
-  "terminal.backend": ["local", "docker", "ssh", "modal", "daytona", "singularity", "vercel_sandbox"],
-  "tts.provider": ["edge", "elevenlabs", "openai", "neutts", "xai", "mistral"],
-  "logging.level": ["DEBUG", "INFO", "WARNING", "ERROR"],
-  "agent.reasoning_effort": ["", "none", "minimal", "low", "medium", "high", "xhigh"],
-  "agent.verify_on_stop": ["auto", "true", "false"],
-  "display.busy_input_mode": ["queue", "steer", "interrupt"],
-  "display.details_mode": ["hidden", "collapsed", "expanded"],
-  "display.thinking_mode": ["collapsed", "truncated", "full"],
-  "display.tool_progress": [...TOOL_PROGRESS],
-  "approvals.mode": [...APPROVAL_MODES],
-  "onboarding.profile_build": ["ask", "off"],
-  "streaming.transport": ["auto", "draft", "edit", "off"],
-  "tools.tool_search.enabled": ["auto", "on", "off"],
-  "updates.non_interactive_local_changes": ["stash", "discard"],
+  options?: readonly string[]
 }
 
 const get = (obj: Record<string, unknown>, path: string): unknown => {
@@ -113,20 +94,6 @@ export const buildFields = (user: Record<string, unknown>): Field[] => {
 // Small/satellite groups fold into a parent. This is a UX decision,
 // not derivable from source — keeps the sidebar to ~18 entries instead
 // of 34 with a dozen 1-field groups.
-const MERGE: Record<string, string> = {
-  approvals: "security", privacy: "security", secrets: "security",
-  checkpoints: "agent", context: "agent", cron: "agent", network: "agent",
-  model_catalog: "general", onboarding: "general",
-  human_delay: "display", dashboard: "display", gateway: "display",
-  desktop: "display", voice: "display",
-  tool_output: "agent", prompt_caching: "compression", code_execution: "terminal",
-  computer_use: "agent", goals: "agent", lsp: "agent", tool_loop_guardrails: "agent",
-  web: "agent", x_search: "agent", tools: "agent", streaming: "display",
-  vertex: "general",
-  slack: "platforms", telegram: "platforms", mattermost: "platforms",
-  discord: "platforms", whatsapp: "platforms", matrix: "platforms",
-}
-
 export const rawGroupOf = (key: string): string =>
   SCHEMA[key]?.group ?? (key.includes(".") ? key.split(".")[0] : "general")
 

--- a/src/config/rules.ts
+++ b/src/config/rules.ts
@@ -10,7 +10,7 @@
  */
 
 import { TOOL_PROGRESS } from "./lane"
-import { APPROVAL_MODES } from "./schema"
+import { SELECTS } from "./semantics"
 
 type Rule = (raw: string) => string | null
 
@@ -38,7 +38,7 @@ const float = (lo: number, hi: number): Rule => raw => {
   return null
 }
 
-const oneOf = (...opts: string[]): Rule => raw =>
+const oneOf = (...opts: readonly string[]): Rule => raw =>
   opts.includes(raw) ? null : `expected one of: ${opts.join(" | ")}`
 
 const nonNeg: Rule = raw => {
@@ -91,7 +91,7 @@ export const RULES: Record<string, Rule> = {
   "display.tool_progress": oneOf(...TOOL_PROGRESS),
   "display.final_response_markdown": oneOf("render", "strip", "raw"),
   "logging.level": oneOf("DEBUG", "INFO", "WARNING", "ERROR"),
-  "approvals.mode": oneOf(...APPROVAL_MODES),
+  "approvals.mode": oneOf(...SELECTS["approvals.mode"]),
   "code_execution.mode": oneOf("project", "strict"),
   "onboarding.profile_build": oneOf("ask", "off"),
   "streaming.transport": oneOf("auto", "draft", "edit", "off"),

--- a/src/config/semantics.ts
+++ b/src/config/semantics.ts
@@ -1,0 +1,33 @@
+import { TOOL_PROGRESS } from "./lane"
+import { APPROVAL_MODES } from "./schema"
+
+export const SELECTS: Record<string, readonly string[]> = {
+  "terminal.backend": ["local", "docker", "ssh", "modal", "daytona", "singularity", "vercel_sandbox"],
+  "tts.provider": ["edge", "elevenlabs", "openai", "neutts", "xai", "mistral"],
+  "logging.level": ["DEBUG", "INFO", "WARNING", "ERROR"],
+  "agent.reasoning_effort": ["", "none", "minimal", "low", "medium", "high", "xhigh"],
+  "agent.verify_on_stop": ["auto", "true", "false"],
+  "display.busy_input_mode": ["queue", "steer", "interrupt"],
+  "display.details_mode": ["hidden", "collapsed", "expanded"],
+  "display.thinking_mode": ["collapsed", "truncated", "full"],
+  "display.tool_progress": [...TOOL_PROGRESS],
+  "approvals.mode": [...APPROVAL_MODES],
+  "onboarding.profile_build": ["ask", "off"],
+  "streaming.transport": ["auto", "draft", "edit", "off"],
+  "tools.tool_search.enabled": ["auto", "on", "off"],
+  "updates.non_interactive_local_changes": ["stash", "discard"],
+}
+
+export const MERGE: Record<string, string> = {
+  approvals: "security", privacy: "security", secrets: "security",
+  checkpoints: "agent", context: "agent", cron: "agent", network: "agent",
+  model_catalog: "general", onboarding: "general",
+  human_delay: "display", dashboard: "display", gateway: "display",
+  desktop: "display", voice: "display",
+  tool_output: "agent", prompt_caching: "compression", code_execution: "terminal",
+  computer_use: "agent", goals: "agent", lsp: "agent", tool_loop_guardrails: "agent",
+  web: "agent", x_search: "agent", tools: "agent", streaming: "display",
+  vertex: "general",
+  slack: "platforms", telegram: "platforms", mattermost: "platforms",
+  discord: "platforms", whatsapp: "platforms", matrix: "platforms",
+}

--- a/test/config-drift.test.ts
+++ b/test/config-drift.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const gen = join(import.meta.dir, "../scripts/gen-schema.ts")
+const drift = join(import.meta.dir, "../scripts/config-drift.ts")
+
+const agent = (root: string, body: string, modes = ["manual", "smart", "off"]) => {
+  const dir = join(root, "hermes_cli")
+  const gw = join(root, "tui_gateway")
+  mkdirSync(dir, { recursive: true })
+  mkdirSync(gw, { recursive: true })
+  writeFileSync(join(dir, "config.py"), body)
+  writeFileSync(join(gw, "server.py"), `_APPROVAL_MODES = frozenset(${JSON.stringify(modes).replace("[", "{").replace("]", "}")})\n`)
+  const git = (...args: string[]) => Bun.spawnSync(["git", ...args], { cwd: root })
+  expect(git("init", "-q").exitCode).toBe(0)
+  expect(git("add", "hermes_cli/config.py", "tui_gateway/server.py").exitCode).toBe(0)
+  expect(git("-c", "user.name=test", "-c", "user.email=test@example.invalid", "commit", "-qm", "fixture").exitCode).toBe(0)
+  return new TextDecoder().decode(git("rev-parse", "HEAD").stdout).trim()
+}
+
+const run = async (cmd: string[], env: Record<string, string>) => {
+  const proc = Bun.spawn(cmd, { env: { ...process.env, ...env }, stdout: "pipe", stderr: "pipe" })
+  const [code, out, err] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  return { code, out, err }
+}
+
+describe("config drift report", () => {
+  test("separates reproducible pinned drift from current-upstream semantic drift", async () => {
+    const root = mkdtempSync(join(tmpdir(), "herm-drift-"))
+    const pinned = join(root, "pinned")
+    const current = join(root, "current")
+    const base = join(root, "schema.ts")
+    mkdirSync(pinned)
+    mkdirSync(current)
+    const body = `DEFAULT_CONFIG = {
+    "agent": { "max_turns": 90 },
+    "approvals": { "mode": "smart" },
+    "compression": { "threshold": 0.8 },
+    "logging": { "level": "INFO" },
+}
+`
+    const next = `DEFAULT_CONFIG = {
+    "agent": { "max_turns": 120 },
+    "approvals": { "mode": "smart" },
+    "cron": { "model": "" },
+    "logging": { "level": "INFO" },
+}
+`
+    const pinnedSha = agent(pinned, body)
+    const currentSha = agent(current, next, ["manual", "smart", "off", "auto"])
+
+    try {
+      expect((await run(["bun", gen, "--out", base], { HERMES_AGENT_ROOT: pinned, HERMES_HOME: join(root, "home") })).code).toBe(0)
+      const json = await run(["bun", drift, "--json", "--baseline", base, "--pinned-root", pinned, "--current-root", current], {
+        HERMES_HOME: join(root, "home"),
+        SOURCE_DATE_EPOCH: "0",
+      })
+      expect(json.code).toBe(1)
+      const report = JSON.parse(json.out)
+      expect(report.schema_version).toBe(1)
+      expect(report.sources.pinned.reproducible).toBe(true)
+      expect(report.sources.pinned.sha).toBe(pinnedSha)
+      expect(report.sources.current_upstream.reproducible).toBe(false)
+      expect(report.sources.current_upstream.resolved_sha).toBe(currentSha)
+      expect(report.summary.pinned.status).toBe("clean")
+      expect(report.summary.current_upstream).toMatchObject({ status: "drift", added: 1, removed: 1, changed: 1 })
+      expect(report.comparisons.keys.added).toEqual(["cron.model"])
+      expect(report.comparisons.keys.removed).toEqual(["compression.threshold"])
+      expect(report.comparisons.entries.changed).toEqual([{ key: "agent.max_turns", fields: ["default"] }])
+      expect(report.comparisons.approval_modes.current_upstream.status).toBe("drift")
+      expect(report.findings.map((f: { category: string }) => f.category)).toEqual(expect.arrayContaining([
+        "added_key", "removed_key", "default_changed", "enum_changed", "review_required",
+      ]))
+      expect(report.findings.find((f: { key?: string; category: string }) => f.key === "cron.model" && f.category === "review_required").classification.requires_review).toBe(true)
+
+      const human = await run(["bun", drift, "--baseline", base, "--pinned-root", pinned, "--current-root", current], {
+        HERMES_HOME: join(root, "home"),
+        SOURCE_DATE_EPOCH: "0",
+      })
+      expect(human.code).toBe(1)
+      expect(human.out).toContain(`Pinned schema: clean (${pinnedSha})`)
+      expect(human.out).toContain(`Current upstream: drift (${currentSha})`)
+      expect(human.out).toContain("keys +1 / -1 / Δ1")
+      expect(human.out).toContain("approval modes: drift")
+      expect(human.out).toContain("review needed: cron.model")
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Context
Herm needs to detect when the local config schema drifts from Hermes Agent in ways that affect default values, option sets, classifications, or approval-mode behavior. The previous schema generation path could report file-level differences, but it did not produce a stable semantic drift report or distinguish pinned reproducible drift from moving upstream drift.

## Summary
- Adds shared Hermes Agent config extraction for defaults, select/group metadata, and STAB-6 approval modes.
- Adds a semantic config drift reporter with JSON and human-readable output for added, removed, default, enum, and classification drift.
- Wires schema and drift checks into CI/release workflows with pinned drift as blocking and current-upstream drift as informational.
- Adds focused coverage for pinned-clean/current-drift reporting behavior.
