### PR TITLE
ci: add current Hermes compatibility canary

### DIFF
--- a/.github/workflows/current-hermes-canary.yml
+++ b/.github/workflows/current-hermes-canary.yml
@@ -1,0 +1,41 @@
+name: current-Hermes canary
+
+on:
+  schedule:
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Hermes Agent ref to check
+        required: false
+        default: main
+
+concurrency:
+  group: current-hermes-canary-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+      - run: bun install --frozen-lockfile
+      - name: run current Hermes compatibility canary
+        env:
+          HERMES_AGENT_REF: ${{ inputs.ref || 'main' }}
+          CURRENT_HERMES_REPORT: ${{ runner.temp }}/current-hermes-report
+        run: bun run current-hermes-canary
+      - name: upload compatibility report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: current-hermes-compatibility-${{ github.run_id }}
+          path: ${{ runner.temp }}/current-hermes-report
+          if-no-files-found: error
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gen-fixtures": "bun scripts/gen-hermes-fixtures.ts",
     "gen-fixtures:check": "bun scripts/gen-hermes-fixtures.ts --check",
     "gen-theme": "bun scripts/gen-theme-manifest.ts",
+    "current-hermes-canary": "bun scripts/current-hermes-canary.ts",
     "build": "bun scripts/build.ts",
     "start": "bun run dist/index.js",
     "test": "bun test",

--- a/scripts/current-hermes-canary.ts
+++ b/scripts/current-hermes-canary.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+
+const args = Bun.argv.slice(2)
+
+const arg = (name: string, fallback = "") => {
+  const pos = args.indexOf(name)
+  if (pos < 0) return fallback
+  return args[pos + 1] || fallback
+}
+
+type Phase = "fetch_failed" | "generator_failed" | "schema_drift" | "compat_pass"
+
+type Run = {
+  code: number
+  out: string
+  err: string
+}
+
+const report = resolve(arg("--report", process.env.CURRENT_HERMES_REPORT || join(process.env.RUNNER_TEMP || ".ignore", "current-hermes-report")))
+const base = resolve(arg("--base", "src/config/schema.ts"))
+const repo = arg("--repo", process.env.HERMES_AGENT_REPO || "https://github.com/NousResearch/hermes-agent.git")
+const ref = arg("--ref", process.env.HERMES_AGENT_REF || "main")
+const given = arg("--root")
+const root = given ? resolve(given) : join(process.env.RUNNER_TEMP || tmpdir(), `hermes-agent-current-${process.pid}`)
+const schema = join(report, "current-schema.ts")
+
+mkdirSync(report, { recursive: true })
+
+const write = (file: string, text: string) => writeFileSync(join(report, file), text)
+const run = (cmd: string, vals: string[], env = process.env): Run => {
+  const proc = Bun.spawnSync([cmd, ...vals], { env, stdout: "pipe", stderr: "pipe" })
+  return {
+    code: proc.exitCode,
+    out: new TextDecoder().decode(proc.stdout),
+    err: new TextDecoder().decode(proc.stderr),
+  }
+}
+
+const keys = async (file: string) => {
+  if (!existsSync(file)) return null
+  const match = Bun.file(file).text().then(text => text.match(/^\/\/ Keys: (\d+)$/m)?.[1])
+  return await match
+}
+
+const finish = async (phase: Phase, code: number, extra: Record<string, unknown> = {}) => {
+  const data = {
+    phase,
+    repo,
+    ref,
+    root,
+    base,
+    upstream_sha: existsSync(join(report, "upstream-sha.txt")) ? (await Bun.file(join(report, "upstream-sha.txt")).text()).trim() : "unknown",
+    base_keys: await keys(base),
+    current_keys: await keys(schema),
+    artifacts: {
+      summary_json: "summary.json",
+      summary_md: "summary.md",
+      upstream_sha: "upstream-sha.txt",
+      current_schema: "current-schema.ts",
+      schema_diff: "schema.diff",
+      fetch_stdout: "fetch.stdout",
+      fetch_stderr: "fetch.stderr",
+      gen_schema_stdout: "gen-schema.stdout",
+      gen_schema_stderr: "gen-schema.stderr",
+    },
+    ...extra,
+  }
+  write("summary.json", `${JSON.stringify(data, null, 2)}\n`)
+  write("summary.md", [
+    `# Current Hermes compatibility canary`,
+    ``,
+    `- Phase: ${phase}`,
+    `- Hermes ref: ${ref}`,
+    `- Hermes SHA: ${data.upstream_sha}`,
+    `- Base schema keys: ${data.base_keys ?? "unknown"}`,
+    `- Current schema keys: ${data.current_keys ?? "unknown"}`,
+    ``,
+    phase === "compat_pass" ? "Generated schema matches the committed Herm schema." : "See the generated artifacts for the actionable failure details.",
+    ``,
+  ].join("\n"))
+  process.exit(code)
+}
+
+if (!given) {
+  rmSync(root, { recursive: true, force: true })
+  mkdirSync(dirname(root), { recursive: true })
+  const init = run("git", ["init", "-q", root])
+  const remote = init.code === 0 ? run("git", ["-C", root, "remote", "add", "origin", repo]) : init
+  const fetch = remote.code === 0 ? run("git", ["-C", root, "fetch", "--depth=1", "origin", ref]) : remote
+  write("fetch.stdout", [init.out, remote.out, fetch.out].join(""))
+  write("fetch.stderr", [init.err, remote.err, fetch.err].join(""))
+  if (fetch.code !== 0) await finish("fetch_failed", 1, { exit_code: fetch.code })
+  const co = run("git", ["-C", root, "checkout", "--detach", "FETCH_HEAD"])
+  write("checkout.stdout", co.out)
+  write("checkout.stderr", co.err)
+  if (co.code !== 0) await finish("fetch_failed", 1, { exit_code: co.code })
+}
+
+const sha = run("git", ["-C", root, "rev-parse", "HEAD"])
+write("upstream-sha.txt", sha.code === 0 ? sha.out.trim() : "unknown")
+
+const gen = run("bun", ["scripts/gen-schema.ts", "--out", schema], { ...process.env, HERMES_AGENT_ROOT: root })
+write("gen-schema.stdout", gen.out)
+write("gen-schema.stderr", gen.err)
+if (gen.code !== 0) await finish("generator_failed", 1, { exit_code: gen.code })
+
+const diff = run("diff", ["-u", base, schema])
+write("schema.diff", diff.out)
+if (diff.code === 0) await finish("compat_pass", 0)
+if (diff.code === 1 && statSync(join(report, "schema.diff")).size > 0) await finish("schema_drift", 1)
+await finish("generator_failed", 1, { exit_code: diff.code, diff_stderr: diff.err })

--- a/test/current-hermes-canary.test.ts
+++ b/test/current-hermes-canary.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const root = join(import.meta.dir, "..")
+const schema = join(root, "scripts/gen-schema.ts")
+const canary = join(root, "scripts/current-hermes-canary.ts")
+
+const writeAgent = (dir: string, turns: number) => {
+  mkdirSync(join(dir, "hermes_cli"), { recursive: true })
+  mkdirSync(join(dir, "tui_gateway"), { recursive: true })
+  writeFileSync(join(dir, "hermes_cli/config.py"), `DEFAULT_CONFIG = {
+    "agent": {
+        # Maximum turns in one session.
+        "max_turns": ${turns},
+    },
+}
+`)
+  writeFileSync(join(dir, "tui_gateway/server.py"), `_APPROVAL_MODES = frozenset({"manual", "smart", "off"})\n`)
+}
+
+const git = (cwd: string, ...args: string[]) => Bun.spawnSync(["git", ...args], { cwd })
+
+const fixture = () => {
+  const dir = mkdtempSync(join(tmpdir(), "herm-current-canary-"))
+  const agent = join(dir, "agent")
+  writeAgent(agent, 90)
+  expect(git(agent, "init", "-q").exitCode).toBe(0)
+  expect(git(agent, "add", "hermes_cli/config.py", "tui_gateway/server.py").exitCode).toBe(0)
+  expect(git(agent, "-c", "user.name=test", "-c", "user.email=test@example.invalid", "commit", "-qm", "fixture").exitCode).toBe(0)
+  return { dir, agent }
+}
+
+const run = async (args: string[]) => {
+  const proc = Bun.spawn(["bun", canary, ...args], {
+    cwd: root,
+    env: { ...process.env, HERMES_HOME: join(tmpdir(), "herm-current-canary-home") },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [code, err] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+  return { code, err }
+}
+
+const base = (agent: string, file: string) => {
+  const proc = Bun.spawnSync(["bun", schema, "--out", file], {
+    cwd: root,
+    env: { ...process.env, HERMES_AGENT_ROOT: agent, HERMES_HOME: join(tmpdir(), "herm-current-canary-base") },
+  })
+  expect(proc.exitCode).toBe(0)
+}
+
+describe("current Hermes canary", () => {
+  test("reports compat_pass without rewriting the committed schema artifact", async () => {
+    const f = fixture()
+    const file = join(f.dir, "base.ts")
+    const report = join(f.dir, "report")
+    base(f.agent, file)
+
+    try {
+      const proc = await run(["--root", f.agent, "--base", file, "--report", report])
+      expect(proc.code).toBe(0)
+      const data = await Bun.file(join(report, "summary.json")).json()
+      expect(data.phase).toBe("compat_pass")
+      expect(await Bun.file(join(report, "schema.diff")).text()).toBe("")
+      expect(await Bun.file(file).text()).not.toContain("schema_drift")
+    } finally {
+      rmSync(f.dir, { recursive: true, force: true })
+    }
+  })
+
+  test("classifies upstream schema drift as an actionable artifact", async () => {
+    const f = fixture()
+    const file = join(f.dir, "base.ts")
+    const report = join(f.dir, "report")
+    base(f.agent, file)
+    writeAgent(f.agent, 120)
+
+    try {
+      const proc = await run(["--root", f.agent, "--base", file, "--report", report])
+      expect(proc.code).toBe(1)
+      const data = await Bun.file(join(report, "summary.json")).json()
+      expect(data.phase).toBe("schema_drift")
+      expect(await Bun.file(join(report, "schema.diff")).text()).toContain("max_turns")
+    } finally {
+      rmSync(f.dir, { recursive: true, force: true })
+    }
+  })
+
+  test("classifies generator failures with report logs", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "herm-current-canary-bad-"))
+    const agent = join(dir, "agent")
+    const report = join(dir, "report")
+    mkdirSync(agent, { recursive: true })
+
+    try {
+      const proc = await run(["--root", agent, "--report", report])
+      expect(proc.code).toBe(1)
+      const data = await Bun.file(join(report, "summary.json")).json()
+      expect(data.phase).toBe("generator_failed")
+      expect(await Bun.file(join(report, "gen-schema.stderr")).text()).toContain("could not locate")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Context
Herm tracks a pinned Hermes backend contract in required CI, but there was no separate signal for drift against the current upstream Hermes source. That made upstream compatibility changes visible only when someone manually refreshed or investigated the contract.

## Summary
- Adds a scheduled and manually-dispatched current-Hermes compatibility canary workflow
- Adds a reporter that fetches the requested Hermes ref, generates the config schema into a report directory, and compares it against the committed schema without rewriting tracked files
- Publishes canary artifacts and classifies fetch, generator, drift, and pass outcomes for triage
- Covers the canary pass, drift, and generator-failure paths with focused regression tests
