### PR TITLE
fix(chat): keep MCP warnings out of transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+### Fixed
+* Prevent duplicate MCP connection warnings in chat transcripts (#251).
+* Support Hermes backend contract 6 for mutating session commands (#251).
+* Allow local gateways more time for slow MCP startup (#251).
+
 # [1.10.0](https://github.com/liftaris/herm/compare/v1.9.0...v1.10.0) (2026-07-10)
 
 

--- a/src/app/useStream.ts
+++ b/src/app/useStream.ts
@@ -183,11 +183,6 @@ export function useStream(c: Ctx) {
         // session.title RPC that would re-emit session.info and create
         // a feedback loop (config.get ↔ session.title ↔ session.info).
         if (si.title !== undefined) x.setTitle(si.title)
-        const bad = (si.mcp_servers ?? []).filter(s => !s.connected)
-        if (bad.length) x.dispatch({
-          kind: "system",
-          text: `MCP: ${bad.length} server(s) failed to connect — ${bad.map(s => s.name + (s.error ? ` (${s.error})` : "")).join(", ")}`,
-        })
         gw.request<{ value?: string }>("config.get", { key: "busy" }).then(r => {
           const m = r.value
           if (m === "queue" || m === "steer" || m === "interrupt") x.setBusy(m)

--- a/src/context/backend-contract.ts
+++ b/src/context/backend-contract.ts
@@ -1,5 +1,5 @@
 export const MIN_BACKEND_CONTRACT = 4
-export const MAX_BACKEND_CONTRACT = 5
+export const MAX_BACKEND_CONTRACT = 6
 
 export type BackendContractReason = "missing" | "malformed" | "older" | "supported" | "newer"
 

--- a/src/context/gateway-client.ts
+++ b/src/context/gateway-client.ts
@@ -11,7 +11,8 @@ import { encode } from "../utils/unicode"
 
 const LOG_MAX = 200
 const LOG_PREVIEW = 240
-const STARTUP_MS = 15_000
+const LOCAL_STARTUP_MS = 35_000
+const WEBSOCKET_STARTUP_MS = 15_000
 const REQUEST_MS = 120_000
 const WS_CONNECTING = 0
 const WS_OPEN = 1
@@ -337,7 +338,7 @@ export class GatewayClient extends EventEmitter {
       try { ws.close() } catch {}
       if (this.sub) this.emit("exit", null)
       else this.exit = null
-    }, STARTUP_MS)
+    }, WEBSOCKET_STARTUP_MS)
 
     ws.addEventListener("message", event => {
       if (this.ws !== ws) return
@@ -420,7 +421,7 @@ export class GatewayClient extends EventEmitter {
         if (this.sub) this.emit("exit", null)
         else this.exit = null
       }
-    }, STARTUP_MS)
+    }, LOCAL_STARTUP_MS)
 
     const proc = (() => {
       try {

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -891,28 +891,23 @@ describe("app", () => {
     t.destroy()
   })
 
-  test("failed MCP servers surface as system line on ready", async () => {
+  test("failed MCP servers stay out of the transcript across session.info updates", async () => {
     const gw = new MockGateway()
     const t = await mount({ gw })
-    // gateway.ready already fired in start(); push a session.info with servers
-    act(() => gw.push({
-      type: "session.info",
-      payload: {
-        model: "test-model", session_id: "test-sid", tools: {}, skills: {},
-        mcp_servers: [
-          { name: "goodsrv", transport: "stdio", tools: 5, connected: true },
-          { name: "badsrv", transport: "http", tools: 0, connected: false, error: "ECONNREFUSED" },
-        ],
-      },
-    }))
-    await until(t, () => t.frame().includes("MCP:"))
-    const f = t.frame()
-    expect(f).toContain("1 server(s) failed")
-    expect(f).toContain("badsrv (ECONNREFUSED)")
-    expect(f).not.toContain("goodsrv (") // good one not listed in failure line
-    // sidebar MCP section appears (collapsed) with hint
-    expect(f).toContain("▸ MCP")
-    expect(f).toContain("1/2 up")
+    const info = {
+      model: "test-model", session_id: "test-sid", tools: {}, skills: {},
+      mcp_servers: [
+        { name: "goodsrv", transport: "stdio", tools: 5, connected: true },
+        { name: "badsrv", transport: "http", tools: 0, connected: false, error: "ECONNREFUSED" },
+      ],
+    }
+    act(() => gw.push({ type: "session.info", payload: info }))
+    await until(t, () => t.frame().includes("1/2 up"))
+    act(() => gw.push({ type: "session.info", payload: info }))
+    await t.settle()
+    expect(t.frame()).not.toContain("MCP: 1 server(s) failed to connect")
+    expect(t.frame()).toContain("▸ MCP")
+    expect(t.frame()).toContain("1/2 up")
     t.destroy()
   })
 

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -168,6 +168,39 @@ describe("GatewayClient", () => {
     }
   })
 
+  test("keeps local gateway startup longer than websocket startup", () => {
+    const spawn = Bun.spawn
+    const clock = globalThis.setTimeout
+    const seen: number[] = []
+    const proc = {
+      stdin: { write() { return 0 } },
+      stdout: null,
+      stderr: null,
+      exited: new Promise<number>(() => {}),
+      exitCode: null as number | null,
+      kill() {},
+    }
+    ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = (() => proc as never) as typeof Bun.spawn
+    globalThis.setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+      seen.push(Number(args[1]))
+      return timer(() => {}, 0)
+    }) as typeof setTimeout
+    globalThis.WebSocket = FakeSocket as unknown as typeof WebSocket
+    const local = new GatewayClient()
+    const remote = new GatewayClient()
+    try {
+      local.start()
+      process.env.HERM_GATEWAY_URL = "ws://gateway.test/api/ws"
+      remote.start()
+      expect(seen).toEqual([35_000, 15_000])
+    } finally {
+      local.kill()
+      remote.kill()
+      globalThis.setTimeout = clock
+      ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = spawn
+    }
+  })
+
   test("startup timeout terminates the wedged gateway", async () => {
     const spawn = Bun.spawn
     const clock = globalThis.setTimeout
@@ -187,7 +220,7 @@ describe("GatewayClient", () => {
       },
     }
     ;(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = (() => proc as never) as typeof Bun.spawn
-    const fast = (handler: () => void, ms?: number) => clock(handler, ms === 15_000 ? 0 : ms)
+    const fast = (handler: () => void, ms?: number) => clock(handler, ms === 35_000 ? 0 : ms)
     globalThis.setTimeout = fast as unknown as typeof setTimeout
     const gw = new GatewayClient()
     let exits = 0

--- a/test/sessionCapabilities.test.ts
+++ b/test/sessionCapabilities.test.ts
@@ -11,7 +11,7 @@ describe("backend contract", () => {
 
     expect(state).toMatchObject({
       minContract: 4,
-      maxContract: 5,
+      maxContract: 6,
       supported: false,
       reason: "missing",
       version: "0.19.0",
@@ -42,19 +42,27 @@ describe("backend contract", () => {
   })
 
   test("current supported producer contract enables session capabilities", () => {
+    const state = info(6)
     const cap = sessionCapabilities({
       sid: "lazy-sid",
       ready: true,
       streaming: false,
-      contract: info(4),
+      contract: state,
     })
 
+    expect(state).toMatchObject({
+      maxContract: 6,
+      observedContract: 6,
+      supported: true,
+      reason: "supported",
+    })
+    expect(backend.contractError("prompt.submit", state)).toBeNull()
     expect(cap).toMatchObject({
       sessionConnected: true,
       metadataHydrated: true,
       minContract: 4,
-      maxContract: 5,
-      observedContract: 4,
+      maxContract: 6,
+      observedContract: 6,
       contractSupported: true,
       contractReason: "supported",
       canSubmitPrompt: true,
@@ -64,10 +72,10 @@ describe("backend contract", () => {
   })
 
   test("newer producer contract is surfaced as unsupported", () => {
-    const state = info(6)
+    const state = info(7)
 
     expect(state).toMatchObject({
-      observedContract: 6,
+      observedContract: 7,
       supported: false,
       reason: "newer",
     })


### PR DESCRIPTION
## Summary
- Stop session metadata from adding MCP connection failures to chat history.
- Keep disconnected MCP counts in the sidebar and status dialog.
- Support Hermes backend contract 6 for mutating session commands.
- Allow local gateways more time for slow MCP startup while retaining the remote websocket deadline.

## Verification
- transcript focal test — passed (1/1)
- app test file — passed (58/58)
- backend contract 6 regression — red: failed with contract 6 unsupported; green: passed (1/1)
- backend contract test file — passed (8/8)
- gateway deadline regression — red: failed with local 15s; green: passed (1/1)
- gateway client test file — passed (29/29)
- typecheck — passed
- bun test — interrupted after an Eikon timeout and Kanban teardown timeouts.