### PR TITLE
feat(preferences): reload config on SIGUSR2

### DIFF
--- a/src/app/reloadSignal.ts
+++ b/src/app/reloadSignal.ts
@@ -1,0 +1,27 @@
+/**
+ * Live config reload on SIGUSR2.
+ *
+ * Desktop environments retint a running TUI by signalling it rather than
+ * restarting it — Omarchy drives opencode (`killall -SIGUSR2 opencode`),
+ * btop and helix exactly this way. Herm already has every piece needed to
+ * take part: `preferences.reload()` re-reads tui.json and bumps `rev`, and
+ * ThemeProvider re-scans `userThemes()` from disk whenever `rev` changes.
+ * This wires the signal to that path so a theme written into
+ * `<configDir>/themes/` lands without relaunching the session.
+ *
+ * Registering a handler also replaces SIGUSR2's default disposition, which
+ * is Term — so a desktop hook that signals Herm can no longer kill the
+ * user's session on a build that predates this.
+ */
+
+import * as preferences from "../context/preferences"
+
+/** The signal desktop environments send to ask a TUI to re-read its config. */
+export const RELOAD_SIGNAL = "SIGUSR2" as const
+
+/** Start listening for reload signals. Returns an uninstall function. */
+export function installReloadSignal(): () => void {
+  const onReload = () => preferences.reload()
+  process.on(RELOAD_SIGNAL, onReload)
+  return () => { process.off(RELOAD_SIGNAL, onReload) }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import { warm as warmIO } from "./io";
 import { skills } from "./service/bundled-skills";
 import { plugins } from "./service/bundled-plugins";
 import * as control from "./app/control";
+import { installReloadSignal } from "./app/reloadSignal";
 import * as preferences from "./context/preferences";
 import { resetTerminalModes, installExitResetHooks } from "./utils/terminal-reset";
 import { clampStdoutDimensions } from "./utils/terminal-size";
@@ -120,6 +121,10 @@ const main = async () => {
 
   // Periodic memory monitor (every 15s when PERF=1)
   perf.monitor(15_000)
+
+  // Retint in place when the desktop switches themes, instead of
+  // requiring a relaunch. See src/app/reloadSignal.ts.
+  installReloadSignal()
 
   // Control server for headless interaction (CONTROL=1)
   control.start()

--- a/test/reload-signal.test.ts
+++ b/test/reload-signal.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+import { installReloadSignal, RELOAD_SIGNAL } from "../src/app/reloadSignal"
+import * as prefs from "../src/context/preferences"
+
+// Contract: a desktop theme switch rewrites tui.json (and drops a theme into
+// <configDir>/themes) underneath an already-running Herm, then signals it.
+// The process must pick the new preferences up without relaunching. The fault
+// this detects is the signal handler going missing — after which desktop theme
+// sync silently stops working, and, because SIGUSR2's default disposition is
+// Term, the same hook starts killing live sessions instead.
+test("SIGUSR2 re-reads tui.json in a running process", () => {
+  const prior = { home: process.env.HERMES_HOME, cfg: process.env.HERM_CONFIG_DIR }
+  const root = mkdtempSync(join(tmpdir(), "herm-reload-signal-"))
+  let uninstall: (() => void) | undefined
+  try {
+    delete process.env.HERM_CONFIG_DIR
+    process.env.HERMES_HOME = root
+    const dir = join(root, "herm")
+    mkdirSync(dir, { recursive: true })
+
+    writeFileSync(join(dir, "tui.json"), JSON.stringify({ theme: "nord" }))
+    prefs.reload()
+    expect(prefs.get("theme")).toBe("nord")
+
+    const before = process.listenerCount(RELOAD_SIGNAL)
+    uninstall = installReloadSignal()
+    // Registering any handler is what displaces the default Term disposition.
+    expect(process.listenerCount(RELOAD_SIGNAL)).toBe(before + 1)
+
+    writeFileSync(join(dir, "tui.json"), JSON.stringify({ theme: "gruvbox" }))
+    expect(prefs.get("theme")).toBe("nord")
+
+    process.emit(RELOAD_SIGNAL)
+    expect(prefs.get("theme")).toBe("gruvbox")
+
+    uninstall()
+    uninstall = undefined
+    expect(process.listenerCount(RELOAD_SIGNAL)).toBe(before)
+  } finally {
+    uninstall?.()
+    if (prior.home === undefined) delete process.env.HERMES_HOME
+    else process.env.HERMES_HOME = prior.home
+    if (prior.cfg === undefined) delete process.env.HERM_CONFIG_DIR
+    else process.env.HERM_CONFIG_DIR = prior.cfg
+    prefs.reload()
+    rmSync(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Desktop environments retint a running TUI by signalling it rather than restarting it. Omarchy already drives opencode (`killall -SIGUSR2 opencode`), btop and helix this way. Herm has no handler, so a theme dropped into `<configDir>/themes/` only appears on relaunch.

Everything needed is already in the tree — this just connects it:

- `preferences.reload()` re-reads `tui.json` and bumps `rev`
- `ThemeProvider` already does `useMemo(() => userThemes(), [pref, rev])`, so a bumped `rev` re-scans the user theme directory from disk

So the change is one `process.on("SIGUSR2", () => preferences.reload())`, in a small module so `index.tsx` stays a single call.

There is a second, less obvious effect. SIGUSR2 has no handler today, and its default disposition is Term — so a desktop hook that signals Herm currently *kills the session*. Registering any handler displaces that.

### Test

`test/reload-signal.test.ts` writes `tui.json` under a temp `HERMES_HOME`, emits the signal, and asserts the new value is picked up; it also asserts the listener is registered and removed. I checked it fails when the `process.on` line is removed, rather than passing vacuously.

Full suite locally: 1434 pass, 8 skip, 0 fail. I also drove a real session — `omarchy theme set` on a running Herm repaints in place, same PID, no restart.

### Notes

Happy to rename the module, inline it at the call site, or drop the exported `RELOAD_SIGNAL` constant if you would rather it were simpler — and no hard feelings at all if this is not a direction you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wuXxreHFXfMptBR9cKXDw